### PR TITLE
Fix clang-tidy regressions and ensure header-only PRs are linted in CI

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -69,13 +69,9 @@ jobs:
                 echo "has_header_changes=false"
               fi
               echo "has_tidy_changes=true"
-            } >> "$GITHUB_OUTPUT"
-            {
               echo "changed_cpp_files<<EOF"
               echo "$CHANGED_CPP"
               echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-            {
               echo "changed_header_files<<EOF"
               echo "$CHANGED_HDR"
               echo "EOF"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -34,40 +34,62 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "has_cpp_changes=true" >> "$GITHUB_OUTPUT"
+            echo "has_header_changes=true" >> "$GITHUB_OUTPUT"
+            echo "has_tidy_changes=true" >> "$GITHUB_OUTPUT"
             echo "changed_cpp_files=" >> "$GITHUB_OUTPUT"
+            echo "changed_header_files=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
           BASE="origin/${{ github.base_ref }}"
-          CHANGED="$(git diff --name-only --diff-filter=ACMR "$BASE...HEAD" | grep -E '\.(c|cc|cpp|cxx)$' || true)"
+          CHANGED_CPP="$(git diff --name-only --diff-filter=ACMR "$BASE...HEAD" | grep -E '\.(c|cc|cpp|cxx)$' || true)"
+          CHANGED_HDR="$(git diff --name-only --diff-filter=ACMR "$BASE...HEAD" | grep -E '\.(h|hh|hpp|hxx)$' || true)"
 
-          if [[ -z "$CHANGED" ]]; then
+          if [[ -z "$CHANGED_CPP" && -z "$CHANGED_HDR" ]]; then
             echo "has_cpp_changes=false" >> "$GITHUB_OUTPUT"
+            echo "has_header_changes=false" >> "$GITHUB_OUTPUT"
+            echo "has_tidy_changes=false" >> "$GITHUB_OUTPUT"
             echo "changed_cpp_files=" >> "$GITHUB_OUTPUT"
+            echo "changed_header_files=" >> "$GITHUB_OUTPUT"
           else
-            echo "has_cpp_changes=true" >> "$GITHUB_OUTPUT"
+            if [[ -n "$CHANGED_CPP" ]]; then
+              echo "has_cpp_changes=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_cpp_changes=false" >> "$GITHUB_OUTPUT"
+            fi
+            if [[ -n "$CHANGED_HDR" ]]; then
+              echo "has_header_changes=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_header_changes=false" >> "$GITHUB_OUTPUT"
+            fi
+            echo "has_tidy_changes=true" >> "$GITHUB_OUTPUT"
             {
               echo "changed_cpp_files<<EOF"
-              echo "$CHANGED"
+              echo "$CHANGED_CPP"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo "changed_header_files<<EOF"
+              echo "$CHANGED_HDR"
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Prepare cache directories
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.has_tidy_changes == 'true'
         run: |
           mkdir -p "${CPM_SOURCE_CACHE}"
           mkdir -p "${CCACHE_DIR}"
 
       - uses: actions/cache@v5
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.has_tidy_changes == 'true'
         with:
           path: ${{ env.CPM_SOURCE_CACHE }}
           key: clang-tidy-${{ runner.os }}-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.has_tidy_changes == 'true'
         uses: actions/cache@v5
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -76,7 +98,7 @@ jobs:
             clang-tidy-${{ runner.os }}-ccache-
 
       - name: Setup required C++ tools
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.has_tidy_changes == 'true'
         uses: aminya/setup-cpp@v1.8.0
         with:
           compiler: llvm-21
@@ -86,7 +108,7 @@ jobs:
           clang-tidy: true
 
       - name: Install protobuf dependencies
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.has_tidy_changes == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
@@ -103,8 +125,20 @@ jobs:
                 -DCMAKE_C_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
                 -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"
 
+      - name: Configure (PR full clang-tidy for header changes)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.has_header_changes == 'true'
+        run: |
+          cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release \
+                -DHPP_PROTO_PROTOC=find \
+                -DCMAKE_C_COMPILER=clang \
+                -DCMAKE_CXX_COMPILER=clang++ \
+                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_C_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
+                -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"
+
       - name: Configure (PR build)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.has_tidy_changes == 'true' && steps.changes.outputs.has_header_changes != 'true'
         run: |
           cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release \
                 -DHPP_PROTO_PROTOC=find \
@@ -118,14 +152,18 @@ jobs:
         if: github.event_name != 'pull_request'
         run: cmake --build build -j"$(nproc)"
 
+      - name: Build (PR full clang-tidy for header changes)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.has_header_changes == 'true'
+        run: cmake --build build -j"$(nproc)"
+
       - name: Build (PR prerequisites)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.has_cpp_changes == 'true' && steps.changes.outputs.has_header_changes != 'true'
         run: |
           # Ensure generated headers/sources exist before running clang-tidy on selected files.
           cmake --build build -j"$(nproc)"
 
       - name: Clang-tidy changed files (PR)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.has_cpp_changes == 'true'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.has_cpp_changes == 'true' && steps.changes.outputs.has_header_changes != 'true'
         shell: bash
         run: |
           CHANGED="${{ steps.changes.outputs.changed_cpp_files }}"
@@ -142,5 +180,5 @@ jobs:
           done <<< "$CHANGED"
 
       - name: No changed C/C++ files (PR)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.has_cpp_changes != 'true'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.has_tidy_changes != 'true'
         run: echo "No changed C/C++ files detected. Skipping clang-tidy workflow steps."

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -33,11 +33,13 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "has_cpp_changes=true" >> "$GITHUB_OUTPUT"
-            echo "has_header_changes=true" >> "$GITHUB_OUTPUT"
-            echo "has_tidy_changes=true" >> "$GITHUB_OUTPUT"
-            echo "changed_cpp_files=" >> "$GITHUB_OUTPUT"
-            echo "changed_header_files=" >> "$GITHUB_OUTPUT"
+            {
+              echo "has_cpp_changes=true"
+              echo "has_header_changes=true"
+              echo "has_tidy_changes=true"
+              echo "changed_cpp_files="
+              echo "changed_header_files="
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -47,23 +49,27 @@ jobs:
           CHANGED_HDR="$(git diff --name-only --diff-filter=ACMR "$BASE...HEAD" | grep -E '\.(h|hh|hpp|hxx)$' || true)"
 
           if [[ -z "$CHANGED_CPP" && -z "$CHANGED_HDR" ]]; then
-            echo "has_cpp_changes=false" >> "$GITHUB_OUTPUT"
-            echo "has_header_changes=false" >> "$GITHUB_OUTPUT"
-            echo "has_tidy_changes=false" >> "$GITHUB_OUTPUT"
-            echo "changed_cpp_files=" >> "$GITHUB_OUTPUT"
-            echo "changed_header_files=" >> "$GITHUB_OUTPUT"
+            {
+              echo "has_cpp_changes=false"
+              echo "has_header_changes=false"
+              echo "has_tidy_changes=false"
+              echo "changed_cpp_files="
+              echo "changed_header_files="
+            } >> "$GITHUB_OUTPUT"
           else
-            if [[ -n "$CHANGED_CPP" ]]; then
-              echo "has_cpp_changes=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "has_cpp_changes=false" >> "$GITHUB_OUTPUT"
-            fi
-            if [[ -n "$CHANGED_HDR" ]]; then
-              echo "has_header_changes=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "has_header_changes=false" >> "$GITHUB_OUTPUT"
-            fi
-            echo "has_tidy_changes=true" >> "$GITHUB_OUTPUT"
+            {
+              if [[ -n "$CHANGED_CPP" ]]; then
+                echo "has_cpp_changes=true"
+              else
+                echo "has_cpp_changes=false"
+              fi
+              if [[ -n "$CHANGED_HDR" ]]; then
+                echo "has_header_changes=true"
+              else
+                echo "has_header_changes=false"
+              fi
+              echo "has_tidy_changes=true"
+            } >> "$GITHUB_OUTPUT"
             {
               echo "changed_cpp_files<<EOF"
               echo "$CHANGED_CPP"

--- a/include/hpp_proto/indirect.hpp
+++ b/include/hpp_proto/indirect.hpp
@@ -24,16 +24,16 @@ private:
 
 public:
   constexpr indirect() : obj_(allocate_default()) {}
-  constexpr explicit indirect(const allocator_type &alloc) : alloc_(alloc), obj_(allocate_default()) {}
-  constexpr indirect(allocator_arg_t, const allocator_type &alloc) : alloc_(alloc), obj_(allocate_default()) {}
+  constexpr explicit indirect(allocator_type alloc) : alloc_(std::move(alloc)), obj_(allocate_default()) {}
+  constexpr indirect(allocator_arg_t, allocator_type alloc) : alloc_(std::move(alloc)), obj_(allocate_default()) {}
   constexpr ~indirect() { destroy(); }
 
   template <class... Args>
   constexpr explicit indirect(std::in_place_t, Args &&...args)
       : obj_(allocate_construct(std::forward<Args>(args)...)) {}
   template <class... Args>
-  constexpr explicit indirect(allocator_arg_t, const allocator_type &alloc, std::in_place_t, Args &&...args)
-      : alloc_(alloc), obj_(allocate_construct(std::forward<Args>(args)...)) {}
+  constexpr explicit indirect(allocator_arg_t, allocator_type alloc, std::in_place_t, Args &&...args)
+      : alloc_(std::move(alloc)), obj_(allocate_construct(std::forward<Args>(args)...)) {}
 
   // NOLINTNEXTLINE(hicpp-explicit-conversions)
   constexpr indirect(T &&object) : obj_(allocate_construct(std::move(object))) {}
@@ -41,8 +41,8 @@ public:
   // NOLINTNEXTLINE(hicpp-explicit-conversions)
   constexpr indirect(const T &object) : obj_(allocate_construct(object)) {}
 
-  constexpr indirect(allocator_arg_t, const allocator_type &alloc, T &&object)
-      : alloc_(alloc), obj_(allocate_construct(std::move(object))) {}
+  constexpr indirect(allocator_arg_t, allocator_type alloc, T &&object)
+      : alloc_(std::move(alloc)), obj_(allocate_construct(std::move(object))) {}
 
   constexpr indirect(const indirect &other)
       : alloc_(allocator_traits::select_on_container_copy_construction(other.alloc_)),
@@ -50,11 +50,11 @@ public:
   constexpr indirect(indirect &&other) noexcept(std::is_nothrow_move_constructible_v<allocator_type>)
       : alloc_(std::move(other.alloc_)), obj_(std::exchange(other.obj_, nullptr)) {}
 
-  constexpr indirect(allocator_arg_t, const allocator_type &alloc, const indirect &other)
-      : alloc_(alloc), obj_(allocate_construct(*other.raw_ptr())) {}
+  constexpr indirect(allocator_arg_t, allocator_type alloc, const indirect &other)
+      : alloc_(std::move(alloc)), obj_(allocate_construct(*other.raw_ptr())) {}
 
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-  constexpr indirect(allocator_arg_t, const allocator_type &alloc, indirect &&other) : alloc_(alloc) {
+  constexpr indirect(allocator_arg_t, allocator_type alloc, indirect &&other) : alloc_(std::move(alloc)) {
     if constexpr (allocator_traits::is_always_equal::value) {
       obj_ = std::exchange(other.obj_, nullptr);
     } else {

--- a/include/hpp_proto/optional_indirect.hpp
+++ b/include/hpp_proto/optional_indirect.hpp
@@ -25,21 +25,26 @@ private:
 
 public:
   constexpr optional_indirect() noexcept = default;
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   constexpr explicit optional_indirect(const allocator_type &alloc) noexcept : alloc_(alloc) {}
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   constexpr optional_indirect(allocator_arg_t, const allocator_type &alloc) noexcept : alloc_(alloc) {}
   constexpr ~optional_indirect() noexcept { reset(); }
 
   constexpr explicit optional_indirect(std::nullopt_t /* unused */) noexcept {};
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   constexpr optional_indirect(allocator_arg_t, const allocator_type &alloc, std::nullopt_t /* unused */) noexcept
       : alloc_(alloc) {}
 
   // NOLINTNEXTLINE(hicpp-explicit-conversions)
   constexpr optional_indirect(const T &object) { emplace(object); }
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   constexpr optional_indirect(allocator_arg_t, const allocator_type &alloc, const T &object) : alloc_(alloc) {
     emplace(object);
   }
   // NOLINTNEXTLINE(hicpp-explicit-conversions)
   constexpr optional_indirect(T &&object) { emplace(std::move(object)); }
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   constexpr optional_indirect(allocator_arg_t, const allocator_type &alloc, T &&object) : alloc_(alloc) {
     emplace(std::move(object));
   }
@@ -51,13 +56,14 @@ public:
       emplace(*other.raw_ptr());
     }
   }
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   constexpr optional_indirect(allocator_arg_t, const allocator_type &alloc, const optional_indirect &other)
       : alloc_(alloc) {
     if (other.obj_) {
       emplace(*other.raw_ptr());
     }
   }
-  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved,modernize-pass-by-value)
   constexpr optional_indirect(allocator_arg_t, const allocator_type &alloc, optional_indirect &&other) : alloc_(alloc) {
     if constexpr (allocator_traits::is_always_equal::value) {
       obj_ = std::exchange(other.obj_, nullptr);
@@ -75,6 +81,7 @@ public:
     emplace(std::forward<Args>(args)...);
   }
   template <class... Args>
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   constexpr explicit optional_indirect(allocator_arg_t, const allocator_type &alloc, std::in_place_t, Args &&...args)
       : alloc_(alloc) {
     emplace(std::forward<Args>(args)...);
@@ -332,7 +339,7 @@ private:
   template <class... Args>
   constexpr T &emplace_impl(Args &&...args) {
     reset();
-    auto new_obj = allocator_traits::allocate(alloc_, 1);
+    auto *new_obj = allocator_traits::allocate(alloc_, 1);
     try {
       allocator_traits::construct(alloc_, std::to_address(new_obj), std::forward<Args>(args)...);
     } catch (...) {

--- a/unittests/test_allocators.hpp
+++ b/unittests/test_allocators.hpp
@@ -32,7 +32,7 @@ struct counting_allocator {
   explicit counting_allocator(std::shared_ptr<counting_alloc_state> s) : state(std::move(s)) {}
 
   template <class U>
-  counting_allocator(const counting_allocator<U> &other) noexcept : state(other.state) {}
+  explicit counting_allocator(const counting_allocator<U> &other) noexcept : state(other.state) {}
 
   [[nodiscard]] T *allocate(std::size_t n) {
     state->alloc_count += n;
@@ -60,9 +60,10 @@ struct throwing_move_ctor_allocator {
   throwing_move_ctor_allocator(throwing_move_ctor_allocator &&) noexcept(false) {}
   throwing_move_ctor_allocator &operator=(const throwing_move_ctor_allocator &) = default;
   throwing_move_ctor_allocator &operator=(throwing_move_ctor_allocator &&) = default;
+  ~throwing_move_ctor_allocator() = default;
 
   template <class U>
-  throwing_move_ctor_allocator(const throwing_move_ctor_allocator<U> &) noexcept {}
+  explicit throwing_move_ctor_allocator(const throwing_move_ctor_allocator<U> &) noexcept {}
 
   [[nodiscard]] T *allocate(std::size_t n) { return std::allocator<T>{}.allocate(n); }
   void deallocate(T *p, std::size_t n) noexcept { std::allocator<T>{}.deallocate(p, n); }
@@ -74,6 +75,7 @@ struct throwing_move_ctor_allocator {
 };
 
 template <class T>
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 struct throwing_move_assign_allocator {
   using value_type = T;
   using is_always_equal = std::false_type;
@@ -86,7 +88,7 @@ struct throwing_move_assign_allocator {
   throwing_move_assign_allocator &operator=(throwing_move_assign_allocator &&) noexcept(false) { return *this; }
 
   template <class U>
-  throwing_move_assign_allocator(const throwing_move_assign_allocator<U> &) noexcept {}
+  explicit throwing_move_assign_allocator(const throwing_move_assign_allocator<U> &) noexcept {}
 
   [[nodiscard]] T *allocate(std::size_t n) { return std::allocator<T>{}.allocate(n); }
   void deallocate(T *p, std::size_t n) noexcept { std::allocator<T>{}.deallocate(p, n); }
@@ -98,6 +100,7 @@ struct throwing_move_assign_allocator {
 };
 
 template <class T>
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 struct throwing_swap_allocator {
   using value_type = T;
   using is_always_equal = std::false_type;
@@ -110,7 +113,7 @@ struct throwing_swap_allocator {
   throwing_swap_allocator &operator=(throwing_swap_allocator &&) noexcept = default;
 
   template <class U>
-  throwing_swap_allocator(const throwing_swap_allocator<U> &) noexcept {}
+  explicit throwing_swap_allocator(const throwing_swap_allocator<U> &) noexcept {}
 
   [[nodiscard]] T *allocate(std::size_t n) { return std::allocator<T>{}.allocate(n); }
   void deallocate(T *p, std::size_t n) noexcept { std::allocator<T>{}.deallocate(p, n); }
@@ -135,7 +138,7 @@ struct propagating_copy_allocator {
   explicit propagating_copy_allocator(int value) : id(value) {}
 
   template <class U>
-  propagating_copy_allocator(const propagating_copy_allocator<U> &other) noexcept : id(other.id) {}
+  explicit propagating_copy_allocator(const propagating_copy_allocator<U> &other) noexcept : id(other.id) {}
 
   [[nodiscard]] T *allocate(std::size_t n) { return std::allocator<T>{}.allocate(n); }
   void deallocate(T *p, std::size_t n) noexcept { std::allocator<T>{}.deallocate(p, n); }


### PR DESCRIPTION
## Summary
This PR does two things:
1. Fixes clang-tidy `-warnings-as-errors` findings in `indirect`, `optional_indirect`, and allocator test fixtures.
2. Fixes the PR clang-tidy workflow so header-only changes are no longer skipped.

## Code Changes
- `include/hpp_proto/indirect.hpp`
  - Updated allocator-taking constructors to satisfy `modernize-pass-by-value` in this type.

- `include/hpp_proto/optional_indirect.hpp`
  - Fixed `readability-qualified-auto` (`auto* new_obj`).
  - Added targeted `NOLINTNEXTLINE(modernize-pass-by-value)` on allocator-copy constructors where passing by value conflicts with `performance-unnecessary-value-param`.
  - Added targeted suppression for allocator-aware move constructor (`cppcoreguidelines-rvalue-reference-param-not-moved`).

- `unittests/test_allocators.hpp`
  - Marked converting allocator ctors `explicit` (`hicpp-explicit-conversions`).
  - Added defaulted destructor for `throwing_move_ctor_allocator` (`cppcoreguidelines-special-member-functions`).

## CI Workflow Fix
- `.github/workflows/clang-tidy.yml`
  - PR change detection now includes headers (`.h/.hh/.hpp/.hxx`) in addition to source files.
  - Added `has_tidy_changes` / `has_header_changes` routing.
  - Header-touching PRs now run full CMake-integrated clang-tidy (`CMAKE_*_CLANG_TIDY`) instead of skipping checks.
  - Source-only PRs keep the fast changed-translation-unit clang-tidy path.

## Why
Header-only changes in this repo can introduce clang-tidy failures, but the previous workflow only keyed off changed `.cpp` files and could skip relevant checks. This PR closes that gap and fixes the currently reported diagnostics.
