### PR TITLE
Implement `always_print_fields_with_no_presence` for dynamic_message JSON serialization

### DIFF
--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -48,8 +48,7 @@ template <>
 struct to<JSON, hpp_proto::field_cref> {
   template <auto Opts>
   GLZ_ALWAYS_INLINE static void op(hpp_proto::field_cref value, is_context auto &ctx, auto &b, auto &ix) {
-    if (value.has_value() ||
-        (always_print_fields_with_no_presence_enabled<Opts>() && !value.explicit_presence())) {
+    if (value.has_value() || (always_print_fields_with_no_presence_enabled<Opts>() && !value.explicit_presence())) {
       value.visit([&](auto v) {
         using T = std::remove_cvref_t<decltype(v)>;
         to<JSON, T>::template op<Opts>(v, ctx, b, ix);

--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -35,11 +35,21 @@ concept map_key_mref = std::same_as<T, ::hpp_proto::string_field_mref> ||
 
 } // namespace concepts
 
+template <auto Opts>
+consteval bool always_print_fields_with_no_presence_enabled() {
+  if constexpr (requires { Opts.always_print_fields_with_no_presence; }) {
+    return Opts.always_print_fields_with_no_presence;
+  } else {
+    return false;
+  }
+}
+
 template <>
 struct to<JSON, hpp_proto::field_cref> {
   template <auto Opts>
   GLZ_ALWAYS_INLINE static void op(hpp_proto::field_cref value, is_context auto &ctx, auto &b, auto &ix) {
-    if (value.has_value()) {
+    if (value.has_value() ||
+        (always_print_fields_with_no_presence_enabled<Opts>() && !value.explicit_presence())) {
       value.visit([&](auto v) {
         using T = std::remove_cvref_t<decltype(v)>;
         to<JSON, T>::template op<Opts>(v, ctx, b, ix);
@@ -62,6 +72,17 @@ struct from<JSON, hpp_proto::field_mref> {
 };
 
 struct generic_message_json_serializer {
+  template <auto Opts>
+  static bool should_serialize_field(hpp_proto::field_cref field) {
+    if (field.has_value()) {
+      return true;
+    }
+    if constexpr (!always_print_fields_with_no_presence_enabled<Opts>()) {
+      return false;
+    }
+    return !field.explicit_presence();
+  }
+
   template <auto Opts>
   static void serialize_regular_field(hpp_proto::field_cref field, is_context auto &ctx, auto &b, auto &ix) {
     constexpr auto field_opts = glz::opening_handled_off<Opts>();
@@ -120,7 +141,7 @@ struct generic_message_json_serializer {
     const char *separator = nullptr;
 
     for (auto field : value.fields()) {
-      if (!field.has_value()) {
+      if (!should_serialize_field<Opts>(field)) {
         continue;
       }
 
@@ -539,7 +560,8 @@ template <typename T, hpp_proto::field_kind_t Kind>
 struct to<JSON, hpp_proto::scalar_field_cref<T, Kind>> {
   template <auto Opts>
   GLZ_ALWAYS_INLINE static void op(const hpp_proto::scalar_field_cref<T, Kind> &value, auto &&...args) {
-    if (value.has_value()) {
+    if (value.has_value() ||
+        (always_print_fields_with_no_presence_enabled<Opts>() && !value.descriptor().explicit_presence())) {
       using value_type = hpp_proto::scalar_field_cref<T, Kind>::value_type;
       constexpr bool need_quote = ::hpp_proto::concepts::integral_64_bits<value_type> || check_quoted_num(Opts);
       to<JSON, value_type>::template op<set_opt<Opts, quoted_num_opt_tag{}>(need_quote)>(
@@ -552,7 +574,8 @@ template <typename T, hpp_proto::field_kind_t Kind>
 struct to<JSON, hpp_proto::repeated_scalar_field_cref<T, Kind>> {
   template <auto Opts>
   GLZ_ALWAYS_INLINE static void op(const hpp_proto::repeated_scalar_field_cref<T, Kind> &value, auto &&...args) {
-    if (!value.empty()) {
+    if (!value.empty() ||
+        (always_print_fields_with_no_presence_enabled<Opts>() && !value.descriptor().explicit_presence())) {
       auto range = std::span{value.data(), value.size()};
       using value_type = hpp_proto::repeated_scalar_field_cref<T, Kind>::value_type;
       constexpr bool need_quote = ::hpp_proto::concepts::integral_64_bits<value_type>;

--- a/tests/dynamic_message_test.cpp
+++ b/tests/dynamic_message_test.cpp
@@ -1001,6 +1001,26 @@ const boost::ut::suite dynamic_message_test = [] {
       expect(10 == msg2.field_value_by_name<hpp_proto::enum_number>("optional_nested_enum"));
     };
 
+    "always_print_fields_with_no_presence for dynamic json"_test = [&factory] {
+      constexpr auto opts = ::hpp_proto::json_write_opts{.always_print_fields_with_no_presence = true};
+      std::pmr::monotonic_buffer_resource mr;
+      auto msg = expect_ok(factory.get_message("proto3_unittest.TestAllTypes", mr));
+
+      std::string json_buf;
+      expect(::hpp_proto::write_json<opts>(msg, json_buf).ok());
+      expect(json_buf.find(R"("optionalInt32":0)") != std::string::npos);
+      expect(json_buf.find(R"("repeatedInt32":[])") != std::string::npos);
+      expect(json_buf.find(R"("optionalNestedMessage")") == std::string::npos);
+
+      std::string json_from_binpb;
+      expect(::hpp_proto::binpb_to_json<opts>(factory, "proto3_unittest.TestAllTypes", std::string_view{},
+                                              json_from_binpb)
+                 .ok());
+      expect(json_from_binpb.find(R"("optionalInt32":0)") != std::string::npos);
+      expect(json_from_binpb.find(R"("repeatedInt32":[])") != std::string::npos);
+      expect(json_from_binpb.find(R"("optionalNestedMessage")") == std::string::npos);
+    };
+
     "repeated enum set and adopt"_test = [&factory] {
       std::pmr::monotonic_buffer_resource memory_resource;
       auto msg = expect_ok(factory.get_message("protobuf_unittest.TestAllTypes", memory_resource));

--- a/tests/dynamic_message_test.cpp
+++ b/tests/dynamic_message_test.cpp
@@ -1013,9 +1013,9 @@ const boost::ut::suite dynamic_message_test = [] {
       expect(json_buf.find(R"("optionalNestedMessage")") == std::string::npos);
 
       std::string json_from_binpb;
-      expect(::hpp_proto::binpb_to_json<opts>(factory, "proto3_unittest.TestAllTypes", std::string_view{},
-                                              json_from_binpb)
-                 .ok());
+      expect(
+          ::hpp_proto::binpb_to_json<opts>(factory, "proto3_unittest.TestAllTypes", std::string_view{}, json_from_binpb)
+              .ok());
       expect(json_from_binpb.find(R"("optionalInt32":0)") != std::string::npos);
       expect(json_from_binpb.find(R"("repeatedInt32":[])") != std::string::npos);
       expect(json_from_binpb.find(R"("optionalNestedMessage")") == std::string::npos);


### PR DESCRIPTION
## Summary
This PR adds support for `json_write_opts::always_print_fields_with_no_presence` in the dynamic message JSON serializer path (`hpp_proto::dynamic_message`), including `binpb_to_json`.

Previously, dynamic serialization skipped unset fields unconditionally, so this option had no effect for dynamic messages.

## What Changed
- Added option-detection helper in dynamic JSON serializer:
  - Supports both `hpp_proto::json_write_opts` and plain `glz::opts` instantiations.
- Updated dynamic field serialization logic to include unset fields that do **not** have explicit presence when the option is enabled.
- Updated scalar and repeated-scalar dynamic serializers to emit default/empty values under the option.
- Added regression test to verify behavior for:
  - `write_json<json_write_opts{.always_print_fields_with_no_presence = true}>`
  - `binpb_to_json<json_write_opts{.always_print_fields_with_no_presence = true}>`

## Behavior
With `always_print_fields_with_no_presence = true` on dynamic messages:
- Proto3 implicit-presence fields are emitted even when unset (for example, scalar defaults and empty repeated fields).
- Explicit-presence unset fields (for example, optional/message fields with presence) remain omitted.
- Existing behavior for normal/default options is unchanged.

## Validation
- Built target: `dynamic_message_test` with clang-tidy-enabled build.
- Ran: `ctest -R dynamic_message_test --output-on-failure`
- Result: all tests passed.