### PR TITLE
Use dedicated cache allocator option for binpb temp storage and remove `max_size_cache_on_stack`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,15 +77,21 @@ jobs:
 
       - name: Upload macOS crash reports
         if: failure()
+        shell: bash
+        run: |
+          mkdir -p build/crash-artifacts
+          cp -v "$HOME/Library/Logs/DiagnosticReports/"* build/crash-artifacts/ 2>/dev/null || true
+          cp -v build/Testing/Temporary/LastTest.log build/crash-artifacts/ 2>/dev/null || true
+          cp -v build/Testing/Temporary/LastTestsFailed.log build/crash-artifacts/ 2>/dev/null || true
+          cp -v build/Testing/Temporary/CTestCostData.txt build/crash-artifacts/ 2>/dev/null || true
+
+      - name: Upload macOS crash artifact bundle
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: macos-crash-reports-${{ matrix.cmake_preset }}
           if-no-files-found: warn
-          path: |
-            ~/Library/Logs/DiagnosticReports/*
-            build/Testing/Temporary/LastTest.log
-            build/Testing/Temporary/LastTestsFailed.log
-            build/Testing/Temporary/CTestCostData.txt
+          path: build/crash-artifacts
 
       - name: capture coverage
         if: matrix.cmake_preset == 'ci-macos-coverage'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -65,6 +65,24 @@ jobs:
       - name: configure
         shell: bash
         run: |
+          protobuf_formula="$(
+            brew info grpc | awk '
+              /^==> Dependencies$/ { in_deps=1; next }
+              in_deps && /^==> / { in_deps=0 }
+              in_deps {
+                if (match($0, /protobuf(@[0-9]+)?/)) {
+                  print substr($0, RSTART, RLENGTH)
+                  exit
+                }
+              }
+            '
+          )"
+          if [[ -z "${protobuf_formula}" ]]; then
+            echo "Failed to resolve protobuf dependency for grpc" >&2
+            exit 1
+          fi
+          protobuf_prefix="$(brew --prefix "${protobuf_formula}")"
+          export PATH="${protobuf_prefix}/bin:${PATH}"
           cmake --preset "${{ matrix.cmake_preset }}"
 
       - name: build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,7 +80,31 @@ jobs:
         shell: bash
         run: |
           mkdir -p build/crash-artifacts
-          cp -v "$HOME/Library/Logs/DiagnosticReports/"* build/crash-artifacts/ 2>/dev/null || true
+          {
+            echo "HOME=$HOME"
+            echo "date=$(date -u)"
+            echo "--- ls \$HOME/Library/Logs ---"
+            ls -la "$HOME/Library/Logs" || true
+            echo "--- ls \$HOME/Library/Logs/DiagnosticReports ---"
+            ls -la "$HOME/Library/Logs/DiagnosticReports" || true
+            echo "--- ls /Library/Logs/DiagnosticReports ---"
+            ls -la /Library/Logs/DiagnosticReports || true
+          } > build/crash-artifacts/diagnosticreports-index.txt
+
+          # Crash reports can be written slightly after process exit.
+          for _ in {1..30}; do
+            count="$(find "$HOME/Library/Logs/DiagnosticReports" /Library/Logs/DiagnosticReports \
+              -maxdepth 1 -type f \( -name '*.crash' -o -name '*.ips' \) 2>/dev/null | wc -l | tr -d ' ')"
+            if [[ "$count" != "0" ]]; then
+              break
+            fi
+            sleep 1
+          done
+
+          find "$HOME/Library/Logs/DiagnosticReports" /Library/Logs/DiagnosticReports \
+            -maxdepth 1 -type f \( -name '*.crash' -o -name '*.ips' \) -print0 2>/dev/null \
+            | xargs -0 -I{} cp -v "{}" build/crash-artifacts/ || true
+
           cp -v build/Testing/Temporary/LastTest.log build/crash-artifacts/ 2>/dev/null || true
           cp -v build/Testing/Temporary/LastTestsFailed.log build/crash-artifacts/ 2>/dev/null || true
           cp -v build/Testing/Temporary/CTestCostData.txt build/crash-artifacts/ 2>/dev/null || true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,47 +92,6 @@ jobs:
         run: |
           ctest --output-on-failure
 
-      - name: Upload macOS crash reports
-        if: failure()
-        shell: bash
-        run: |
-          mkdir -p build/crash-artifacts
-          {
-            echo "HOME=$HOME"
-            echo "date=$(date -u)"
-            echo "--- ls \$HOME/Library/Logs ---"
-            ls -la "$HOME/Library/Logs" || true
-            echo "--- ls \$HOME/Library/Logs/DiagnosticReports ---"
-            ls -la "$HOME/Library/Logs/DiagnosticReports" || true
-            echo "--- ls /Library/Logs/DiagnosticReports ---"
-            ls -la /Library/Logs/DiagnosticReports || true
-          } > build/crash-artifacts/diagnosticreports-index.txt
-
-          # Crash reports can be written slightly after process exit.
-          for _ in {1..30}; do
-            count="$(find "$HOME/Library/Logs/DiagnosticReports" /Library/Logs/DiagnosticReports \
-              -maxdepth 1 -type f \( -name '*.crash' -o -name '*.ips' \) 2>/dev/null | wc -l | tr -d ' ')"
-            if [[ "$count" != "0" ]]; then
-              break
-            fi
-            sleep 1
-          done
-
-          find "$HOME/Library/Logs/DiagnosticReports" /Library/Logs/DiagnosticReports \
-            -maxdepth 1 -type f \( -name '*.crash' -o -name '*.ips' \) -print0 2>/dev/null \
-            | xargs -0 -I{} cp -v "{}" build/crash-artifacts/ || true
-
-          cp -v build/Testing/Temporary/LastTest.log build/crash-artifacts/ 2>/dev/null || true
-          cp -v build/Testing/Temporary/LastTestsFailed.log build/crash-artifacts/ 2>/dev/null || true
-          cp -v build/Testing/Temporary/CTestCostData.txt build/crash-artifacts/ 2>/dev/null || true
-
-      - name: Upload macOS crash artifact bundle
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-crash-reports-${{ matrix.cmake_preset }}
-          if-no-files-found: warn
-          path: build/crash-artifacts
 
       - name: capture coverage
         if: matrix.cmake_preset == 'ci-macos-coverage'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -66,15 +66,14 @@ jobs:
         shell: bash
         run: |
           protobuf_formula="$(
-            brew info grpc | awk '
-              /^==> Dependencies$/ { in_deps=1; next }
-              in_deps && /^==> / { in_deps=0 }
-              in_deps {
-                if (match($0, /protobuf(@[0-9]+)?/)) {
-                  print substr($0, RSTART, RLENGTH)
-                  exit
-                }
-              }
+            brew info --json=v2 grpc | /usr/bin/ruby -rjson -e '
+              data = JSON.parse(STDIN.read)
+              formula = data.fetch("formulae").first || {}
+              installed = formula.fetch("installed", [])
+              runtime = installed.flat_map { |i| i.fetch("runtime_dependencies", []) }
+              dep = runtime.map { |d| d["full_name"] }.find { |n| n&.match?(/^protobuf(@\d+)?$/) }
+              dep ||= formula.fetch("dependencies", []).find { |n| n.match?(/^protobuf(@\d+)?$/) }
+              puts(dep) if dep
             '
           )"
           if [[ -z "${protobuf_formula}" ]]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,6 +75,17 @@ jobs:
         run: |
           ctest --output-on-failure
 
+      - name: Upload macOS crash reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-crash-reports-${{ matrix.cmake_preset }}
+          if-no-files-found: warn
+          path: |
+            ~/Library/Logs/DiagnosticReports/*
+            build/Testing/Temporary/LastTest.log
+            build/Testing/Temporary/LastTestsFailed.log
+            build/Testing/Temporary/CTestCostData.txt
 
       - name: capture coverage
         if: matrix.cmake_preset == 'ci-macos-coverage'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,6 +75,38 @@ jobs:
         run: |
           ctest --output-on-failure
 
+      - name: Rerun failed tests with verbose logging
+        if: failure()
+        shell: bash
+        working-directory: ./build
+        run: |
+          mkdir -p crash-artifacts
+          set +e
+          ctest --rerun-failed -VV --output-on-failure 2>&1 | tee crash-artifacts/ctest-rerun-failed-vv.log
+          echo "$?" > crash-artifacts/ctest-rerun-failed-vv.exitcode
+
+      - name: Capture direct grpc binary runs
+        if: failure()
+        shell: bash
+        working-directory: ./build
+        run: |
+          mkdir -p crash-artifacts/direct-runs
+          set +e
+          run_and_log() {
+            local name="$1"
+            shift
+            "$@" > "crash-artifacts/direct-runs/${name}.stdout.log" 2> "crash-artifacts/direct-runs/${name}.stderr.log"
+            echo "$?" > "crash-artifacts/direct-runs/${name}.exitcode"
+          }
+
+          run_and_log grpc_unary_tests ./tests/grpc/grpc_unary_tests
+          run_and_log grpc_client_stream_tests ./tests/grpc/grpc_client_stream_tests
+          run_and_log grpc_server_stream_tests ./tests/grpc/grpc_server_stream_tests
+          run_and_log grpc_bidi_stream_tests ./tests/grpc/grpc_bidi_stream_tests
+          run_and_log grpc_server_failure_tests ./tests/grpc/grpc_server_failure_tests
+          run_and_log grpc_serialization_tests ./tests/grpc/grpc_serialization_tests
+          run_and_log greeter_test_script bash -lc "cd tutorial/grpc && ../../../../../tutorial/grpc/greeter_test.sh"
+
       - name: Upload macOS crash reports
         if: failure()
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,9 +54,9 @@ jobs:
           ninja: true
           ccache: true
 
-      - name: Install protobuf
+      - name: Install grpc
         shell: bash
-        run: brew install protobuf grpc
+        run: brew install grpc
         
       - name: install lcov
         if: matrix.cmake_preset == 'ci-macos-coverage'
@@ -74,38 +74,6 @@ jobs:
         working-directory: ./build
         run: |
           ctest --output-on-failure
-
-      - name: Rerun failed tests with verbose logging
-        if: failure()
-        shell: bash
-        working-directory: ./build
-        run: |
-          mkdir -p crash-artifacts
-          set +e
-          ctest --rerun-failed -VV --output-on-failure 2>&1 | tee crash-artifacts/ctest-rerun-failed-vv.log
-          echo "$?" > crash-artifacts/ctest-rerun-failed-vv.exitcode
-
-      - name: Capture direct grpc binary runs
-        if: failure()
-        shell: bash
-        working-directory: ./build
-        run: |
-          mkdir -p crash-artifacts/direct-runs
-          set +e
-          run_and_log() {
-            local name="$1"
-            shift
-            "$@" > "crash-artifacts/direct-runs/${name}.stdout.log" 2> "crash-artifacts/direct-runs/${name}.stderr.log"
-            echo "$?" > "crash-artifacts/direct-runs/${name}.exitcode"
-          }
-
-          run_and_log grpc_unary_tests ./tests/grpc/grpc_unary_tests
-          run_and_log grpc_client_stream_tests ./tests/grpc/grpc_client_stream_tests
-          run_and_log grpc_server_stream_tests ./tests/grpc/grpc_server_stream_tests
-          run_and_log grpc_bidi_stream_tests ./tests/grpc/grpc_bidi_stream_tests
-          run_and_log grpc_server_failure_tests ./tests/grpc/grpc_server_failure_tests
-          run_and_log grpc_serialization_tests ./tests/grpc/grpc_serialization_tests
-          run_and_log greeter_test_script bash -lc "cd tutorial/grpc && ../../../../../tutorial/grpc/greeter_test.sh"
 
       - name: Upload macOS crash reports
         if: failure()

--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ cmake --build build
 
 You should see output indicating that both binary and JSON round-trips were successful.
 
+## Documentation
+
+* [Front-End API Guide](docs/frontend_apis.md): `read/write` binary+JSON APIs, sink modes, and allocator/cache options.
+* [Code Generation Guide](docs/Code_Generation_Guide.md): generated APIs, traits, and customization model.
+* [gRPC Adapter Guide](docs/grpc-adapter.md): gRPC integration for generated messages.
+* [Dynamic Message Guide](docs/dynamic_message.md): descriptor-driven runtime messaging APIs.
+
 ## Advanced Usage & Concepts
 
 ### Library Targets

--- a/docs/Code_Generation_Guide.md
+++ b/docs/Code_Generation_Guide.md
@@ -435,6 +435,7 @@ Regardless of return type (`std::expected` or status), `read_binpb`/`read_json` 
 
 </p>
 </details>
+
 <details open><summary> View Traits (`hpp_proto::non_owning_traits`)</summary>
 <p>
 
@@ -462,3 +463,75 @@ assert(hpp_proto::unpack_any(round_trip.any_value.value(), fm2, ctx).ok());
 
 </p>
 </details>
+
+## Memory Options for Serialization/Deserialization
+
+`hpp-proto` exposes three related options that control where temporary and object storage comes from:
+
+| Option | Purpose | Typical lifetime |
+|---|---|---|
+| `hpp_proto::alloc_from(mr)` | Message/object allocations during parse/build (for example strings, bytes, repeated/map storage in non-owning/PMR flows) | Usually tied to decoded message lifetime |
+| `hpp_proto::cache_alloc_from(mr)` | Internal temp/cache allocations used by binpb encode/decode working buffers | Usually short-lived per call/batch |
+| `hpp_proto::max_size_cache_on_stack<N>` | Stack front-buffer size (bytes) for binpb size cache before upstream allocation | Per call (stack) |
+
+### `alloc_from`
+
+Use `alloc_from` when you want decoded objects (or APIs that build message content) to allocate from a specific memory resource:
+
+```cpp
+std::pmr::monotonic_buffer_resource object_pool;
+auto obj_ctx = hpp_proto::alloc_from(object_pool);
+
+MyViewMessage<hpp_proto::non_owning_traits> msg;
+auto st = hpp_proto::read_binpb(msg, input_bytes, obj_ctx);
+```
+
+### `cache_alloc_from`
+
+Use `cache_alloc_from` when you want binpb internal working memory to come from a dedicated resource:
+
+```cpp
+std::pmr::monotonic_buffer_resource cache_pool;
+
+test_out_sink sink(7);
+auto st = hpp_proto::write_binpb(
+    message,
+    sink,
+    hpp_proto::chunked_mode,
+    hpp_proto::cache_alloc_from(cache_pool));
+```
+
+For chunked-input decode, temporary patch/region buffers follow `cache_alloc_from` as well:
+
+```cpp
+auto st = hpp_proto::read_binpb(
+    message,
+    chunked_segments,
+    hpp_proto::cache_alloc_from(cache_pool));
+```
+
+### `max_size_cache_on_stack`
+
+`max_size_cache_on_stack<N>` controls the stack front-buffer size used by binpb size-cache allocation:
+
+- If working cache fits in `N` bytes, no upstream allocation is needed for that cache.
+- If it exceeds `N`, additional bytes come from the cache upstream resource.
+- `N = 0` forces cache growth to use upstream immediately.
+
+```cpp
+auto st = hpp_proto::write_binpb(
+    message,
+    sink,
+    hpp_proto::chunked_mode,
+    hpp_proto::max_size_cache_on_stack<0>,
+    hpp_proto::cache_alloc_from(cache_pool));
+```
+
+### Precedence Rules for Binpb Cache/Temp Allocation
+
+For binpb internal cache/temp storage, hpp-proto resolves upstream memory resource as:
+
+1. `cache_alloc_from(...)` (if provided)
+2. default PMR resource (`std::pmr::get_default_resource()`)
+
+`alloc_from(...)` is intentionally not used as fallback for cache/temp storage, so object lifetime memory and cache lifetime memory can be controlled independently.

--- a/docs/Code_Generation_Guide.md
+++ b/docs/Code_Generation_Guide.md
@@ -466,13 +466,12 @@ assert(hpp_proto::unpack_any(round_trip.any_value.value(), fm2, ctx).ok());
 
 ## Memory Options for Serialization/Deserialization
 
-`hpp-proto` exposes three related options that control where temporary and object storage comes from:
+`hpp-proto` exposes two related options that control where temporary and object storage comes from:
 
 | Option | Purpose | Typical lifetime |
 |---|---|---|
 | `hpp_proto::alloc_from(mr)` | Message/object allocations during parse/build (for example strings, bytes, repeated/map storage in non-owning/PMR flows) | Usually tied to decoded message lifetime |
 | `hpp_proto::cache_alloc_from(mr)` | Internal temp/cache allocations used by binpb encode/decode working buffers | Usually short-lived per call/batch |
-| `hpp_proto::max_size_cache_on_stack<N>` | Stack front-buffer size (bytes) for binpb size cache before upstream allocation | Per call (stack) |
 
 ### `alloc_from`
 
@@ -510,28 +509,11 @@ auto st = hpp_proto::read_binpb(
     hpp_proto::cache_alloc_from(cache_pool));
 ```
 
-### `max_size_cache_on_stack`
-
-`max_size_cache_on_stack<N>` controls the stack front-buffer size used by binpb size-cache allocation:
-
-- If working cache fits in `N` bytes, no upstream allocation is needed for that cache.
-- If it exceeds `N`, additional bytes come from the cache upstream resource.
-- `N = 0` forces cache growth to use upstream immediately.
-
-```cpp
-auto st = hpp_proto::write_binpb(
-    message,
-    sink,
-    hpp_proto::chunked_mode,
-    hpp_proto::max_size_cache_on_stack<0>,
-    hpp_proto::cache_alloc_from(cache_pool));
-```
-
 ### Precedence Rules for Binpb Cache/Temp Allocation
 
-For binpb internal cache/temp storage, hpp-proto resolves upstream memory resource as:
+For binpb internal cache/temp storage, hpp-proto resolves cache memory resource as:
 
 1. `cache_alloc_from(...)` (if provided)
-2. default PMR resource (`std::pmr::get_default_resource()`)
+2. internal default cache memory resource (1024-byte stack-backed monotonic buffer, upstreaming to `std::pmr::get_default_resource()`)
 
 `alloc_from(...)` is intentionally not used as fallback for cache/temp storage, so object lifetime memory and cache lifetime memory can be controlled independently.

--- a/docs/frontend_apis.md
+++ b/docs/frontend_apis.md
@@ -105,20 +105,12 @@ Controls message/object allocations (for example when parsing into non-owning/PM
 
 Controls internal binpb temporary/cache allocations (size cache, chunked-input temp buffers).
 
-### `max_size_cache_on_stack<N>`
-
-Sets stack front-buffer bytes for binpb size cache.
-
-- small caches fit on stack
-- larger caches spill to upstream cache resource
-- `N = 0` forces immediate upstream usage
-
 ### Cache resource resolution
 
 For binpb temp/cache allocations:
 
 1. `cache_alloc_from(...)` if supplied
-2. default PMR resource
+2. internal default cache resource (1024-byte stack-backed monotonic buffer with default PMR upstream)
 
 `alloc_from(...)` is intentionally separate and not used as fallback for cache/temp storage.
 

--- a/docs/frontend_apis.md
+++ b/docs/frontend_apis.md
@@ -1,0 +1,136 @@
+# Front-End API Guide
+
+This guide documents the primary user-facing serialization/deserialization APIs:
+
+- `write_binpb` / `read_binpb`
+- `write_json` / `read_json`
+
+It also explains binary sink modes and allocator-related options.
+
+## Quick Map
+
+| API family | Input/Output style | Return type |
+|---|---|---|
+| `write_binpb(msg, buffer, ...)` | write protobuf binary into contiguous buffer | `hpp_proto::status` |
+| `write_binpb(msg, sink, ...)` | write protobuf binary into chunked sink | `hpp_proto::status` |
+| `write_binpb<Buffer>(msg, ...)` | allocate/return serialized buffer | `std::expected<Buffer, std::errc>` |
+| `read_binpb(msg, buffer, ...)` | parse binary into existing message | `hpp_proto::status` |
+| `read_binpb<T>(buffer, ...)` | parse binary and return message | `std::expected<T, std::errc>` |
+| `write_json(value, buffer, ...)` | write JSON into caller buffer | `hpp_proto::json_status` |
+| `write_json<Buffer>(value, ...)` | allocate/return JSON buffer | `std::expected<Buffer, hpp_proto::json_status>` |
+| `read_json(value, input, ...)` | parse JSON into existing message | `hpp_proto::json_status` |
+| `read_json<T>(input, ...)` | parse JSON and return message | `std::expected<T, hpp_proto::json_status>` |
+
+## Binary APIs (`read_binpb` / `write_binpb`)
+
+### Contiguous buffer write
+
+```cpp
+std::vector<std::byte> out;
+auto st = hpp_proto::write_binpb(message, out);
+```
+
+Use this for standard in-memory serialization.
+
+### Sink write (stream/chunk oriented)
+
+```cpp
+my_sink sink;
+auto st = hpp_proto::write_binpb(message, sink, hpp_proto::adaptive_mode);
+```
+
+Supported mode options:
+
+- `hpp_proto::contiguous_mode`: one-shot write into first chunk; fastest when sink chunk is large enough.
+- `hpp_proto::chunked_mode`: always write in chunks.
+- `hpp_proto::adaptive_mode` (default for sink): contiguous if message fits one sink chunk, otherwise chunked.
+
+> Mode options only affect sink-based `write_binpb`. Contiguous-buffer writes are always contiguous.
+
+### Read from contiguous/chunked input
+
+```cpp
+MyMessage msg;
+auto st1 = hpp_proto::read_binpb(msg, bytes);
+auto st2 = hpp_proto::read_binpb(msg, chunked_segments);
+```
+
+`chunked_segments` is a random-access range of contiguous byte ranges.
+
+### `padded_input` option
+
+`hpp_proto::padded_input` enables a faster contiguous-input parse path by allowing internal loops to skip some boundary checks.
+
+```cpp
+std::string_view payload = /* valid protobuf payload only */;
+auto st = hpp_proto::read_binpb(message, payload, hpp_proto::padded_input);
+```
+
+Required preconditions:
+
+1. The passed range must contain only valid payload bytes (no extra logical bytes in-range).
+2. The underlying memory must be readable for at least 16 bytes past the end of the range.
+3. The first byte after payload must be `0` (sentinel).
+
+If these preconditions are not guaranteed, do not use `padded_input`.
+
+## JSON APIs (`read_json` / `write_json`)
+
+### Write JSON
+
+```cpp
+std::string json;
+auto st = hpp_proto::write_json(message, json);
+```
+
+### Read JSON
+
+```cpp
+MyMessage msg;
+auto st = hpp_proto::read_json(msg, json_input);
+```
+
+`read_json` supports:
+
+- null-terminated inputs (`const char*`, `std::string`, char arrays)
+- non-null-terminated contiguous ranges (`std::string_view`, spans)
+
+## Allocator/Cache Options
+
+### `alloc_from(resource)`
+
+Controls message/object allocations (for example when parsing into non-owning/PMR-oriented messages).
+
+### `cache_alloc_from(resource)`
+
+Controls internal binpb temporary/cache allocations (size cache, chunked-input temp buffers).
+
+### `max_size_cache_on_stack<N>`
+
+Sets stack front-buffer bytes for binpb size cache.
+
+- small caches fit on stack
+- larger caches spill to upstream cache resource
+- `N = 0` forces immediate upstream usage
+
+### Cache resource resolution
+
+For binpb temp/cache allocations:
+
+1. `cache_alloc_from(...)` if supplied
+2. default PMR resource
+
+`alloc_from(...)` is intentionally separate and not used as fallback for cache/temp storage.
+
+## Failure Semantics
+
+### Existing-output overloads
+
+For APIs that deserialize into an existing output object (`read_binpb(msg, ...)`, `read_json(msg, ...)`):
+
+- on parse failure, prior `msg` contents are not guaranteed to be preserved
+- behavior is parser/field-path dependent; treat output as modified-on-failure
+
+### Exception note
+
+`read_binpb`/`read_json` do not catch exceptions from standard containers (for example `std::bad_alloc`).

--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -158,7 +158,7 @@ status write_binpb(T &&msg, Sink &sink, concepts::is_pb_context auto &ctx) {
 /// @tparam Buffer A contiguous byte range.
 /// @param msg The message to serialize.
 /// @param buffer The buffer to write the serialized data into.
-/// @param option Optional configuration parameters (e.g., alloc_from, cache_alloc_from, max_size_cache_on_stack).
+/// @param option Optional configuration parameters (e.g., alloc_from, cache_alloc_from).
 /// @return status indicating success or failure.
 template <concepts::has_meta T, concepts::contiguous_byte_range Buffer>
 status write_binpb(T &&msg, Buffer &buffer, concepts::is_option_type auto &&...option) {
@@ -171,7 +171,7 @@ status write_binpb(T &&msg, Buffer &buffer, concepts::is_option_type auto &&...o
 /// @tparam Sink A chunked output sink.
 /// @param msg The message to serialize.
 /// @param sink The sink to write the serialized data into.
-/// @param option Optional configuration parameters (e.g., cache_alloc_from, max_size_cache_on_stack).
+/// @param option Optional configuration parameters (e.g., cache_alloc_from).
 /// @return status indicating success or failure.
 template <concepts::has_meta T, concepts::out_sink Sink>
 status write_binpb(T &&msg, Sink &sink, concepts::is_option_type auto &&...option) {

--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -158,7 +158,7 @@ status write_binpb(T &&msg, Sink &sink, concepts::is_pb_context auto &ctx) {
 /// @tparam Buffer A contiguous byte range.
 /// @param msg The message to serialize.
 /// @param buffer The buffer to write the serialized data into.
-/// @param option Optional configuration parameters (e.g., alloc_from, max_size_cache_on_stack).
+/// @param option Optional configuration parameters (e.g., alloc_from, cache_alloc_from, max_size_cache_on_stack).
 /// @return status indicating success or failure.
 template <concepts::has_meta T, concepts::contiguous_byte_range Buffer>
 status write_binpb(T &&msg, Buffer &buffer, concepts::is_option_type auto &&...option) {
@@ -171,7 +171,7 @@ status write_binpb(T &&msg, Buffer &buffer, concepts::is_option_type auto &&...o
 /// @tparam Sink A chunked output sink.
 /// @param msg The message to serialize.
 /// @param sink The sink to write the serialized data into.
-/// @param option Optional configuration parameters (e.g., max_size_cache_on_stack).
+/// @param option Optional configuration parameters (e.g., cache_alloc_from, max_size_cache_on_stack).
 /// @return status indicating success or failure.
 template <concepts::has_meta T, concepts::out_sink Sink>
 status write_binpb(T &&msg, Sink &sink, concepts::is_option_type auto &&...option) {
@@ -203,7 +203,7 @@ status append_binpb(T &&msg, concepts::resizable_contiguous_byte_container auto 
 /// @brief Deserializes a message from a byte range and returns the message object.
 /// @tparam T Type of the message to deserialize, must satisfy concepts::has_meta.
 /// @param buffer The input byte range containing serialized data.
-/// @param option Optional configuration parameters (e.g., alloc_from).
+/// @param option Optional configuration parameters (e.g., alloc_from, cache_alloc_from).
 /// @details This API does not catch std::bad_alloc thrown by standard containers.
 /// @return A std::expected containing the deserialized message on success, or an error code on failure.
 template <concepts::has_meta T>

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1455,7 +1455,7 @@ status deserialize(auto &item, concepts::chunked_byte_range auto const &buffer, 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
   std::array<std::byte, 1024> tmp_buffer;
   std::pmr::monotonic_buffer_resource mr{tmp_buffer.data(), tmp_buffer.size(),
-                                         upstream_memory_resource_or_default(context)};
+                                         cache_memory_resource_or_default(context)};
 
   std::pmr::vector<std::byte> patch_buffer(patch_buffer_bytes_count, &mr);
   std::pmr::vector<input_buffer_region<std::byte>> regions(num_regions, &mr);

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1454,7 +1454,8 @@ status deserialize(auto &item, concepts::chunked_byte_range auto const &buffer, 
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
   std::array<std::byte, 1024> tmp_buffer;
-  std::pmr::monotonic_buffer_resource mr{tmp_buffer.data(), tmp_buffer.size()};
+  std::pmr::monotonic_buffer_resource mr{tmp_buffer.data(), tmp_buffer.size(),
+                                         upstream_memory_resource_or_default(context)};
 
   std::pmr::vector<std::byte> patch_buffer(patch_buffer_bytes_count, &mr);
   std::pmr::vector<input_buffer_region<std::byte>> regions(num_regions, &mr);

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1452,23 +1452,27 @@ status deserialize(auto &item, concepts::chunked_byte_range auto const &buffer, 
   const auto num_regions = num_segments * 2;
   const auto patch_buffer_bytes_count = num_segments * patch_buffer_size;
 
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
-  std::array<std::byte, 1024> tmp_buffer;
-  std::pmr::monotonic_buffer_resource mr{tmp_buffer.data(), tmp_buffer.size(),
-                                         cache_memory_resource_or_default(context)};
+  auto deserialize_with_cache_resource = [&](std::pmr::memory_resource &cache_mr) -> status {
+    std::pmr::vector<std::byte> patch_buffer(patch_buffer_bytes_count, &cache_mr);
+    std::pmr::vector<input_buffer_region<std::byte>> regions(num_regions, &cache_mr);
 
-  std::pmr::vector<std::byte> patch_buffer(patch_buffer_bytes_count, &mr);
-  std::pmr::vector<input_buffer_region<std::byte>> regions(num_regions, &mr);
+    std::ranges::transform(
+        buffer, std::next(regions.begin(), static_cast<std::ptrdiff_t>(num_segments)), [](const auto &b) {
+          return input_buffer_region<std::byte>{std::as_bytes(std::span{std::ranges::data(b), std::ranges::size(b)})};
+        });
 
-  std::ranges::transform(
-      buffer, std::next(regions.begin(), static_cast<std::ptrdiff_t>(num_segments)), [](const auto &b) {
-        return input_buffer_region<std::byte>{std::as_bytes(std::span{std::ranges::data(b), std::ranges::size(b)})};
-      });
+    constexpr bool is_contiguous = false;
+    auto archive = basic_in<std::byte, std::decay_t<decltype(context)>, is_contiguous>(
+        std::span{regions.data(), regions.size()}, std::span{patch_buffer.data(), patch_buffer.size()}, context);
+    return deserialize(item, archive);
+  };
 
-  constexpr bool is_contiguous = false;
-  auto archive = basic_in<std::byte, std::decay_t<decltype(context)>, is_contiguous>(
-      std::span{regions.data(), regions.size()}, std::span{patch_buffer.data(), patch_buffer.size()}, context);
-  return deserialize(item, archive);
+  if constexpr (has_cache_memory_resource<decltype(context)>) {
+    return deserialize_with_cache_resource(context.cache_memory_resource());
+  } else {
+    default_cache_memory_resource default_cache;
+    return deserialize_with_cache_resource(default_cache.memory_resource());
+  }
 }
 
 } // namespace pb_serializer

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -547,7 +547,8 @@ constexpr status serialize(const T &item, Buffer &buffer, [[maybe_unused]] conce
   } else {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
     std::array<std::byte, max_stack_cache_size> cache_storage;
-    std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size()};
+    std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size(),
+                                           upstream_memory_resource_or_default(context)};
     std::pmr::vector<uint32_t> cache(n, &mr);
     return serialize_contiguous_buffer_with_cache<overwrite_buffer>(item, buffer, context, cache);
   }
@@ -592,7 +593,8 @@ status serialize(const T &item, Sink &sink, Context &context) {
   constexpr std::size_t max_stack_cache_size = max_stack_cache_size_for_context<Context>();
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
   std::array<std::byte, max_stack_cache_size> cache_storage;
-  std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size()};
+  std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size(),
+                                         upstream_memory_resource_or_default(context)};
   std::pmr::vector<uint32_t> cache(n, &mr);
   const std::size_t msg_sz = message_size_calculator<T>::message_size(item, cache);
   if (msg_sz >= max_message_size) {

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -548,7 +548,7 @@ constexpr status serialize(const T &item, Buffer &buffer, [[maybe_unused]] conce
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
     std::array<std::byte, max_stack_cache_size> cache_storage;
     std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size(),
-                                           upstream_memory_resource_or_default(context)};
+                                           cache_memory_resource_or_default(context)};
     std::pmr::vector<uint32_t> cache(n, &mr);
     return serialize_contiguous_buffer_with_cache<overwrite_buffer>(item, buffer, context, cache);
   }
@@ -594,7 +594,7 @@ status serialize(const T &item, Sink &sink, Context &context) {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
   std::array<std::byte, max_stack_cache_size> cache_storage;
   std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size(),
-                                         upstream_memory_resource_or_default(context)};
+                                         cache_memory_resource_or_default(context)};
   std::pmr::vector<uint32_t> cache(n, &mr);
   const std::size_t msg_sz = message_size_calculator<T>::message_size(item, cache);
   if (msg_sz >= max_message_size) {

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -187,15 +187,6 @@ private:
   }
 };
 
-template <typename Context>
-constexpr std::size_t max_stack_cache_size_for_context() {
-  if constexpr (requires { Context::max_size_cache_on_stack; }) {
-    return Context::max_size_cache_on_stack;
-  } else {
-    return hpp_proto::max_size_cache_on_stack<>.max_size_cache_on_stack;
-  }
-}
-
 constexpr uint64_t len_size(uint64_t len) { return varint_size(len) + len; }
 
 /**
@@ -540,17 +531,20 @@ template <bool overwrite_buffer = true, typename T, concepts::contiguous_byte_ra
 constexpr status serialize(const T &item, Buffer &buffer, [[maybe_unused]] concepts::is_pb_context auto &context) {
   const std::size_t n = size_cache_counter<T>::count(item);
 
-  constexpr std::size_t max_stack_cache_size = max_stack_cache_size_for_context<decltype(context)>();
   if (std::is_constant_evaluated()) {
     std::vector<uint32_t> cache(n);
     return serialize_contiguous_buffer_with_cache<overwrite_buffer>(item, buffer, context, cache);
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
-    std::array<std::byte, max_stack_cache_size> cache_storage;
-    std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size(),
-                                           cache_memory_resource_or_default(context)};
-    std::pmr::vector<uint32_t> cache(n, &mr);
-    return serialize_contiguous_buffer_with_cache<overwrite_buffer>(item, buffer, context, cache);
+    if constexpr (has_cache_memory_resource<decltype(context)>) {
+      auto &cache_mr = context.cache_memory_resource();
+      std::pmr::vector<uint32_t> cache(n, &cache_mr);
+      return serialize_contiguous_buffer_with_cache<overwrite_buffer>(item, buffer, context, cache);
+    } else {
+      default_cache_memory_resource default_cache;
+      auto &cache_mr = default_cache.memory_resource();
+      std::pmr::vector<uint32_t> cache(n, &cache_mr);
+      return serialize_contiguous_buffer_with_cache<overwrite_buffer>(item, buffer, context, cache);
+    }
   }
 }
 
@@ -590,30 +584,34 @@ template <typename T, concepts::out_sink Sink, concepts::is_pb_context Context>
 status serialize(const T &item, Sink &sink, Context &context) {
   const std::size_t n = size_cache_counter<T>::count(item);
 
-  constexpr std::size_t max_stack_cache_size = max_stack_cache_size_for_context<Context>();
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
-  std::array<std::byte, max_stack_cache_size> cache_storage;
-  std::pmr::monotonic_buffer_resource mr{cache_storage.data(), cache_storage.size(),
-                                         cache_memory_resource_or_default(context)};
-  std::pmr::vector<uint32_t> cache(n, &mr);
-  const std::size_t msg_sz = message_size_calculator<T>::message_size(item, cache);
-  if (msg_sz >= max_message_size) {
-    return std::errc::value_too_large;
-  }
-  constexpr auto mode = serialization_mode_for_context<Context>();
-  sink.set_message_size(msg_sz);
+  auto serialize_with_cache_resource = [&](std::pmr::memory_resource &cache_mr) -> status {
+    std::pmr::vector<uint32_t> cache(n, &cache_mr);
+    const std::size_t msg_sz = message_size_calculator<T>::message_size(item, cache);
+    if (msg_sz >= max_message_size) {
+      return std::errc::value_too_large;
+    }
+    constexpr auto mode = serialization_mode_for_context<Context>();
+    sink.set_message_size(msg_sz);
 
-  if constexpr (mode == serialization_mode::contiguous) {
-    return serialize_contiguous_sink(item, sink, context, cache);
-  }
-
-  if constexpr (mode == serialization_mode::adaptive) {
-    if (msg_sz <= sink.chunk_size()) {
+    if constexpr (mode == serialization_mode::contiguous) {
       return serialize_contiguous_sink(item, sink, context, cache);
     }
-  }
 
-  return serialize_chunked_sink(item, sink, context, cache);
+    if constexpr (mode == serialization_mode::adaptive) {
+      if (msg_sz <= sink.chunk_size()) {
+        return serialize_contiguous_sink(item, sink, context, cache);
+      }
+    }
+
+    return serialize_chunked_sink(item, sink, context, cache);
+  };
+
+  if constexpr (has_cache_memory_resource<Context>) {
+    return serialize_with_cache_resource(context.cache_memory_resource());
+  } else {
+    default_cache_memory_resource default_cache;
+    return serialize_with_cache_resource(default_cache.memory_resource());
+  }
 }
 
 template <concepts::has_meta T>

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -88,6 +88,21 @@ public:
   [[nodiscard]] T &memory_resource() const { return *mr; }
 };
 
+template <concepts::memory_resource T>
+class cache_alloc_from {
+  T *mr;
+
+public:
+  using option_type = cache_alloc_from<T>;
+  explicit cache_alloc_from(T &m) : mr(&m) {}
+  ~cache_alloc_from() = default;
+  cache_alloc_from(const cache_alloc_from &other) = default;
+  cache_alloc_from(cache_alloc_from &&other) = default;
+  cache_alloc_from &operator=(const cache_alloc_from &) = default;
+  cache_alloc_from &operator=(cache_alloc_from &&) = default;
+  [[nodiscard]] T &cache_memory_resource() const { return *mr; }
+};
+
 template <uint32_t n>
 struct max_size_cache_on_stack_t {
   using option_type = max_size_cache_on_stack_t<n>;
@@ -142,12 +157,12 @@ auto &get_memory_resource(T &v) {
 }
 
 template <typename Context>
-constexpr std::pmr::memory_resource *upstream_memory_resource_or_default(Context &context) {
+constexpr std::pmr::memory_resource *cache_memory_resource_or_default(Context &context) {
   if constexpr (requires(Context &ctx) {
-                  requires std::derived_from<std::remove_reference_t<decltype(ctx.memory_resource())>,
+                  requires std::derived_from<std::remove_reference_t<decltype(ctx.cache_memory_resource())>,
                                              std::pmr::memory_resource>;
                 }) {
-    return &context.memory_resource();
+    return &context.cache_memory_resource();
   } else {
     return std::pmr::get_default_resource();
   }

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -156,11 +156,9 @@ auto &get_memory_resource(T &v) {
 }
 
 template <typename Context>
-concept has_cache_memory_resource =
-    requires(Context &ctx) {
-      requires std::derived_from<std::remove_reference_t<decltype(ctx.cache_memory_resource())>,
-                                 std::pmr::memory_resource>;
-    };
+concept has_cache_memory_resource = requires(Context &ctx) {
+  requires std::derived_from<std::remove_reference_t<decltype(ctx.cache_memory_resource())>, std::pmr::memory_resource>;
+};
 
 namespace detail {
 template <concepts::byte_serializable T, std::ranges::contiguous_range Range>

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -103,11 +103,11 @@ public:
 };
 
 class default_cache_memory_resource {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
-  std::array<std::byte, 1024> stack_buffer;
+  std::array<std::byte, 1024> stack_buffer{};
   std::pmr::monotonic_buffer_resource mr;
 
 public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
   default_cache_memory_resource() : mr(stack_buffer.data(), stack_buffer.size(), std::pmr::get_default_resource()) {}
   ~default_cache_memory_resource() = default;
   default_cache_memory_resource(const default_cache_memory_resource &) = delete;

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -88,19 +88,18 @@ public:
   [[nodiscard]] T &memory_resource() const { return *mr; }
 };
 
-template <concepts::memory_resource T>
 class cache_alloc_from {
-  T *mr;
+  std::pmr::memory_resource *mr;
 
 public:
-  using option_type = cache_alloc_from<T>;
-  explicit cache_alloc_from(T &m) : mr(&m) {}
+  using option_type = cache_alloc_from;
+  explicit cache_alloc_from(std::pmr::memory_resource &m) : mr(&m) {}
   ~cache_alloc_from() = default;
   cache_alloc_from(const cache_alloc_from &other) = default;
   cache_alloc_from(cache_alloc_from &&other) = default;
   cache_alloc_from &operator=(const cache_alloc_from &) = default;
   cache_alloc_from &operator=(cache_alloc_from &&) = default;
-  [[nodiscard]] T &cache_memory_resource() const { return *mr; }
+  [[nodiscard]] std::pmr::memory_resource &cache_memory_resource() const { return *mr; }
 };
 
 template <uint32_t n>

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -102,20 +102,20 @@ public:
   [[nodiscard]] std::pmr::memory_resource &cache_memory_resource() const { return *mr; }
 };
 
-template <uint32_t n>
-struct max_size_cache_on_stack_t {
-  using option_type = max_size_cache_on_stack_t<n>;
-  static constexpr auto max_size_cache_on_stack = n;
-};
+class default_cache_memory_resource {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+  std::array<std::byte, 1024> stack_buffer;
+  std::pmr::monotonic_buffer_resource mr;
 
-/// @brief max size in bytes which can be used for allocating size cache on stack
-///
-/// @details To accelerate Protobuf serialization, a size cache is utilized to store the serialized byte count of
-/// variable-length fields before the fields’ content is serialized. If the total size of the size cache required is
-/// less than or equal to max_size_cache_on_stack, the cache is allocated directly on the stack. Otherwise, it is
-/// allocated on the heap.
-template <uint32_t n = 1024>
-constexpr auto max_size_cache_on_stack = max_size_cache_on_stack_t<n>{};
+public:
+  default_cache_memory_resource() : mr(stack_buffer.data(), stack_buffer.size(), std::pmr::get_default_resource()) {}
+  ~default_cache_memory_resource() = default;
+  default_cache_memory_resource(const default_cache_memory_resource &) = delete;
+  default_cache_memory_resource(default_cache_memory_resource &&) = delete;
+  default_cache_memory_resource &operator=(const default_cache_memory_resource &) = delete;
+  default_cache_memory_resource &operator=(default_cache_memory_resource &&) = delete;
+  [[nodiscard]] std::pmr::memory_resource &memory_resource() { return mr; }
+};
 
 template <typename... T>
 struct pb_context : T::option_type... {
@@ -156,16 +156,11 @@ auto &get_memory_resource(T &v) {
 }
 
 template <typename Context>
-constexpr std::pmr::memory_resource *cache_memory_resource_or_default(Context &context) {
-  if constexpr (requires(Context &ctx) {
-                  requires std::derived_from<std::remove_reference_t<decltype(ctx.cache_memory_resource())>,
-                                             std::pmr::memory_resource>;
-                }) {
-    return &context.cache_memory_resource();
-  } else {
-    return std::pmr::get_default_resource();
-  }
-}
+concept has_cache_memory_resource =
+    requires(Context &ctx) {
+      requires std::derived_from<std::remove_reference_t<decltype(ctx.cache_memory_resource())>,
+                                 std::pmr::memory_resource>;
+    };
 
 namespace detail {
 template <concepts::byte_serializable T, std::ranges::contiguous_range Range>

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -141,6 +141,18 @@ auto &get_memory_resource(T &v) {
   return v.memory_resource();
 }
 
+template <typename Context>
+constexpr std::pmr::memory_resource *upstream_memory_resource_or_default(Context &context) {
+  if constexpr (requires(Context &ctx) {
+                  requires std::derived_from<std::remove_reference_t<decltype(ctx.memory_resource())>,
+                                             std::pmr::memory_resource>;
+                }) {
+    return &context.memory_resource();
+  } else {
+    return std::pmr::get_default_resource();
+  }
+}
+
 namespace detail {
 template <concepts::byte_serializable T, std::ranges::contiguous_range Range>
 class bit_cast_view_t : public std::ranges::view_interface<bit_cast_view_t<T, Range>> {

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1068,6 +1068,7 @@ struct counting_memory_resource : std::pmr::memory_resource {
   counting_memory_resource &operator=(const counting_memory_resource &) = delete;
   counting_memory_resource(counting_memory_resource &&) = delete;
   counting_memory_resource &operator=(counting_memory_resource &&) = delete;
+  ~counting_memory_resource() override = default;
 
 private:
   void *do_allocate(std::size_t bytes, std::size_t alignment) override {
@@ -1080,7 +1081,9 @@ private:
     upstream->deallocate(p, bytes, alignment);
   }
 
-  bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
+  [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
+    return this == &other;
+  }
 };
 
 const ut::suite test_chunked_byte_range = [] {

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1130,12 +1130,6 @@ const ut::suite test_chunked_byte_range = [] {
     std::vector<char> encoded;
     ut::expect(hpp_proto::write_binpb(value, encoded).ok());
 
-    std::vector<std::vector<char>> segments;
-    segments.reserve(encoded.size());
-    for (char ch : encoded) {
-      segments.emplace_back(1, ch);
-    }
-
     counting_memory_resource cache_resource;
     verify_chunked_input(encoded, value, std::vector<int>(encoded.size(), 1),
                          hpp_proto::cache_alloc_from(cache_resource));

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1037,10 +1037,50 @@ void verify_chunked_input(auto &encoded, const T &value, const std::vector<int> 
   ut::expect(value == decoded);
 };
 
+template <typename T, typename... Options>
+void verify_chunked_input(auto &encoded, const T &value, const std::vector<int> &sizes, Options &&...options) {
+  std::vector<std::vector<char>> segments;
+  segments.resize(sizes.size());
+  std::size_t len = 0;
+  for (unsigned i = 0; i < sizes.size(); ++i) {
+    auto begin = std::next(encoded.begin(), static_cast<std::ptrdiff_t>(len));
+    auto end = std::next(begin, static_cast<std::ptrdiff_t>(sizes[i]));
+    segments[i] = std::vector<char>{begin, end};
+    len += sizes[i];
+  }
+  T decoded;
+  ut::expect(hpp_proto::read_binpb(decoded, segments, std::forward<Options>(options)...).ok());
+  ut::expect(value == decoded);
+};
+
 auto split(auto data, int pos) {
   auto midpoint = std::next(data.begin(), pos);
   return std::array<std::vector<char>, 2>{std::vector<char>{data.begin(), midpoint},
                                           std::vector<char>{midpoint, data.end()}};
+};
+
+struct counting_memory_resource : std::pmr::memory_resource {
+  std::size_t alloc_calls = 0;
+  std::size_t dealloc_calls = 0;
+  std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
+  counting_memory_resource() = default;
+  counting_memory_resource(const counting_memory_resource &) = delete;
+  counting_memory_resource &operator=(const counting_memory_resource &) = delete;
+  counting_memory_resource(counting_memory_resource &&) = delete;
+  counting_memory_resource &operator=(counting_memory_resource &&) = delete;
+
+private:
+  void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+    ++alloc_calls;
+    return upstream->allocate(bytes, alignment);
+  }
+
+  void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
+    ++dealloc_calls;
+    upstream->deallocate(p, bytes, alignment);
+  }
+
+  bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
 };
 
 const ut::suite test_chunked_byte_range = [] {
@@ -1081,29 +1121,7 @@ const ut::suite test_chunked_byte_range = [] {
     verify_chunked_input(encoded, value, {90, 10, 70});
   };
 
-  "chunked_input_uses_supplied_memory_resource_for_temp_buffers"_test = [] {
-    struct counting_memory_resource_for_chunked_read : std::pmr::memory_resource {
-      std::size_t alloc_calls = 0;
-      std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
-      counting_memory_resource_for_chunked_read() = default;
-      counting_memory_resource_for_chunked_read(const counting_memory_resource_for_chunked_read &) = delete;
-      counting_memory_resource_for_chunked_read &operator=(const counting_memory_resource_for_chunked_read &) = delete;
-      counting_memory_resource_for_chunked_read(counting_memory_resource_for_chunked_read &&) = delete;
-      counting_memory_resource_for_chunked_read &operator=(counting_memory_resource_for_chunked_read &&) = delete;
-
-    private:
-      void *do_allocate(std::size_t bytes, std::size_t alignment) override {
-        ++alloc_calls;
-        return upstream->allocate(bytes, alignment);
-      }
-
-      void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
-        upstream->deallocate(p, bytes, alignment);
-      }
-
-      bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
-    };
-
+  "chunked_input_uses_cache_alloc_from_for_temp_buffers"_test = [] {
     bytes_example<hpp_proto::default_traits> value;
     value.field.resize(128);
     for (int i = 0; i < 128; ++i) {
@@ -1118,11 +1136,27 @@ const ut::suite test_chunked_byte_range = [] {
       segments.emplace_back(1, ch);
     }
 
-    counting_memory_resource_for_chunked_read resource;
-    bytes_example<hpp_proto::default_traits> decoded;
-    ut::expect(hpp_proto::read_binpb(decoded, segments, hpp_proto::alloc_from(resource)).ok());
-    ut::expect(decoded == value);
-    ut::expect(resource.alloc_calls > 0U);
+    counting_memory_resource cache_resource;
+    verify_chunked_input(encoded, value, std::vector<int>(encoded.size(), 1),
+                         hpp_proto::cache_alloc_from(cache_resource));
+    ut::expect(cache_resource.alloc_calls > 0U);
+  };
+
+  "chunked_input_cache_alloc_from_takes_precedence_over_alloc_from"_test = [] {
+    bytes_example<hpp_proto::default_traits> value;
+    value.field.resize(128);
+    for (int i = 0; i < 128; ++i) {
+      value.field[i] = std::byte(i);
+    }
+    std::vector<char> encoded;
+    ut::expect(hpp_proto::write_binpb(value, encoded).ok());
+
+    counting_memory_resource cache_resource;
+    counting_memory_resource object_resource;
+    verify_chunked_input(encoded, value, std::vector<int>(encoded.size(), 1), hpp_proto::cache_alloc_from(cache_resource),
+                         hpp_proto::alloc_from(object_resource));
+    ut::expect(cache_resource.alloc_calls > 0U);
+    ut::expect(object_resource.alloc_calls == 0U);
   };
 
   "invalid_packed_int32_with_chunked_input"_test = [] {
@@ -1942,30 +1976,6 @@ struct test_out_sink {
   }
 };
 
-struct counting_memory_resource : std::pmr::memory_resource {
-  std::size_t alloc_calls = 0;
-  std::size_t dealloc_calls = 0;
-  std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
-  counting_memory_resource() = default;
-  counting_memory_resource(const counting_memory_resource &) = delete;
-  counting_memory_resource &operator=(const counting_memory_resource &) = delete;
-  counting_memory_resource(counting_memory_resource &&) = delete;
-  counting_memory_resource &operator=(counting_memory_resource &&) = delete;
-
-private:
-  void *do_allocate(std::size_t bytes, std::size_t alignment) override {
-    ++alloc_calls;
-    return upstream->allocate(bytes, alignment);
-  }
-
-  void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
-    ++dealloc_calls;
-    upstream->deallocate(p, bytes, alignment);
-  }
-
-  bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
-};
-
 const ut::suite out_sink_serialization_modes = [] {
   "write_binpb_out_sink_adaptive_mode"_test = [] {
     monster m = make_test_monster();
@@ -2002,14 +2012,27 @@ const ut::suite out_sink_serialization_modes = [] {
     ut::expect(decoded == m);
   };
 
-  "write_binpb_out_sink_uses_supplied_memory_resource_for_cache"_test = [] {
+  "write_binpb_out_sink_uses_cache_alloc_from_for_cache"_test = [] {
     monster m = make_test_monster();
     test_out_sink sink(7);
-    counting_memory_resource resource;
-    auto status =
-        hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::max_size_cache_on_stack<0>, hpp_proto::alloc_from(resource));
+    counting_memory_resource cache_resource;
+    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::max_size_cache_on_stack<0>,
+                                         hpp_proto::cache_alloc_from(cache_resource));
     ut::expect(status.ok());
-    ut::expect(resource.alloc_calls > 0U);
+    ut::expect(cache_resource.alloc_calls > 0U);
+  };
+
+  "write_binpb_out_sink_cache_alloc_from_takes_precedence_over_alloc_from"_test = [] {
+    monster m = make_test_monster();
+    test_out_sink sink(7);
+    counting_memory_resource cache_resource;
+    counting_memory_resource object_resource;
+    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::max_size_cache_on_stack<0>,
+                                         hpp_proto::cache_alloc_from(cache_resource),
+                                         hpp_proto::alloc_from(object_resource));
+    ut::expect(status.ok());
+    ut::expect(cache_resource.alloc_calls > 0U);
+    ut::expect(object_resource.alloc_calls == 0U);
   };
 };
 

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1081,6 +1081,50 @@ const ut::suite test_chunked_byte_range = [] {
     verify_chunked_input(encoded, value, {90, 10, 70});
   };
 
+  "chunked_input_uses_supplied_memory_resource_for_temp_buffers"_test = [] {
+    struct counting_memory_resource_for_chunked_read : std::pmr::memory_resource {
+      std::size_t alloc_calls = 0;
+      std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
+      counting_memory_resource_for_chunked_read() = default;
+      counting_memory_resource_for_chunked_read(const counting_memory_resource_for_chunked_read &) = delete;
+      counting_memory_resource_for_chunked_read &operator=(const counting_memory_resource_for_chunked_read &) = delete;
+      counting_memory_resource_for_chunked_read(counting_memory_resource_for_chunked_read &&) = delete;
+      counting_memory_resource_for_chunked_read &operator=(counting_memory_resource_for_chunked_read &&) = delete;
+
+    private:
+      void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+        ++alloc_calls;
+        return upstream->allocate(bytes, alignment);
+      }
+
+      void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
+        upstream->deallocate(p, bytes, alignment);
+      }
+
+      bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
+    };
+
+    bytes_example<hpp_proto::default_traits> value;
+    value.field.resize(128);
+    for (int i = 0; i < 128; ++i) {
+      value.field[i] = std::byte(i);
+    }
+    std::vector<char> encoded;
+    ut::expect(hpp_proto::write_binpb(value, encoded).ok());
+
+    std::vector<std::vector<char>> segments;
+    segments.reserve(encoded.size());
+    for (char ch : encoded) {
+      segments.emplace_back(1, ch);
+    }
+
+    counting_memory_resource_for_chunked_read resource;
+    bytes_example<hpp_proto::default_traits> decoded;
+    ut::expect(hpp_proto::read_binpb(decoded, segments, hpp_proto::alloc_from(resource)).ok());
+    ut::expect(decoded == value);
+    ut::expect(resource.alloc_calls > 0U);
+  };
+
   "invalid_packed_int32_with_chunked_input"_test = [] {
     repeated_int32 value;
 
@@ -1898,6 +1942,30 @@ struct test_out_sink {
   }
 };
 
+struct counting_memory_resource : std::pmr::memory_resource {
+  std::size_t alloc_calls = 0;
+  std::size_t dealloc_calls = 0;
+  std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
+  counting_memory_resource() = default;
+  counting_memory_resource(const counting_memory_resource &) = delete;
+  counting_memory_resource &operator=(const counting_memory_resource &) = delete;
+  counting_memory_resource(counting_memory_resource &&) = delete;
+  counting_memory_resource &operator=(counting_memory_resource &&) = delete;
+
+private:
+  void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+    ++alloc_calls;
+    return upstream->allocate(bytes, alignment);
+  }
+
+  void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
+    ++dealloc_calls;
+    upstream->deallocate(p, bytes, alignment);
+  }
+
+  bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
+};
+
 const ut::suite out_sink_serialization_modes = [] {
   "write_binpb_out_sink_adaptive_mode"_test = [] {
     monster m = make_test_monster();
@@ -1932,6 +2000,16 @@ const ut::suite out_sink_serialization_modes = [] {
     monster decoded{};
     ut::expect(hpp_proto::read_binpb(decoded, sink.written()).ok());
     ut::expect(decoded == m);
+  };
+
+  "write_binpb_out_sink_uses_supplied_memory_resource_for_cache"_test = [] {
+    monster m = make_test_monster();
+    test_out_sink sink(7);
+    counting_memory_resource resource;
+    auto status =
+        hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::max_size_cache_on_stack<0>, hpp_proto::alloc_from(resource));
+    ut::expect(status.ok());
+    ut::expect(resource.alloc_calls > 0U);
   };
 };
 

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1147,8 +1147,8 @@ const ut::suite test_chunked_byte_range = [] {
 
     counting_memory_resource cache_resource;
     counting_memory_resource object_resource;
-    verify_chunked_input(encoded, value, std::vector<int>(encoded.size(), 1), hpp_proto::cache_alloc_from(cache_resource),
-                         hpp_proto::alloc_from(object_resource));
+    verify_chunked_input(encoded, value, std::vector<int>(encoded.size(), 1),
+                         hpp_proto::cache_alloc_from(cache_resource), hpp_proto::alloc_from(object_resource));
     ut::expect(cache_resource.alloc_calls > 0U);
     ut::expect(object_resource.alloc_calls == 0U);
   };
@@ -2020,8 +2020,7 @@ const ut::suite out_sink_serialization_modes = [] {
     test_out_sink sink(7);
     counting_memory_resource cache_resource;
     counting_memory_resource object_resource;
-    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode,
-                                         hpp_proto::cache_alloc_from(cache_resource),
+    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::cache_alloc_from(cache_resource),
                                          hpp_proto::alloc_from(object_resource));
     ut::expect(status.ok());
     ut::expect(cache_resource.alloc_calls > 0U);

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -2010,8 +2010,7 @@ const ut::suite out_sink_serialization_modes = [] {
     monster m = make_test_monster();
     test_out_sink sink(7);
     counting_memory_resource cache_resource;
-    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::max_size_cache_on_stack<0>,
-                                         hpp_proto::cache_alloc_from(cache_resource));
+    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::cache_alloc_from(cache_resource));
     ut::expect(status.ok());
     ut::expect(cache_resource.alloc_calls > 0U);
   };
@@ -2021,7 +2020,7 @@ const ut::suite out_sink_serialization_modes = [] {
     test_out_sink sink(7);
     counting_memory_resource cache_resource;
     counting_memory_resource object_resource;
-    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode, hpp_proto::max_size_cache_on_stack<0>,
+    auto status = hpp_proto::write_binpb(m, sink, hpp_proto::chunked_mode,
                                          hpp_proto::cache_alloc_from(cache_resource),
                                          hpp_proto::alloc_from(object_resource));
     ut::expect(status.ok());


### PR DESCRIPTION
## Summary
This PR adds explicit cache-memory control for binpb internals and simplifies cache configuration.

## Changes
- Added dedicated cache allocator option in `include/hpp_proto/memory_resource_utils.hpp`:
  - `cache_alloc_from(std::pmr::memory_resource&)`
  - `default_cache_memory_resource` (1024-byte stack-backed monotonic resource)
  - compile-time detection of cache allocator presence (`has_cache_memory_resource`)
- Updated binpb cache/temp allocation paths to use:
  1. user-supplied `cache_alloc_from(...)` when present
  2. internal default cache resource otherwise
  - `include/hpp_proto/binpb/serialize.hpp`
  - `include/hpp_proto/binpb/deserialize.hpp`
- Removed `max_size_cache_on_stack` option and related implementation.
- Updated API comments/docs:
  - `include/hpp_proto/binpb.hpp`
  - `docs/frontend_apis.md`
  - `docs/Code_Generation_Guide.md`
  - `README.md`
- Added tests for cache allocator routing and precedence in `unittests/pb_serializer_tests.cpp`.

## Notes
- `alloc_from(...)` and binpb cache/temp allocation remain intentionally separate.
- This PR keeps that separation and adds explicit user control for cache/temp storage.

## Breaking change
- Removed public option: `max_size_cache_on_stack`.
