### PR TITLE
Clarify deserialize failure semantics and `scan_object_fields` callback contract

### DIFF
--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -224,6 +224,7 @@ constexpr static expected<T, std::errc> read_binpb(concepts::input_byte_range au
 /// @param buffer The input byte range.
 /// @param ctx The protobuf serialization context.
 /// @details This API does not catch std::bad_alloc thrown by standard containers.
+///          The previous contents of @p msg are not preserved on parse failure.
 /// @return status indicating success or failure.
 template <concepts::has_meta T, concepts::input_byte_range Buffer>
 status read_binpb(T &msg, const Buffer &buffer, concepts::is_pb_context auto &ctx) {
@@ -251,6 +252,7 @@ constexpr static expected<T, std::errc> read_binpb(const char (&buffer)[N], conc
 /// @param msg The message object to deserialize into.
 /// @param buffer The character array.
 /// @param option Optional configuration parameters.
+/// @details The previous contents of @p msg are not preserved on parse failure.
 /// @return status indicating success or failure.
 template <concepts::has_meta T, std::size_t N>
 status read_binpb(T &msg, const char (&buffer)[N], concepts::is_option_type auto &&...option) {
@@ -265,6 +267,7 @@ status read_binpb(T &msg, const char (&buffer)[N], concepts::is_option_type auto
 /// @param msg The message object to deserialize into.
 /// @param buffer The input byte range.
 /// @param option Optional configuration parameters.
+/// @details The previous contents of @p msg are not preserved on parse failure.
 /// @return status indicating success or failure.
 template <concepts::has_meta T, concepts::input_byte_range Buffer>
 status read_binpb(T &msg, const Buffer &buffer, concepts::is_option_type auto &&...option) {

--- a/include/hpp_proto/dynamic_message/binpb.hpp
+++ b/include/hpp_proto/dynamic_message/binpb.hpp
@@ -22,6 +22,8 @@
 #include <hpp_proto/dynamic_message/pb_serializer_ext.hpp>
 namespace hpp_proto {
 
+/// @brief Deserializes binary protobuf data into a dynamic message.
+/// @details The message is reset before parsing. The previous contents of @p msg are not preserved on parse failure.
 [[nodiscard]] status read_binpb(message_value_mref msg, auto &&buffer) {
   msg.reset();
   auto context = pb_context{alloc_from(msg.memory_resource())};
@@ -29,6 +31,8 @@ namespace hpp_proto {
 }
 
 template <std::size_t N>
+/// @brief Deserializes binary protobuf data from a character array into a dynamic message.
+/// @details The previous contents of @p msg are not preserved on parse failure.
 [[nodiscard]] status read_binpb(message_value_mref msg, const char (&buffer)[N]) {
   constexpr auto span_size = N == 0 ? 0 : N - 1;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,-warnings-as-errors)

--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -291,8 +291,8 @@ struct any_message_json_serializer {
           }
         },
         [&](auto &it_ref, auto &end_ref) {
-          return handle_any_type_key<opening_handled_off<ws_handled_off<Options>()>()>(key, ctx, it_ref, end_ref,
-                                                                                       any_type_url, is_type_key_first);
+          return handle_any_type_key<opening_handled_off<ws_handled<Options>()>()>(key, ctx, it_ref, end_ref,
+                                                                                   any_type_url, is_type_key_first);
         },
         [&](auto &it_ref, auto &) {
           if (is_type_key_first) {

--- a/include/hpp_proto/grpc/serialization.hpp
+++ b/include/hpp_proto/grpc/serialization.hpp
@@ -178,6 +178,8 @@ private:
   bool supported_ = true;
 };
 
+/// @brief Deserializes a gRPC ByteBuffer into a protobuf message.
+/// @details The previous contents of @p message are not preserved on parse failure.
 ::grpc::Status read_binpb(::hpp_proto::concepts::has_meta auto &message, const ::grpc::ByteBuffer &buffer,
                           ::hpp_proto::concepts::is_pb_context auto &context) {
 
@@ -191,6 +193,8 @@ private:
   return {::grpc::StatusCode::INTERNAL, "Failed to deserialize message"};
 }
 
+/// @brief Deserializes a gRPC ByteBuffer into a protobuf message with ad-hoc options.
+/// @details The previous contents of @p message are not preserved on parse failure.
 ::grpc::Status read_binpb(::hpp_proto::concepts::has_meta auto &message, const ::grpc::ByteBuffer &buffer,
                           ::hpp_proto::concepts::is_option_type auto &&...option) {
   pb_context context{option...};

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -401,6 +401,7 @@ struct [[nodiscard]] json_status final {
 ///          - uses hpp_proto::json_context options
 ///          - validates that the full buffer is consumed (trailing non-whitespace becomes syntax_error)
 ///          - does not catch std::bad_alloc thrown by standard containers (same as glz::read)
+///          - does not preserve the previous contents of @p value on parse failure
 /// @param value The message object to populate.
 /// @param buffer The input buffer containing JSON bytes.
 /// @param option Optional configuration parameters.
@@ -432,6 +433,7 @@ inline json_status read_json_buffer(concepts::read_json_supported auto &value, a
 /// @brief Deserializes JSON from a contiguous char/char8_t range that is not null-terminated.
 /// @details Unlike glz::read, this wrapper forces null_terminated=false and validates full-buffer consumption.
 ///          It does not catch std::bad_alloc thrown by standard containers (same as glz::read).
+///          The previous contents of @p value are not preserved on parse failure.
 /// @param value The message object to populate.
 /// @param buffer Contiguous range of char or char8_t that is not null-terminated.
 /// @param option Optional configuration parameters.
@@ -453,6 +455,7 @@ inline json_status read_json(concepts::read_json_supported auto &value,
 /// @brief Deserializes JSON from a null-terminated string or pointer into a message object.
 /// @details Unlike glz::read, this wrapper forces null_terminated=true and validates full-buffer consumption.
 ///          It does not catch std::bad_alloc thrown by standard containers (same as glz::read).
+///          The previous contents of @p value are not preserved on parse failure.
 /// @param value The message object to populate.
 /// @param str The null-terminated string or pointer containing the JSON.
 /// @param option Optional configuration parameters.

--- a/include/hpp_proto/json/util.hpp
+++ b/include/hpp_proto/json/util.hpp
@@ -79,9 +79,6 @@ bool parse_null(auto &&value, auto &ctx, auto &it, auto &end) {
       return true;
     }
   }
-  if constexpr (not Opts.null_terminated) {
-    assert(it != end);
-  }
 
   if (*it == 'n') {
     ++it; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
@@ -243,8 +240,10 @@ bool match_ending_or_consume_comma(auto ws_start, size_t ws_size, bool &first, g
  * @param it Current input iterator.
  * @param end Input end iterator.
  * @param key The key
- * @param on_key_start Invoked before key parsing; can update iterator-related state.
- * @param on_key Invoked after key parsing; return true to terminate scanning.
+ * @param on_key_start Invoked before key parsing but after trailing whitespace parsing; can update iterator-related
+ *                     state.
+ * @param on_key Invoked after key parsing and colon parsing, including the whitespace consumed inside
+ *               util::parse_key_and_colon; return true to terminate scanning.
  * @param on_after_ws Invoked after trailing whitespace is skipped.
  * @return None; scanning stops by returning from the function.
  */


### PR DESCRIPTION
## Summary
This PR clarifies deserialization API contracts and JSON object-scan callback sequencing.

## What changed
- Added explicit docs that output-parameter deserialization does **not** preserve prior value on parse failure:
  - `include/hpp_proto/json.hpp`
  - `include/hpp_proto/binpb.hpp`
  - `include/hpp_proto/dynamic_message/binpb.hpp`
  - `include/hpp_proto/grpc/serialization.hpp`
- Clarified `scan_object_fields` callback order docs:
  - `on_key_start` runs before key parsing, after field-leading whitespace handling.
  - `on_key` runs after key+colon parsing, including whitespace consumed by `util::parse_key_and_colon`.
  - `include/hpp_proto/json/util.hpp`
- Updated Any type-key parsing option propagation to align with the clarified callback/whitespace contract:
  - `include/hpp_proto/dynamic_message/json.hpp`
- Removed a debug-only `assert(it != end)` in `parse_null`:
  - `include/hpp_proto/json/util.hpp`

## Notes
- No public API signature changes.
- Main impact is improved contract clarity and consistency across JSON/BinPB and gRPC/dynamic-message adapters.