### PR TITLE
Fix `merge` compilation for `optional<bool>` and add regression coverage

### DIFF
--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -130,7 +130,11 @@ struct message_merger {
       }
     } else {
       if (source.has_value()) {
-        perform(dest.emplace(), *std::forward<U>(source));
+        if constexpr (requires { dest = *std::forward<U>(source); }) {
+          dest = *std::forward<U>(source);
+        } else {
+          perform(dest.emplace(), *std::forward<U>(source));
+        }
       }
     }
   }

--- a/tests/grpc/client_stream_tests.cpp
+++ b/tests/grpc/client_stream_tests.cpp
@@ -1,5 +1,6 @@
 #include <boost/ut.hpp>
 
+#include <chrono>
 #include <condition_variable>
 #include <memory_resource>
 #include <mutex>
@@ -23,6 +24,7 @@ class ClientStreamReactor : public ::hpp_proto::grpc::ClientCallbackReactor<Clie
   bool use_sentinel_ = true;
   bool sentinel_sent_ = false;
   bool writes_complete_ = false;
+  size_t write_done_count_ = 0;
   ::grpc::Status status_;
   hpp_proto_test::StreamSummary<> summary_;
   ::grpc::ClientContext *context_ = nullptr;
@@ -53,11 +55,20 @@ public:
     std::scoped_lock lock(mu_);
     return summary_;
   }
+  [[nodiscard]] bool wait_for_writes(size_t n, std::chrono::milliseconds timeout) {
+    std::unique_lock lock(mu_);
+    return cv_.wait_for(lock, timeout, [&] { return write_done_count_ >= n || done_; });
+  }
 
   void OnWriteDone(bool ok) override {
     if (!ok) {
       // gRPC will deliver OnDone() for terminal write failure.
       return;
+    }
+    {
+      std::scoped_lock lock(mu_);
+      ++write_done_count_;
+      cv_.notify_all();
     }
     send_next();
   }
