### PR TITLE
Fix enum JSON end-of-buffer OOB read and add truncated-input regression test

### DIFF
--- a/include/hpp_proto/json/util.hpp
+++ b/include/hpp_proto/json/util.hpp
@@ -362,6 +362,12 @@ void from_json(T &v, auto &ctx, auto &it, auto &end) {
       return;
     }
   }
+  if constexpr (!Opts.null_terminated) {
+    if (it == end) {
+      ctx.error = error_code::end_reached;
+      return;
+    }
+  }
   if (*it != '"') {
     int32_t number = 0;
     from<JSON, int32_t>::template op<ws_handled<Opts>()>(number, ctx, it, end);

--- a/tests/read_json_consistency_test.cpp
+++ b/tests/read_json_consistency_test.cpp
@@ -55,6 +55,7 @@ const suite test_read_json = [] {
   test_read<protobuf_unittest::TestAllTypes>(message_factory, R"({"repeatedString":["abc,"def"]})"sv, fail);
   test_read<protobuf_unittest::TestAllTypes>(message_factory, "{\"repeatedString\":[\"\xcd\"]}"sv, fail);
   test_read<protobuf_unittest::TestAllTypes>(message_factory, R"({"optionalNestedEnum": )"sv, fail);
+  test_read<proto3_unittest::TestAllTypes>(message_factory, "{\"optionalNestedEnum\":\""sv, fail);
   test_read<protobuf_unittest::TestAllTypes>(message_factory, R"({"repeatedNestedEnum":[2, 0]})"sv, ok);
 
   test_read<protobuf_unittest::TestMap>(message_factory, R"({"mapInt32Int32":{"	102":0}})"sv, ok);


### PR DESCRIPTION
### Summary
This PR fixes a heap-buffer-overflow in enum JSON parsing for non-null-terminated inputs and adds a regression test to lock in the behavior.

### Root cause
In `hpp_proto::json::util::from_json` (enum overload), the parser could dereference `*it` without first checking `it == end` on the `ws_handled` path for non-null-terminated buffers.  
For truncated input like `{"optionalNestedEnum":"`, this could read past the buffer boundary (ASan-reported OOB in Glaze enum parsing).

### Fix
- Added an explicit boundary check before `*it` access in enum `from_json`:
  - if `!Opts.null_terminated && it == end`, set `ctx.error = error_code::end_reached` and return.
- File:
  - `include/hpp_proto/json/util.hpp`

### Tests
- Added regression case in read-json consistency tests:
  - `test_read<proto3_unittest::TestAllTypes>(..., "{\"optionalNestedEnum\":\"", fail);`
- File:
  - `tests/read_json_consistency_test.cpp`
