### PR TITLE
Fix `pack_any` option propagation in `binpb` serialization

### DIFF
--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -341,7 +341,7 @@ status pack_any(concepts::is_any auto &any, concepts::has_meta auto const &msg,
   any.type_url = message_type_url(msg);
   auto ctx = pb_context{std::forward<decltype(option)>(option)...};
   decltype(auto) v = detail::as_modifiable(ctx, any.value);
-  return write_binpb(msg, v);
+  return write_binpb(msg, v, ctx);
 }
 
 status unpack_any(concepts::is_any auto const &any, concepts::has_meta auto &msg,


### PR DESCRIPTION
### Summary
This PR fixes `pack_any(..., option...)` so caller-supplied serialization options are actually used during `Any` payload encoding.

### Change
- Updated `pack_any` overload in `include/hpp_proto/binpb.hpp`:
  - from: `write_binpb(msg, v)`
  - to: `write_binpb(msg, v, ctx)`

### Why
The overload constructed `pb_context` from options, but did not pass it to `write_binpb`.  
As a result, options like custom allocation/context settings were ignored for `Any` serialization.