@@ -156,9 +167,14 @@ void run_client_stream_cancel_case() {
   auto &stub = harness.stub();
 
   ::grpc::ClientContext context;
+  context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
   ClientStreamReactor reactor;
-  reactor.set_payloads({"chunk_0", "chunk_1", "chunk_2", "chunk_3"});
+  reactor.set_use_sentinel(false);
+  reactor.set_payloads({"chunk_0",  "chunk_1",  "chunk_2",  "chunk_3",  "chunk_4",  "chunk_5",  "chunk_6",
+                        "chunk_7",  "chunk_8",  "chunk_9",  "chunk_10", "chunk_11", "chunk_12", "chunk_13",
+                        "chunk_14", "chunk_15", "chunk_16", "chunk_17", "chunk_18", "chunk_19"});
   reactor.begin(stub, context);
+  expect(reactor.wait_for_writes(1, std::chrono::seconds(2)));
   context.TryCancel();
   reactor.wait();
 

--- a/unittests/merge_message_tests.cpp
+++ b/unittests/merge_message_tests.cpp
@@ -116,6 +116,17 @@ template <typename Traits>
 auto pb_meta(const MoveRepeatedMessage<Traits> &)
     -> std::tuple<hpp_proto::field_meta<1, &MoveRepeatedMessage<Traits>::values, hpp_proto::field_option::none>>;
 
+template <typename Traits = hpp_proto::default_traits>
+struct BoolOptionalMessage {
+  hpp_proto::optional<bool> optional_bool;
+  bool operator==(const BoolOptionalMessage &) const = default;
+};
+
+template <typename Traits>
+auto pb_meta(const BoolOptionalMessage<Traits> &)
+    -> std::tuple<hpp_proto::field_meta<1, &BoolOptionalMessage<Traits>::optional_bool,
+                                        hpp_proto::field_option::explicit_presence>>;
+
 const boost::ut::suite merge_test_suite = [] {
   using namespace boost::ut;
   using namespace boost::ut::literals;
@@ -390,6 +401,37 @@ const boost::ut::suite merge_test_suite = [] {
     expect(source.values[1].empty());
     // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved)
   };
+
+  "merge_optional_bool"_test = []<class TraitsPair> {
+    using DestTraits = typename TraitsPair::first_type;
+    using SourceTraits = typename TraitsPair::second_type;
+
+    should("merge const reference should overwrite optional<bool>") = [] {
+      BoolOptionalMessage<DestTraits> dest;
+      BoolOptionalMessage<SourceTraits> source;
+      dest.optional_bool.emplace(false);
+      source.optional_bool.emplace(true);
+
+      std::pmr::monotonic_buffer_resource mr;
+      hpp_proto::merge(dest, source, hpp_proto::alloc_from(mr));
+      expect(eq(dest.optional_bool.has_value(), true));
+      expect(eq(*dest.optional_bool, true));
+    };
+
+    should("merge rvalue should overwrite optional<bool>") = [] {
+      BoolOptionalMessage<DestTraits> dest;
+      BoolOptionalMessage<SourceTraits> source;
+      dest.optional_bool.emplace(false);
+      source.optional_bool.emplace(true);
+
+      std::pmr::monotonic_buffer_resource mr;
+      hpp_proto::merge(dest, std::move(source), hpp_proto::alloc_from(mr));
+      expect(eq(dest.optional_bool.has_value(), true));
+      expect(eq(*dest.optional_bool, true));
+    };
+  } | std::tuple<std::pair<hpp_proto::default_traits, hpp_proto::default_traits>,
+                 std::pair<hpp_proto::non_owning_traits, hpp_proto::default_traits>,
+                 std::pair<hpp_proto::default_traits, hpp_proto::non_owning_traits>>{};
 };
 
 int main() {

--- a/unittests/merge_message_tests.cpp
+++ b/unittests/merge_message_tests.cpp
@@ -402,34 +402,36 @@ const boost::ut::suite merge_test_suite = [] {
     // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved)
   };
 
-  "merge_optional_bool"_test = []<class TraitsPair> {
-    using DestTraits = typename TraitsPair::first_type;
-    using SourceTraits = typename TraitsPair::second_type;
+  "merge_optional_bool"_test =
+      []<class TraitsPair> {
+        using DestTraits = typename TraitsPair::first_type;
+        using SourceTraits = typename TraitsPair::second_type;
 
-    should("merge const reference should overwrite optional<bool>") = [] {
-      BoolOptionalMessage<DestTraits> dest;
-      BoolOptionalMessage<SourceTraits> source;
-      dest.optional_bool.emplace(false);
-      source.optional_bool.emplace(true);
+        should("merge const reference should overwrite optional<bool>") = [] {
+          BoolOptionalMessage<DestTraits> dest;
+          BoolOptionalMessage<SourceTraits> source;
+          dest.optional_bool.emplace(false);
+          source.optional_bool.emplace(true);
 
-      std::pmr::monotonic_buffer_resource mr;
-      hpp_proto::merge(dest, source, hpp_proto::alloc_from(mr));
-      expect(eq(dest.optional_bool.has_value(), true));
-      expect(eq(*dest.optional_bool, true));
-    };
+          std::pmr::monotonic_buffer_resource mr;
+          hpp_proto::merge(dest, source, hpp_proto::alloc_from(mr));
+          expect(eq(dest.optional_bool.has_value(), true));
+          expect(eq(*dest.optional_bool, true));
+        };
 
-    should("merge rvalue should overwrite optional<bool>") = [] {
-      BoolOptionalMessage<DestTraits> dest;
-      BoolOptionalMessage<SourceTraits> source;
-      dest.optional_bool.emplace(false);
-      source.optional_bool.emplace(true);
+        should("merge rvalue should overwrite optional<bool>") = [] {
+          BoolOptionalMessage<DestTraits> dest;
+          BoolOptionalMessage<SourceTraits> source;
+          dest.optional_bool.emplace(false);
+          source.optional_bool.emplace(true);
 
-      std::pmr::monotonic_buffer_resource mr;
-      hpp_proto::merge(dest, std::move(source), hpp_proto::alloc_from(mr));
-      expect(eq(dest.optional_bool.has_value(), true));
-      expect(eq(*dest.optional_bool, true));
-    };
-  } | std::tuple<std::pair<hpp_proto::default_traits, hpp_proto::default_traits>,
+          std::pmr::monotonic_buffer_resource mr;
+          hpp_proto::merge(dest, std::move(source), hpp_proto::alloc_from(mr));
+          expect(eq(dest.optional_bool.has_value(), true));
+          expect(eq(*dest.optional_bool, true));
+        };
+      } |
+      std::tuple<std::pair<hpp_proto::default_traits, hpp_proto::default_traits>,
                  std::pair<hpp_proto::non_owning_traits, hpp_proto::default_traits>,
                  std::pair<hpp_proto::default_traits, hpp_proto::non_owning_traits>>{};
 };


### PR DESCRIPTION
## Summary
This PR fixes a merge-time template instantiation failure for messages containing `hpp_proto::optional<bool>` and adds targeted unit tests.

## Problem
`message_merger::perform` for optional non-message fields always merged through `dest.emplace()`.  
For `hpp_proto::optional<bool>`, `emplace()` returns `bool_proxy`, which is not compatible with the generic merge overload set, causing compilation failure.

## Fix
In `include/hpp_proto/merge.hpp`:
- For optional non-message fields, prefer direct assignment when available:
  - `dest = *source`
- Fall back to previous `perform(dest.emplace(), *source)` behavior otherwise.

