### PR TITLE
Add JSON alias support (`json_name` + proto name), preserve-proto-field-name generation option, and dynamic schema conflict validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,12 @@ endif()
 
 if(NOT MSVC)
   set(HPP_PROTO_COMPILE_OPTIONS "-Wall" "-Wextra" "-Werror=sign-conversion")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Alias-enabled JSON metadata can substantially increase constexpr work in Glaze
+    # for very large generated messages (e.g., TestAllTypes). Raise GCC's default
+    # constexpr operation budget to avoid spurious compile failures in CI.
+    list(APPEND HPP_PROTO_COMPILE_OPTIONS "-fconstexpr-ops-limit=67108864")
+  endif()
 else()
   # Ensure exception unwind semantics are enabled for MSVC builds.
   # This is required for tests that use boost::ut `throws(...)` and avoids C4530.

--- a/docs/Code_Generation_Guide.md
+++ b/docs/Code_Generation_Guide.md
@@ -23,6 +23,7 @@ protobuf_generate_hpp(
 - <a id="plugin-options">PLUGIN_OPTIONS</a>: A comma-separated string forwarded to the protoc-gen-hpp plugin to customize code generation. Options include:
   - `namespace_prefix=`: Specifies a namespace prefix to be added to the generated C++ code in addition to the package namespace. If the specified prefix contains multiple components, they should be separated by a __dot (.)__ instead of double colons (::).
   - `directory_prefix=`:  Prepends a directory to included non-system dependencies.
+  - `preserve_proto_field_names=`: If set to `true`, the original field names from the `.proto` file (typically `snake_case`) are used as the primary keys for JSON serialization. If `false` (default), the `json_name` (typically `camelCase`) is used. Regardless of this setting, the generated JSON parser always accepts both naming conventions.
   - `proto2_explicit_presence=`: For Proto2 only, makes optional scalar fields implicitly present except for specified scopes. This option can be specified multiple times. For example: the option `proto2_explicit_presence=.pkg1.msg1.field1,proto2_explicit_presence=.pkg1.msg2` instructs the code generator that explicit presence is only applicable for the `field1` of `pkg1.msg1` and all fields of `pkg1.msg2`.
 
 ## Traits at a Glance

--- a/docs/frontend_apis.md
+++ b/docs/frontend_apis.md
@@ -96,6 +96,7 @@ Supported options in `json_write_opts`:
 
 - `prettify` (default: `false`): Enables multi-line, indented JSON output.
 - `always_print_fields_with_no_presence` (default: `false`): If `true`, non-presence fields (primitives, repeated, maps) are always included in the output even if they are set to their default values (e.g., `0`, `""`, `false`, `[]`). Presence-tracking fields (like sub-messages or explicit `optional` fields) are still omitted if not set.
+- `preserve_proto_field_names` (default: `false`): If `true`, the original field names from the `.proto` file (typically `snake_case`) are used as the primary keys for JSON serialization. **Note: This option only applies to dynamic messages.** For generated messages, use the corresponding plugin option. Regardless of this setting, `read_json` always accepts both naming conventions.
 - `escape_control_characters` (default: `true`): Escapes control characters in strings.
 
 ### Read JSON

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -91,6 +91,11 @@ endforeach()
 
 add_library(fuzz_common common.cpp json_extern.cpp binpb_extern.cpp)
 target_link_libraries(fuzz_common PUBLIC glaze::glaze hpp_proto::hpp_proto hpp_proto::dynamic_message unittest_proto_lib)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # Alias metadata roughly doubles JSON key entries for very large protos (for example TestAllTypes),
+  # which can exceed Clang's default expression nesting depth in Glaze reflection.
+  target_compile_options(fuzz_common PRIVATE -fbracket-depth=512)
+endif()
 
 function(add_fuzz_target type source)
   set(target fuzz_${type})

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -93,8 +93,8 @@ add_library(fuzz_common common.cpp json_extern.cpp binpb_extern.cpp)
 target_link_libraries(fuzz_common PUBLIC glaze::glaze hpp_proto::hpp_proto hpp_proto::dynamic_message unittest_proto_lib)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Alias metadata roughly doubles JSON key entries for very large protos (for example TestAllTypes),
-  # which can exceed Clang's default expression nesting depth in Glaze reflection.
-  target_compile_options(fuzz_common PRIVATE -fbracket-depth=512)
+  # which can exceed Clang's default expression nesting depth/constexpr budget in Glaze reflection.
+  target_compile_options(fuzz_common PRIVATE -fbracket-depth=512 -fconstexpr-steps=67108864)
 endif()
 
 function(add_fuzz_target type source)

--- a/include/google/protobuf/compiler/plugin.glz.hpp
+++ b/include/google/protobuf/compiler/plugin.glz.hpp
@@ -29,10 +29,14 @@ struct glz::meta<google::protobuf::compiler::CodeGeneratorRequest<Traits>> {
   using T = google::protobuf::compiler::CodeGeneratorRequest<Traits>;
   static constexpr auto value = object(
     "fileToGenerate", ::hpp_proto::as_optional_ref<&T::file_to_generate>,
+    "file_to_generate", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::file_to_generate>>,
     "parameter", ::hpp_proto::as_optional_ref<&T::parameter>,
     "protoFile", ::hpp_proto::as_optional_ref<&T::proto_file>,
+    "proto_file", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::proto_file>>,
     "sourceFileDescriptors", ::hpp_proto::as_optional_ref<&T::source_file_descriptors>,
-    "compilerVersion", &T::compiler_version);
+    "source_file_descriptors", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::source_file_descriptors>>,
+    "compilerVersion", &T::compiler_version,
+    "compiler_version", ::hpp_proto::as_alias<&T::compiler_version>);
 };
 
 template <typename Traits>
@@ -43,8 +47,11 @@ struct glz::meta<google::protobuf::compiler::CodeGeneratorResponse<Traits>> {
   static constexpr auto value = object(
     "error", ::hpp_proto::as_optional_ref<&T::error>,
     "supportedFeatures", ::hpp_proto::as_optional_ref<&T::supported_features>,
+    "supported_features", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::supported_features>>,
     "minimumEdition", ::hpp_proto::as_optional_ref<&T::minimum_edition>,
+    "minimum_edition", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::minimum_edition>>,
     "maximumEdition", ::hpp_proto::as_optional_ref<&T::maximum_edition>,
+    "maximum_edition", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::maximum_edition>>,
     "file", ::hpp_proto::as_optional_ref<&T::file>);
 };
 
@@ -54,8 +61,10 @@ struct glz::meta<google::protobuf::compiler::CodeGeneratorResponse_::File<Traits
   static constexpr auto value = object(
     "name", ::hpp_proto::as_optional_ref<&T::name>,
     "insertionPoint", ::hpp_proto::as_optional_ref<&T::insertion_point>,
+    "insertion_point", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::insertion_point>>,
     "content", ::hpp_proto::as_optional_ref<&T::content>,
-    "generatedCodeInfo", &T::generated_code_info);
+    "generatedCodeInfo", &T::generated_code_info,
+    "generated_code_info", ::hpp_proto::as_alias<&T::generated_code_info>);
 };
 
 template <typename Traits>

--- a/include/google/protobuf/descriptor.glz.hpp
+++ b/include/google/protobuf/descriptor.glz.hpp
@@ -28,14 +28,20 @@ struct glz::meta<google::protobuf::FileDescriptorProto<Traits>> {
     "package", ::hpp_proto::as_optional_ref<&T::package>,
     "dependency", ::hpp_proto::as_optional_ref<&T::dependency>,
     "publicDependency", ::hpp_proto::as_optional_ref<&T::public_dependency>,
+    "public_dependency", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::public_dependency>>,
     "weakDependency", ::hpp_proto::as_optional_ref<&T::weak_dependency>,
+    "weak_dependency", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::weak_dependency>>,
     "optionDependency", ::hpp_proto::as_optional_ref<&T::option_dependency>,
+    "option_dependency", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::option_dependency>>,
     "messageType", ::hpp_proto::as_optional_ref<&T::message_type>,
+    "message_type", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::message_type>>,
     "enumType", ::hpp_proto::as_optional_ref<&T::enum_type>,
+    "enum_type", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::enum_type>>,
     "service", ::hpp_proto::as_optional_ref<&T::service>,
     "extension", ::hpp_proto::as_optional_ref<&T::extension>,
     "options", &T::options,
     "sourceCodeInfo", &T::source_code_info,
+    "source_code_info", ::hpp_proto::as_alias<&T::source_code_info>,
     "syntax", ::hpp_proto::as_optional_ref<&T::syntax>,
     "edition", ::hpp_proto::as_optional_ref<&T::edition, google::protobuf::Edition::EDITION_UNKNOWN>);
 };
@@ -50,12 +56,18 @@ struct glz::meta<google::protobuf::DescriptorProto<Traits>> {
     "field", ::hpp_proto::as_optional_ref<&T::field>,
     "extension", ::hpp_proto::as_optional_ref<&T::extension>,
     "nestedType", ::hpp_proto::as_optional_ref<&T::nested_type>,
+    "nested_type", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::nested_type>>,
     "enumType", ::hpp_proto::as_optional_ref<&T::enum_type>,
+    "enum_type", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::enum_type>>,
     "extensionRange", ::hpp_proto::as_optional_ref<&T::extension_range>,
+    "extension_range", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::extension_range>>,
     "oneofDecl", ::hpp_proto::as_optional_ref<&T::oneof_decl>,
+    "oneof_decl", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::oneof_decl>>,
     "options", &T::options,
     "reservedRange", ::hpp_proto::as_optional_ref<&T::reserved_range>,
+    "reserved_range", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::reserved_range>>,
     "reservedName", ::hpp_proto::as_optional_ref<&T::reserved_name>,
+    "reserved_name", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::reserved_name>>,
     "visibility", ::hpp_proto::as_optional_ref<&T::visibility, google::protobuf::SymbolVisibility::VISIBILITY_UNSET>);
 };
 
@@ -87,6 +99,7 @@ struct glz::meta<google::protobuf::ExtensionRangeOptions<Traits>> {
   using T = google::protobuf::ExtensionRangeOptions<Traits>;
   static constexpr auto value = object(
     "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>,
     "declaration", ::hpp_proto::as_optional_ref<&T::declaration>,
     "features", &T::features,
     "verification", ::hpp_proto::as_optional_ref<&T::verification, google::protobuf::ExtensionRangeOptions_::VerificationState::UNVERIFIED>);
@@ -98,6 +111,7 @@ struct glz::meta<google::protobuf::ExtensionRangeOptions_::Declaration<Traits>> 
   static constexpr auto value = object(
     "number", ::hpp_proto::as_optional_ref<&T::number>,
     "fullName", ::hpp_proto::as_optional_ref<&T::full_name>,
+    "full_name", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::full_name>>,
     "type", ::hpp_proto::as_optional_ref<&T::type>,
     "reserved", ::hpp_proto::as_optional_ref<&T::reserved>,
     "repeated", ::hpp_proto::as_optional_ref<&T::repeated>);
@@ -124,12 +138,17 @@ struct glz::meta<google::protobuf::FieldDescriptorProto<Traits>> {
     "label", ::hpp_proto::as_optional_ref<&T::label, google::protobuf::FieldDescriptorProto_::Label::LABEL_OPTIONAL>,
     "type", ::hpp_proto::as_optional_ref<&T::type, google::protobuf::FieldDescriptorProto_::Type::TYPE_DOUBLE>,
     "typeName", ::hpp_proto::as_optional_ref<&T::type_name>,
+    "type_name", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::type_name>>,
     "extendee", ::hpp_proto::as_optional_ref<&T::extendee>,
     "defaultValue", ::hpp_proto::as_optional_ref<&T::default_value>,
+    "default_value", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::default_value>>,
     "oneofIndex", &T::oneof_index,
+    "oneof_index", ::hpp_proto::as_alias<&T::oneof_index>,
     "jsonName", ::hpp_proto::as_optional_ref<&T::json_name>,
+    "json_name", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::json_name>>,
     "options", &T::options,
-    "proto3Optional", ::hpp_proto::as_optional_ref<&T::proto3_optional>);
+    "proto3Optional", ::hpp_proto::as_optional_ref<&T::proto3_optional>,
+    "proto3_optional", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::proto3_optional>>);
 };
 
 template <>
@@ -185,7 +204,9 @@ struct glz::meta<google::protobuf::EnumDescriptorProto<Traits>> {
     "value", ::hpp_proto::as_optional_ref<&T::value>,
     "options", &T::options,
     "reservedRange", ::hpp_proto::as_optional_ref<&T::reserved_range>,
+    "reserved_range", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::reserved_range>>,
     "reservedName", ::hpp_proto::as_optional_ref<&T::reserved_name>,
+    "reserved_name", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::reserved_name>>,
     "visibility", ::hpp_proto::as_optional_ref<&T::visibility, google::protobuf::SymbolVisibility::VISIBILITY_UNSET>);
 };
 
@@ -229,10 +250,14 @@ struct glz::meta<google::protobuf::MethodDescriptorProto<Traits>> {
   static constexpr auto value = object(
     "name", ::hpp_proto::as_optional_ref<&T::name>,
     "inputType", ::hpp_proto::as_optional_ref<&T::input_type>,
+    "input_type", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::input_type>>,
     "outputType", ::hpp_proto::as_optional_ref<&T::output_type>,
+    "output_type", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::output_type>>,
     "options", &T::options,
     "clientStreaming", ::hpp_proto::as_optional_ref<&T::client_streaming, false>,
-    "serverStreaming", ::hpp_proto::as_optional_ref<&T::server_streaming, false>);
+    "client_streaming", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::client_streaming, false>>,
+    "serverStreaming", ::hpp_proto::as_optional_ref<&T::server_streaming, false>,
+    "server_streaming", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::server_streaming, false>>);
 };
 
 template <typename Traits>
@@ -242,26 +267,45 @@ struct glz::meta<google::protobuf::FileOptions<Traits>> {
   using T = google::protobuf::FileOptions<Traits>;
   static constexpr auto value = object(
     "javaPackage", ::hpp_proto::as_optional_ref<&T::java_package>,
+    "java_package", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::java_package>>,
     "javaOuterClassname", ::hpp_proto::as_optional_ref<&T::java_outer_classname>,
+    "java_outer_classname", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::java_outer_classname>>,
     "javaMultipleFiles", ::hpp_proto::as_optional_ref<&T::java_multiple_files, false>,
+    "java_multiple_files", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::java_multiple_files, false>>,
     "javaGenerateEqualsAndHash", ::hpp_proto::as_optional_ref<&T::java_generate_equals_and_hash>,
+    "java_generate_equals_and_hash", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::java_generate_equals_and_hash>>,
     "javaStringCheckUtf8", ::hpp_proto::as_optional_ref<&T::java_string_check_utf8, false>,
+    "java_string_check_utf8", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::java_string_check_utf8, false>>,
     "optimizeFor", ::hpp_proto::as_optional_ref<&T::optimize_for, google::protobuf::FileOptions_::OptimizeMode::SPEED>,
+    "optimize_for", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::optimize_for, google::protobuf::FileOptions_::OptimizeMode::SPEED>>,
     "goPackage", ::hpp_proto::as_optional_ref<&T::go_package>,
+    "go_package", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::go_package>>,
     "ccGenericServices", ::hpp_proto::as_optional_ref<&T::cc_generic_services, false>,
+    "cc_generic_services", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::cc_generic_services, false>>,
     "javaGenericServices", ::hpp_proto::as_optional_ref<&T::java_generic_services, false>,
+    "java_generic_services", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::java_generic_services, false>>,
     "pyGenericServices", ::hpp_proto::as_optional_ref<&T::py_generic_services, false>,
+    "py_generic_services", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::py_generic_services, false>>,
     "deprecated", ::hpp_proto::as_optional_ref<&T::deprecated, false>,
     "ccEnableArenas", ::hpp_proto::as_optional_ref<&T::cc_enable_arenas, true>,
+    "cc_enable_arenas", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::cc_enable_arenas, true>>,
     "objcClassPrefix", ::hpp_proto::as_optional_ref<&T::objc_class_prefix>,
+    "objc_class_prefix", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::objc_class_prefix>>,
     "csharpNamespace", ::hpp_proto::as_optional_ref<&T::csharp_namespace>,
+    "csharp_namespace", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::csharp_namespace>>,
     "swiftPrefix", ::hpp_proto::as_optional_ref<&T::swift_prefix>,
+    "swift_prefix", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::swift_prefix>>,
     "phpClassPrefix", ::hpp_proto::as_optional_ref<&T::php_class_prefix>,
+    "php_class_prefix", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::php_class_prefix>>,
     "phpNamespace", ::hpp_proto::as_optional_ref<&T::php_namespace>,
+    "php_namespace", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::php_namespace>>,
     "phpMetadataNamespace", ::hpp_proto::as_optional_ref<&T::php_metadata_namespace>,
+    "php_metadata_namespace", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::php_metadata_namespace>>,
     "rubyPackage", ::hpp_proto::as_optional_ref<&T::ruby_package>,
+    "ruby_package", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::ruby_package>>,
     "features", &T::features,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <>
@@ -280,12 +324,17 @@ struct glz::meta<google::protobuf::MessageOptions<Traits>> {
   using T = google::protobuf::MessageOptions<Traits>;
   static constexpr auto value = object(
     "messageSetWireFormat", ::hpp_proto::as_optional_ref<&T::message_set_wire_format, false>,
+    "message_set_wire_format", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::message_set_wire_format, false>>,
     "noStandardDescriptorAccessor", ::hpp_proto::as_optional_ref<&T::no_standard_descriptor_accessor, false>,
+    "no_standard_descriptor_accessor", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::no_standard_descriptor_accessor, false>>,
     "deprecated", ::hpp_proto::as_optional_ref<&T::deprecated, false>,
     "mapEntry", ::hpp_proto::as_optional_ref<&T::map_entry>,
+    "map_entry", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::map_entry>>,
     "deprecatedLegacyJsonFieldConflicts", ::hpp_proto::as_optional_ref<&T::deprecated_legacy_json_field_conflicts>,
+    "deprecated_legacy_json_field_conflicts", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::deprecated_legacy_json_field_conflicts>>,
     "features", &T::features,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <typename Traits>
@@ -299,15 +348,20 @@ struct glz::meta<google::protobuf::FieldOptions<Traits>> {
     "jstype", ::hpp_proto::as_optional_ref<&T::jstype, google::protobuf::FieldOptions_::JSType::JS_NORMAL>,
     "lazy", ::hpp_proto::as_optional_ref<&T::lazy, false>,
     "unverifiedLazy", ::hpp_proto::as_optional_ref<&T::unverified_lazy, false>,
+    "unverified_lazy", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::unverified_lazy, false>>,
     "deprecated", ::hpp_proto::as_optional_ref<&T::deprecated, false>,
     "weak", ::hpp_proto::as_optional_ref<&T::weak, false>,
     "debugRedact", ::hpp_proto::as_optional_ref<&T::debug_redact, false>,
+    "debug_redact", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::debug_redact, false>>,
     "retention", ::hpp_proto::as_optional_ref<&T::retention, google::protobuf::FieldOptions_::OptionRetention::RETENTION_UNKNOWN>,
     "targets", ::hpp_proto::as_optional_ref<&T::targets>,
     "editionDefaults", ::hpp_proto::as_optional_ref<&T::edition_defaults>,
+    "edition_defaults", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::edition_defaults>>,
     "features", &T::features,
     "featureSupport", &T::feature_support,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "feature_support", ::hpp_proto::as_alias<&T::feature_support>,
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <typename Traits>
@@ -325,9 +379,13 @@ struct glz::meta<google::protobuf::FieldOptions_::FeatureSupport<Traits>> {
   using T = google::protobuf::FieldOptions_::FeatureSupport<Traits>;
   static constexpr auto value = object(
     "editionIntroduced", ::hpp_proto::as_optional_ref<&T::edition_introduced, google::protobuf::Edition::EDITION_UNKNOWN>,
+    "edition_introduced", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::edition_introduced, google::protobuf::Edition::EDITION_UNKNOWN>>,
     "editionDeprecated", ::hpp_proto::as_optional_ref<&T::edition_deprecated, google::protobuf::Edition::EDITION_UNKNOWN>,
+    "edition_deprecated", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::edition_deprecated, google::protobuf::Edition::EDITION_UNKNOWN>>,
     "deprecationWarning", ::hpp_proto::as_optional_ref<&T::deprecation_warning>,
-    "editionRemoved", ::hpp_proto::as_optional_ref<&T::edition_removed, google::protobuf::Edition::EDITION_UNKNOWN>);
+    "deprecation_warning", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::deprecation_warning>>,
+    "editionRemoved", ::hpp_proto::as_optional_ref<&T::edition_removed, google::protobuf::Edition::EDITION_UNKNOWN>,
+    "edition_removed", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::edition_removed, google::protobuf::Edition::EDITION_UNKNOWN>>);
 };
 
 template <typename Traits>
@@ -382,7 +440,8 @@ struct glz::meta<google::protobuf::OneofOptions<Traits>> {
   using T = google::protobuf::OneofOptions<Traits>;
   static constexpr auto value = object(
     "features", &T::features,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <typename Traits>
@@ -392,10 +451,13 @@ struct glz::meta<google::protobuf::EnumOptions<Traits>> {
   using T = google::protobuf::EnumOptions<Traits>;
   static constexpr auto value = object(
     "allowAlias", ::hpp_proto::as_optional_ref<&T::allow_alias>,
+    "allow_alias", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::allow_alias>>,
     "deprecated", ::hpp_proto::as_optional_ref<&T::deprecated, false>,
     "deprecatedLegacyJsonFieldConflicts", ::hpp_proto::as_optional_ref<&T::deprecated_legacy_json_field_conflicts>,
+    "deprecated_legacy_json_field_conflicts", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::deprecated_legacy_json_field_conflicts>>,
     "features", &T::features,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <typename Traits>
@@ -407,8 +469,11 @@ struct glz::meta<google::protobuf::EnumValueOptions<Traits>> {
     "deprecated", ::hpp_proto::as_optional_ref<&T::deprecated, false>,
     "features", &T::features,
     "debugRedact", ::hpp_proto::as_optional_ref<&T::debug_redact, false>,
+    "debug_redact", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::debug_redact, false>>,
     "featureSupport", &T::feature_support,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "feature_support", ::hpp_proto::as_alias<&T::feature_support>,
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <typename Traits>
@@ -419,7 +484,8 @@ struct glz::meta<google::protobuf::ServiceOptions<Traits>> {
   static constexpr auto value = object(
     "features", &T::features,
     "deprecated", ::hpp_proto::as_optional_ref<&T::deprecated, false>,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <typename Traits>
@@ -430,8 +496,10 @@ struct glz::meta<google::protobuf::MethodOptions<Traits>> {
   static constexpr auto value = object(
     "deprecated", ::hpp_proto::as_optional_ref<&T::deprecated, false>,
     "idempotencyLevel", ::hpp_proto::as_optional_ref<&T::idempotency_level, google::protobuf::MethodOptions_::IdempotencyLevel::IDEMPOTENCY_UNKNOWN>,
+    "idempotency_level", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::idempotency_level, google::protobuf::MethodOptions_::IdempotencyLevel::IDEMPOTENCY_UNKNOWN>>,
     "features", &T::features,
-    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>);
+    "uninterpretedOption", ::hpp_proto::as_optional_ref<&T::uninterpreted_option>,
+    "uninterpreted_option", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::uninterpreted_option>>);
 };
 
 template <>
@@ -451,11 +519,17 @@ struct glz::meta<google::protobuf::UninterpretedOption<Traits>> {
   static constexpr auto value = object(
     "name", ::hpp_proto::as_optional_ref<&T::name>,
     "identifierValue", ::hpp_proto::as_optional_ref<&T::identifier_value>,
+    "identifier_value", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::identifier_value>>,
     "positiveIntValue", ::hpp_proto::as_optional_ref<&T::positive_int_value>,
+    "positive_int_value", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::positive_int_value>>,
     "negativeIntValue", ::hpp_proto::as_optional_ref<&T::negative_int_value>,
+    "negative_int_value", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::negative_int_value>>,
     "doubleValue", ::hpp_proto::as_optional_ref<&T::double_value>,
+    "double_value", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::double_value>>,
     "stringValue", ::hpp_proto::as_optional_ref<&T::string_value>,
-    "aggregateValue", ::hpp_proto::as_optional_ref<&T::aggregate_value>);
+    "string_value", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::string_value>>,
+    "aggregateValue", ::hpp_proto::as_optional_ref<&T::aggregate_value>,
+    "aggregate_value", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::aggregate_value>>);
 };
 
 template <typename Traits>
@@ -463,7 +537,9 @@ struct glz::meta<google::protobuf::UninterpretedOption_::NamePart<Traits>> {
   using T = google::protobuf::UninterpretedOption_::NamePart<Traits>;
   static constexpr auto value = object(
     "namePart", &T::name_part,
-    "isExtension", &T::is_extension);
+    "name_part", ::hpp_proto::as_alias<&T::name_part>,
+    "isExtension", &T::is_extension,
+    "is_extension", ::hpp_proto::as_alias<&T::is_extension>);
 };
 
 template <typename Traits>
@@ -475,13 +551,21 @@ struct glz::meta<google::protobuf::FeatureSet<Traits>> {
   using T = google::protobuf::FeatureSet<Traits>;
   static constexpr auto value = object(
     "fieldPresence", ::hpp_proto::as_optional_ref<&T::field_presence, google::protobuf::FeatureSet_::FieldPresence::FIELD_PRESENCE_UNKNOWN>,
+    "field_presence", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::field_presence, google::protobuf::FeatureSet_::FieldPresence::FIELD_PRESENCE_UNKNOWN>>,
     "enumType", ::hpp_proto::as_optional_ref<&T::enum_type, google::protobuf::FeatureSet_::EnumType::ENUM_TYPE_UNKNOWN>,
+    "enum_type", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::enum_type, google::protobuf::FeatureSet_::EnumType::ENUM_TYPE_UNKNOWN>>,
     "repeatedFieldEncoding", ::hpp_proto::as_optional_ref<&T::repeated_field_encoding, google::protobuf::FeatureSet_::RepeatedFieldEncoding::REPEATED_FIELD_ENCODING_UNKNOWN>,
+    "repeated_field_encoding", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::repeated_field_encoding, google::protobuf::FeatureSet_::RepeatedFieldEncoding::REPEATED_FIELD_ENCODING_UNKNOWN>>,
     "utf8Validation", ::hpp_proto::as_optional_ref<&T::utf8_validation, google::protobuf::FeatureSet_::Utf8Validation::UTF8_VALIDATION_UNKNOWN>,
+    "utf8_validation", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::utf8_validation, google::protobuf::FeatureSet_::Utf8Validation::UTF8_VALIDATION_UNKNOWN>>,
     "messageEncoding", ::hpp_proto::as_optional_ref<&T::message_encoding, google::protobuf::FeatureSet_::MessageEncoding::MESSAGE_ENCODING_UNKNOWN>,
+    "message_encoding", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::message_encoding, google::protobuf::FeatureSet_::MessageEncoding::MESSAGE_ENCODING_UNKNOWN>>,
     "jsonFormat", ::hpp_proto::as_optional_ref<&T::json_format, google::protobuf::FeatureSet_::JsonFormat::JSON_FORMAT_UNKNOWN>,
+    "json_format", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::json_format, google::protobuf::FeatureSet_::JsonFormat::JSON_FORMAT_UNKNOWN>>,
     "enforceNamingStyle", ::hpp_proto::as_optional_ref<&T::enforce_naming_style, google::protobuf::FeatureSet_::EnforceNamingStyle::ENFORCE_NAMING_STYLE_UNKNOWN>,
-    "defaultSymbolVisibility", ::hpp_proto::as_optional_ref<&T::default_symbol_visibility, google::protobuf::FeatureSet_::VisibilityFeature_::DefaultSymbolVisibility::DEFAULT_SYMBOL_VISIBILITY_UNKNOWN>);
+    "enforce_naming_style", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::enforce_naming_style, google::protobuf::FeatureSet_::EnforceNamingStyle::ENFORCE_NAMING_STYLE_UNKNOWN>>,
+    "defaultSymbolVisibility", ::hpp_proto::as_optional_ref<&T::default_symbol_visibility, google::protobuf::FeatureSet_::VisibilityFeature_::DefaultSymbolVisibility::DEFAULT_SYMBOL_VISIBILITY_UNKNOWN>,
+    "default_symbol_visibility", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::default_symbol_visibility, google::protobuf::FeatureSet_::VisibilityFeature_::DefaultSymbolVisibility::DEFAULT_SYMBOL_VISIBILITY_UNKNOWN>>);
 };
 
 template <typename Traits>
@@ -576,7 +660,9 @@ struct glz::meta<google::protobuf::FeatureSetDefaults<Traits>> {
   static constexpr auto value = object(
     "defaults", ::hpp_proto::as_optional_ref<&T::defaults>,
     "minimumEdition", ::hpp_proto::as_optional_ref<&T::minimum_edition, google::protobuf::Edition::EDITION_UNKNOWN>,
-    "maximumEdition", ::hpp_proto::as_optional_ref<&T::maximum_edition, google::protobuf::Edition::EDITION_UNKNOWN>);
+    "minimum_edition", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::minimum_edition, google::protobuf::Edition::EDITION_UNKNOWN>>,
+    "maximumEdition", ::hpp_proto::as_optional_ref<&T::maximum_edition, google::protobuf::Edition::EDITION_UNKNOWN>,
+    "maximum_edition", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::maximum_edition, google::protobuf::Edition::EDITION_UNKNOWN>>);
 };
 
 template <typename Traits>
@@ -585,7 +671,9 @@ struct glz::meta<google::protobuf::FeatureSetDefaults_::FeatureSetEditionDefault
   static constexpr auto value = object(
     "edition", ::hpp_proto::as_optional_ref<&T::edition, google::protobuf::Edition::EDITION_UNKNOWN>,
     "overridableFeatures", &T::overridable_features,
-    "fixedFeatures", &T::fixed_features);
+    "overridable_features", ::hpp_proto::as_alias<&T::overridable_features>,
+    "fixedFeatures", &T::fixed_features,
+    "fixed_features", ::hpp_proto::as_alias<&T::fixed_features>);
 };
 
 template <typename Traits>
@@ -606,8 +694,11 @@ struct glz::meta<google::protobuf::SourceCodeInfo_::Location<Traits>> {
     "path", ::hpp_proto::as_optional_ref<&T::path>,
     "span", ::hpp_proto::as_optional_ref<&T::span>,
     "leadingComments", ::hpp_proto::as_optional_ref<&T::leading_comments>,
+    "leading_comments", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::leading_comments>>,
     "trailingComments", ::hpp_proto::as_optional_ref<&T::trailing_comments>,
-    "leadingDetachedComments", ::hpp_proto::as_optional_ref<&T::leading_detached_comments>);
+    "trailing_comments", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::trailing_comments>>,
+    "leadingDetachedComments", ::hpp_proto::as_optional_ref<&T::leading_detached_comments>,
+    "leading_detached_comments", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::leading_detached_comments>>);
 };
 
 template <typename Traits>
@@ -627,6 +718,7 @@ struct glz::meta<google::protobuf::GeneratedCodeInfo_::Annotation<Traits>> {
   static constexpr auto value = object(
     "path", ::hpp_proto::as_optional_ref<&T::path>,
     "sourceFile", ::hpp_proto::as_optional_ref<&T::source_file>,
+    "source_file", ::hpp_proto::as_alias<::hpp_proto::as_optional_ref<&T::source_file>>,
     "begin", ::hpp_proto::as_optional_ref<&T::begin>,
     "end", ::hpp_proto::as_optional_ref<&T::end>,
     "semantic", ::hpp_proto::as_optional_ref<&T::semantic, google::protobuf::GeneratedCodeInfo_::Annotation_::Semantic::NONE>);

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -945,6 +945,7 @@ private:
     return itr == types.end() ? nullptr : itr->second;
   }
 
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
   std::expected<void, descriptor_pool_errc> build_fields(message_descriptor_t &descriptor) {
     auto to_default_json_name = [](std::string_view proto_name) {
       std::string json_name;

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -946,14 +946,59 @@ private:
   }
 
   std::expected<void, descriptor_pool_errc> build_fields(message_descriptor_t &descriptor) {
+    auto to_default_json_name = [](std::string_view proto_name) {
+      std::string json_name;
+      json_name.reserve(proto_name.size());
+      bool upper_next = false;
+      for (char ch : proto_name) {
+        if (ch == '_') {
+          upper_next = true;
+          continue;
+        }
+        if (upper_next && ch >= 'a' && ch <= 'z') {
+          json_name.push_back(static_cast<char>(ch - ('a' - 'A')));
+        } else {
+          json_name.push_back(ch);
+        }
+        upper_next = false;
+      }
+      return json_name;
+    };
+    auto has_custom_json_name = [&](const FieldDescriptorProto &field) {
+      return !field.json_name.empty() && field.json_name != to_default_json_name(field.name);
+    };
+    auto has_custom_json_conflict = [&](const FieldDescriptorProto &lhs, const FieldDescriptorProto &rhs) {
+      if (has_custom_json_name(lhs)) {
+        if (lhs.json_name == rhs.name || lhs.json_name == rhs.json_name) {
+          return true;
+        }
+      }
+      if (has_custom_json_name(rhs)) {
+        if (rhs.json_name == lhs.name || rhs.json_name == lhs.json_name) {
+          return true;
+        }
+      }
+      return false;
+    };
+
     descriptor.fields_.reserve(descriptor.proto_.field.size());
     std::unordered_set<int32_t> seen_field_numbers;
     seen_field_numbers.reserve(descriptor.proto_.field.size());
+    std::unordered_set<std::string_view> seen_field_names;
+    seen_field_names.reserve(descriptor.proto_.field.size());
     for (auto &proto : descriptor.proto_.field) {
       if (!is_valid_field_number(proto.number)) {
         return std::unexpected(descriptor_pool_errc::validation_error);
       }
       if (!seen_field_numbers.insert(proto.number).second) {
+        return std::unexpected(descriptor_pool_errc::validation_error);
+      }
+      if (!seen_field_names.insert(proto.name).second) {
+        return std::unexpected(descriptor_pool_errc::validation_error);
+      }
+      if (std::ranges::any_of(descriptor.fields_, [&](const auto *existing) {
+            return has_custom_json_conflict(existing->proto(), proto);
+          })) {
         return std::unexpected(descriptor_pool_errc::validation_error);
       }
       auto &field = fields_.emplace_back(proto, &descriptor, descriptor.options_);

--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -44,6 +44,15 @@ consteval bool always_print_fields_with_no_presence_enabled() {
   }
 }
 
+template <auto Opts>
+consteval bool preserve_proto_field_names_enabled() {
+  if constexpr (requires { Opts.preserve_proto_field_names; }) {
+    return Opts.preserve_proto_field_names;
+  } else {
+    return false;
+  }
+}
+
 template <>
 struct to<JSON, hpp_proto::field_cref> {
   template <auto Opts>
@@ -85,8 +94,13 @@ struct generic_message_json_serializer {
   template <auto Opts>
   static void serialize_regular_field(hpp_proto::field_cref field, is_context auto &ctx, auto &b, auto &ix) {
     constexpr auto field_opts = glz::opening_handled_off<Opts>();
-    auto json_name = field.descriptor().proto().json_name;
-    to<glz::JSON, std::string_view>::template op<field_opts>(json_name, ctx, b, ix);
+    std::string_view name;
+    if constexpr (preserve_proto_field_names_enabled<Opts>()) {
+      name = field.descriptor().proto().name;
+    } else {
+      name = field.descriptor().proto().json_name;
+    }
+    to<glz::JSON, std::string_view>::template op<field_opts>(name, ctx, b, ix);
     glz::dump<':'>(b, ix);
     if constexpr (Opts.prettify) {
       glz::dump<' '>(b, ix);
@@ -181,10 +195,10 @@ struct generic_message_json_serializer {
         ctx, it, end, key, [](auto &, auto &) {},
         [&](auto &it_ref, auto &end_ref) {
           static constexpr auto Opts = opening_handled_off<ws_handled<Options>()>();
-          // Current limitation: in this Glaze-based path we match only proto json_name.
-          // Proto field-name fallback (e.g. "optional_int32") is intentionally not
-          // enabled here for now.
           const auto *desc = value.field_descriptor_by_json_name(key);
+          if (desc == nullptr) {
+            desc = value.field_descriptor_by_name(key);
+          }
           if (desc == nullptr) {
             if constexpr (Opts.error_on_unknown_keys) {
               ctx.error = error_code::unknown_key;
@@ -963,6 +977,9 @@ bool any_message_json_serializer::parse_generic_any_value(::hpp_proto::message_v
           skip_value<JSON>::template op<Opts>(ctx, it_ref, end_ref);
         } else {
           const auto *desc = message.field_descriptor_by_json_name(key);
+          if (desc == nullptr) {
+            desc = message.field_descriptor_by_name(key);
+          }
           if (desc == nullptr) {
             if constexpr (Opts.error_on_unknown_keys) {
               ctx.error = error_code::unknown_key;

--- a/include/hpp_proto/hpp_options.glz.hpp
+++ b/include/hpp_proto/hpp_options.glz.hpp
@@ -16,7 +16,8 @@ template <typename Traits>
 struct glz::meta<hpp_proto::FileOptions<Traits>> {
   using T = hpp_proto::FileOptions<Traits>;
   static constexpr auto value = object(
-    "namespacePrefix", &T::namespace_prefix);
+    "namespacePrefix", &T::namespace_prefix,
+    "namespace_prefix", ::hpp_proto::as_alias<&T::namespace_prefix>);
 };
 
 template <typename Traits>

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -350,6 +350,20 @@ struct to<JSON, hpp_proto::indirect_view<Type>> {
   }
 };
 
+template <typename T>
+struct to<JSON, hpp_proto::alias_ref<T>> {
+  template <auto Opts, class... Args>
+  GLZ_ALWAYS_INLINE static void op(auto &&...) noexcept {}
+};
+
+template <typename T>
+struct from<JSON, hpp_proto::alias_ref<T>> {
+  template <auto Opts>
+  GLZ_ALWAYS_INLINE static void op(auto &&wrapper, auto &&...args) noexcept {
+    from<JSON, std::remove_cvref_t<T>>::template op<Opts>(*wrapper, std::forward<decltype(args)>(args)...);
+  }
+};
+
 } // namespace glz
 
 namespace hpp_proto {

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -371,6 +371,10 @@ struct json_write_opts : glz::opts {
   bool escape_control_characters = true;
   bool prettify = false;
   bool always_print_fields_with_no_presence = false;
+  /// If true, the original field names from the .proto file (typically snake_case) are used
+  /// as the primary keys for JSON serialization. This option is only used for dynamic messages.
+  /// For generated messages, use the preserve_proto_field_names plugin option instead.
+  bool preserve_proto_field_names = false;
 };
 
 struct json_read_opts : glz::opts {

--- a/include/hpp_proto/json/field_wrappers.hpp
+++ b/include/hpp_proto/json/field_wrappers.hpp
@@ -184,4 +184,29 @@ constexpr decltype(auto) as_optional_indirect_view_ref_impl() noexcept {
 template <auto MemPtr>
 constexpr auto as_optional_indirect_view_ref = as_optional_indirect_view_ref_impl<MemPtr>();
 
+template <typename T>
+struct alias_ref {
+  static constexpr auto glaze_reflect = false;
+  T val;
+  operator bool() const noexcept { return false; }
+  T &operator*() noexcept { return val; }
+  const T &operator*() const noexcept { return val; }
+};
+
+template <auto Expr>
+constexpr auto as_alias = [](auto &&val) {
+  if constexpr (std::is_member_object_pointer_v<decltype(Expr)>) {
+    return alias_ref<decltype(val.*Expr)>{val.*Expr};
+  } else {
+    auto wrapper = Expr(val);
+    return alias_ref<decltype(wrapper)>{std::move(wrapper)};
+  }
+};
+
+template <auto MemPtr, int Index>
+constexpr auto as_oneof_alias = [](auto &&val) {
+  return alias_ref<oneof_wrapper<std::remove_reference_t<decltype(val.*MemPtr)>, Index>>{
+      wrap_oneof<Index>(val.*MemPtr)};
+};
+
 } // namespace hpp_proto

--- a/include/hpp_proto/json/field_wrappers.hpp
+++ b/include/hpp_proto/json/field_wrappers.hpp
@@ -184,14 +184,16 @@ constexpr decltype(auto) as_optional_indirect_view_ref_impl() noexcept {
 template <auto MemPtr>
 constexpr auto as_optional_indirect_view_ref = as_optional_indirect_view_ref_impl<MemPtr>();
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members,hicpp-explicit-conversions)
 template <typename T>
 struct alias_ref {
   static constexpr auto glaze_reflect = false;
   T val;
-  operator bool() const noexcept { return false; }
+  explicit operator bool() const noexcept { return false; }
   T &operator*() noexcept { return val; }
   const T &operator*() const noexcept { return val; }
 };
+// NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members,hicpp-explicit-conversions)
 
 template <auto Expr>
 constexpr auto as_alias = [](auto &&val) {

--- a/include/hpp_proto/json/field_wrappers.hpp
+++ b/include/hpp_proto/json/field_wrappers.hpp
@@ -203,7 +203,7 @@ constexpr auto as_alias = [](auto &&val) {
   }
 };
 
-template <auto MemPtr, int Index>
+template <auto MemPtr, std::size_t Index>
 constexpr auto as_oneof_alias = [](auto &&val) {
   return alias_ref<oneof_wrapper<std::remove_reference_t<decltype(val.*MemPtr)>, Index>>{
       wrap_oneof<Index>(val.*MemPtr)};

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -580,6 +580,7 @@ struct code_generator {
   static std::string plugin_parameters;
   static std::vector<std::string> proto2_explicit_presences;
   static std::string directory_prefix;
+  static bool preserve_proto_field_names;
   std::size_t indent_num = 0;
   typename CodeGeneratorResponse::File &file;
   std::back_insert_iterator<std::string> target;
@@ -930,6 +931,7 @@ std::filesystem::path code_generator::plugin_name;
 std::string code_generator::plugin_parameters;
 std::vector<std::string> code_generator::proto2_explicit_presences;
 std::string code_generator::directory_prefix;
+bool code_generator::preserve_proto_field_names = false;
 
 struct msg_code_generator : code_generator {
   std::string syntax;
@@ -1789,23 +1791,47 @@ struct glaze_meta_generator : code_generator {
 
     auto type = descriptor.proto().type;
     const bool is_google_any = (type == TYPE_MESSAGE && descriptor.proto().type_name == ".google.protobuf.Any");
-    if (descriptor.is_cpp_optional && !is_google_any) {
-      format_to(target, "    \"{}\", &T::{},\n", descriptor.proto().json_name, descriptor.cpp_name);
-    } else if (descriptor.proto().label == LABEL_REQUIRED) {
 
-      if (type == TYPE_INT64 || type == TYPE_UINT64 || type == TYPE_FIXED64 || type == TYPE_SFIXED64 ||
-          type == TYPE_SINT64) {
-        format_to(target, "    \"{}\", glz::quoted_num<&T::{}>,\n", descriptor.proto().json_name, descriptor.cpp_name);
+    auto emit_field = [&](const std::string &name, bool is_alias) {
+      std::string expr;
+      if (descriptor.is_cpp_optional && !is_google_any) {
+        expr = std::format("&T::{}", descriptor.cpp_name);
+      } else if (descriptor.proto().label == LABEL_REQUIRED) {
+
+        if (type == TYPE_INT64 || type == TYPE_UINT64 || type == TYPE_FIXED64 || type == TYPE_SFIXED64 ||
+            type == TYPE_SINT64) {
+          expr = std::format("glz::quoted_num<&T::{}>", descriptor.cpp_name);
+        } else {
+          expr = std::format("&T::{}", descriptor.cpp_name);
+        }
       } else {
-        format_to(target, "    \"{}\", &T::{},\n", descriptor.proto().json_name, descriptor.cpp_name);
+        std::string name_and_default_value = descriptor.cpp_name;
+        if (!descriptor.default_value_template_arg.empty()) {
+          name_and_default_value += ", " + descriptor.default_value_template_arg;
+        }
+        expr = std::format("::hpp_proto::as_optional_ref<&T::{}>", name_and_default_value);
+      }
+
+      if (is_alias) {
+        format_to(target, "    \"{}\", ::hpp_proto::as_alias<{}>,\n", name, expr);
+      } else {
+        format_to(target, "    \"{}\", {},\n", name, expr);
+      }
+    };
+
+    const std::string &json_name = descriptor.proto().json_name;
+    const std::string &proto_name = descriptor.proto().name;
+
+    if (code_generator::preserve_proto_field_names) {
+      emit_field(proto_name, false);
+      if (json_name != proto_name) {
+        emit_field(json_name, true);
       }
     } else {
-      std::string name_and_default_value = descriptor.cpp_name;
-      if (!descriptor.default_value_template_arg.empty()) {
-        name_and_default_value += ", " + descriptor.default_value_template_arg;
+      emit_field(json_name, false);
+      if (proto_name != json_name) {
+        emit_field(proto_name, true);
       }
-      format_to(target, "    \"{}\", ::hpp_proto::as_optional_ref<&T::{}>,\n", descriptor.proto().json_name,
-                name_and_default_value);
     }
   }
 
@@ -1813,8 +1839,28 @@ struct glaze_meta_generator : code_generator {
     auto fields = descriptor.fields();
     if (fields.size() > 1) {
       for (unsigned i = 0; i < fields.size(); ++i) {
-        format_to(target, "    \"{}\", ::hpp_proto::as_oneof_member<&T::{},{}>,\n", fields[i].proto().json_name,
-                  descriptor.cpp_name, i + 1);
+        auto emit_oneof = [&](const std::string &name, bool is_alias) {
+          if (is_alias) {
+            format_to(target, "    \"{}\", ::hpp_proto::as_oneof_alias<&T::{},{}>,\n", name, descriptor.cpp_name, i + 1);
+          } else {
+            format_to(target, "    \"{}\", ::hpp_proto::as_oneof_member<&T::{},{}>,\n", name, descriptor.cpp_name, i + 1);
+          }
+        };
+
+        const std::string &json_name = fields[i].proto().json_name;
+        const std::string &proto_name = fields[i].proto().name;
+
+        if (code_generator::preserve_proto_field_names) {
+          emit_oneof(proto_name, false);
+          if (json_name != proto_name) {
+            emit_oneof(json_name, true);
+          }
+        } else {
+          emit_oneof(json_name, false);
+          if (proto_name != json_name) {
+            emit_oneof(proto_name, true);
+          }
+        }
       }
     } else {
       process(fields[0]);
@@ -2049,6 +2095,8 @@ int main(int argc, const char **argv) {
       hpp_addons::namespace_prefix = make_qualified_cpp_name("", opt_value);
     } else if (opt_key == "proto2_explicit_presence") {
       code_generator::proto2_explicit_presences.emplace_back(opt_value);
+    } else if (opt_key == "preserve_proto_field_names") {
+      code_generator::preserve_proto_field_names = (opt_value == "true" || opt_value.empty());
     } else if (opt_key == "export_request") {
       std::ofstream out{std::string(opt_value), std::ios::binary};
       if (!out) {

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -2042,6 +2042,7 @@ void split(std::string_view str, char deliminator, auto &&callback) {
   }
 }
 } // namespace
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 int main(int argc, const char **argv) {
   std::span<const char *> args{argv, static_cast<std::size_t>(argc)};
   if (std::ranges::find_if(args, [](auto arg) { return std::string_view(arg) == "--version"; }) != args.end()) {

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -1841,9 +1841,11 @@ struct glaze_meta_generator : code_generator {
       for (unsigned i = 0; i < fields.size(); ++i) {
         auto emit_oneof = [&](const std::string &name, bool is_alias) {
           if (is_alias) {
-            format_to(target, "    \"{}\", ::hpp_proto::as_oneof_alias<&T::{},{}>,\n", name, descriptor.cpp_name, i + 1);
+            format_to(target, "    \"{}\", ::hpp_proto::as_oneof_alias<&T::{},{}>,\n", name, descriptor.cpp_name,
+                      i + 1);
           } else {
-            format_to(target, "    \"{}\", ::hpp_proto::as_oneof_member<&T::{},{}>,\n", name, descriptor.cpp_name, i + 1);
+            format_to(target, "    \"{}\", ::hpp_proto::as_oneof_member<&T::{},{}>,\n", name, descriptor.cpp_name,
+                      i + 1);
           }
         };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Alias-enabled JSON metadata for large generated protos (for example unittest TestAllTypes)
     # can exceed Clang's default constexpr evaluation budget inside Glaze reflection.
-    add_compile_options("-fconstexpr-steps=67108864")
+    add_compile_options("-fbracket-depth=512 -fconstexpr-steps=67108864")
 endif()
 
 set(Min_Protobuf_VERSION 3.12.0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Alias-enabled JSON metadata for large generated protos (for example unittest TestAllTypes)
     # can exceed Clang's default constexpr evaluation budget inside Glaze reflection.
-    add_compile_options("-fbracket-depth=512 -fconstexpr-steps=67108864")
+    add_compile_options("-fbracket-depth=512" "-fconstexpr-steps=67108864")
 endif()
 
 set(Min_Protobuf_VERSION 3.12.0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,12 @@ if(MSVC)
     add_compile_options("/bigobj" "/wd4459" "/wd4125")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Alias-enabled JSON metadata for large generated protos (for example unittest TestAllTypes)
+    # can exceed GCC's default constexpr evaluation budgets inside Glaze reflection.
+    add_compile_options("-fconstexpr-ops-limit=67108864" "-fconstexpr-loop-limit=1048576")
+endif()
+
 set(Min_Protobuf_VERSION 3.12.0)
 
 if("${Protobuf_VERSION}" VERSION_LESS "${Min_Protobuf_VERSION}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,3 +123,24 @@ add_hpp_proto_test(
     SOURCES basic_test_proto2.cpp
     LINK_LIBRARIES basic_test_proto2_lib
     REQUIRES edition_support)
+
+add_hpp_proto_generated_test_lib(
+    NAME json_alias_test_lib
+    SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/json_alias_test.proto"
+        "${CMAKE_CURRENT_SOURCE_DIR}/json_required_alias_test.proto"
+    IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+add_hpp_proto_generated_test_lib(
+    NAME json_alias_preserved_lib
+    SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/json_alias_preserved_test.proto"
+    IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
+    PLUGIN_OPTIONS "preserve_proto_field_names=true"
+)
+
+add_hpp_proto_test(
+    NAME json_alias_test
+    SOURCES json_alias_test.cpp
+    LINK_LIBRARIES json_alias_test_lib json_alias_preserved_lib Boost::ut glaze::glaze
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options("-fconstexpr-ops-limit=67108864" "-fconstexpr-loop-limit=1048576")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Alias-enabled JSON metadata for large generated protos (for example unittest TestAllTypes)
+    # can exceed Clang's default constexpr evaluation budget inside Glaze reflection.
+    add_compile_options("-fconstexpr-steps=67108864")
+endif()
+
 set(Min_Protobuf_VERSION 3.12.0)
 
 if("${Protobuf_VERSION}" VERSION_LESS "${Min_Protobuf_VERSION}")
@@ -88,6 +94,12 @@ add_hpp_proto_test(
     NAME read_json_consistency_test
     SOURCES read_json_consistency_test.cpp
     LINK_LIBRARIES hpp_proto::dynamic_message unittest_proto_lib unittest_proto3_proto_lib map_unittest_proto_lib well_known_types Boost::ut glaze::glaze)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Glaze key hashing for very large reflected messages can exceed Clang's
+    # default constexpr step budget during compilation.
+    target_compile_options(read_json_consistency_test PRIVATE "-fconstexpr-steps=67108864")
+endif()
 
 add_hpp_proto_generated_test_lib(
     NAME unittest_lite_proto_lib

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -206,6 +206,64 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     };
   };
 
+  auto make_json_name_proto_name_conflict_fileset = [] {
+    return OwningFileDescriptorProto{
+        .name = "json_name_proto_name_conflict.proto",
+        .message_type =
+            {
+                MessageProto{
+                    .name = "Root",
+                    .field =
+                        {
+                            FieldProto{
+                                .name = "alpha",
+                                .number = 1,
+                                .label = LABEL_OPTIONAL,
+                                .type = TYPE_STRING,
+                                .json_name = "beta",
+                            },
+                            FieldProto{
+                                .name = "beta",
+                                .number = 2,
+                                .label = LABEL_OPTIONAL,
+                                .type = TYPE_STRING,
+                                .json_name = "beta2",
+                            },
+                        },
+                },
+            },
+    };
+  };
+
+  auto make_empty_json_name_fileset = [] {
+    return OwningFileDescriptorProto{
+        .name = "empty_json_name.proto",
+        .message_type =
+            {
+                MessageProto{
+                    .name = "Root",
+                    .field =
+                        {
+                            FieldProto{
+                                .name = "alpha_value",
+                                .number = 1,
+                                .label = LABEL_OPTIONAL,
+                                .type = TYPE_STRING,
+                                .json_name = "",
+                            },
+                            FieldProto{
+                                .name = "beta_value",
+                                .number = 2,
+                                .label = LABEL_OPTIONAL,
+                                .type = TYPE_STRING,
+                                .json_name = "betaValue",
+                            },
+                        },
+                },
+            },
+    };
+  };
+
   auto make_invalid_field_number_fileset = [] {
     return OwningFileDescriptorProto{
         .name = "invalid_field_number.proto",
@@ -889,6 +947,16 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   "duplicate_field_number_sets_error"_test = [&] {
     auto desc_binpb = make_descriptor_set_binpb_one(make_duplicate_field_number_fileset());
     expect(!hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
+  };
+
+  "json_name_proto_name_conflict_sets_error"_test = [&] {
+    auto desc_binpb = make_descriptor_set_binpb_one(make_json_name_proto_name_conflict_fileset());
+    expect(!hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
+  };
+
+  "empty_json_name_is_allowed"_test = [&] {
+    auto desc_binpb = make_descriptor_set_binpb_one(make_empty_json_name_fileset());
+    expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
   };
 
   "invalid_field_number_sets_error"_test = [&] {

--- a/tests/dynamic_message_test.cpp
+++ b/tests/dynamic_message_test.cpp
@@ -1021,6 +1021,31 @@ const boost::ut::suite dynamic_message_test = [] {
       expect(json_from_binpb.find(R"("optionalNestedMessage")") == std::string::npos);
     };
 
+    "json_snake_case_parsing"_test = [&factory] {
+      std::pmr::monotonic_buffer_resource mr;
+      auto msg = expect_ok(factory.get_message("protobuf_unittest.TestAllTypes", mr));
+
+      // optionalInt32 has json_name "optionalInt32" and original name "optional_int32"
+      std::string json = R"({"optional_int32":123,"optional_string":"hello"})";
+      expect(hpp_proto::read_json(msg, json).ok());
+      expect(eq(123, *msg.field_value_by_name<int32_t>("optional_int32")));
+      expect(eq("hello"sv, *msg.field_value_by_name<std::string_view>("optional_string")));
+    };
+
+    "json_snake_case_serialization"_test = [&factory] {
+      std::pmr::monotonic_buffer_resource mr;
+      auto msg = expect_ok(factory.get_message("protobuf_unittest.TestAllTypes", mr));
+      expect(msg.set_field_by_name("optional_int32", 123).has_value());
+      expect(msg.set_field_by_name("optional_string", "hello"sv).has_value());
+
+      constexpr auto opts = hpp_proto::json_write_opts{.preserve_proto_field_names = true};
+      std::string json;
+      expect(hpp_proto::write_json<opts>(msg, json).ok());
+      // Expect snake_case names
+      expect(json.find(R"("optional_int32":123)") != std::string::npos) << "Actual: " << json;
+      expect(json.find(R"("optional_string":"hello")") != std::string::npos) << "Actual: " << json;
+    };
+
     "repeated enum set and adopt"_test = [&factory] {
       std::pmr::monotonic_buffer_resource memory_resource;
       auto msg = expect_ok(factory.get_message("protobuf_unittest.TestAllTypes", memory_resource));

--- a/tests/json_alias_preserved_test.proto
+++ b/tests/json_alias_preserved_test.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package hpp_proto.test_preserved;
+
+message JsonAliasPreservedMessage {
+  string first_name = 1;
+  int32 account_id = 2;
+  oneof test_oneof {
+    string status_code = 3;
+    int32 status_val = 4;
+  }
+}

--- a/tests/json_alias_test.cpp
+++ b/tests/json_alias_test.cpp
@@ -1,0 +1,87 @@
+#include <boost/ut.hpp>
+#include <hpp_proto/json.hpp>
+#include "json_alias_test.glz.hpp"
+#include "json_alias_test.pb.hpp"
+#include "json_alias_preserved_test.glz.hpp"
+#include "json_alias_preserved_test.pb.hpp"
+#include "json_required_alias_test.glz.hpp"
+#include "json_required_alias_test.pb.hpp"
+
+using namespace boost::ut;
+using namespace std::string_literals;
+
+suite json_alias_tests = [] {
+  "default_naming_serialization"_test = [] {
+    hpp_proto::test::JsonAliasMessage<> msg;
+    msg.first_name = "John";
+    msg.account_id = 123;
+    msg.test_oneof = "OK"s;
+
+    auto json = hpp_proto::write_json(msg).value();
+    // Default should be camelCase for all fields
+    expect(eq(json, R"({"firstName":"John","accountId":123,"statusCode":"OK"})"s));
+  };
+
+  "default_naming_parsing"_test = [] {
+    hpp_proto::test::JsonAliasMessage<> msg;
+
+    // Test camelCase input
+    expect(hpp_proto::read_json(msg, R"({"firstName":"Alice","accountId":456,"statusVal":1})").ok());
+    expect(eq(msg.first_name, "Alice"s));
+    expect(eq(msg.account_id, 456));
+    expect(eq(std::get<2>(msg.test_oneof), 1)); // status_val is index 2 (1-based in my generator logic)
+
+    // Test snake_case input (aliases)
+    expect(hpp_proto::read_json(msg, R"({"first_name":"Bob","account_id":789,"status_code":"FAIL"})").ok());
+    expect(eq(msg.first_name, "Bob"s));
+    expect(eq(msg.account_id, 789));
+    expect(eq(std::get<1>(msg.test_oneof), "FAIL"s));
+  };
+
+  "preserved_naming_serialization"_test = [] {
+    hpp_proto::test_preserved::JsonAliasPreservedMessage<> msg;
+    msg.first_name = "John";
+    msg.account_id = 123;
+    msg.test_oneof = "OK"s;
+
+    // preserve_proto_field_names=true should use snake_case
+    auto json = hpp_proto::write_json(msg).value();
+    expect(eq(json, R"({"first_name":"John","account_id":123,"status_code":"OK"})"s));
+  };
+
+  "preserved_naming_parsing"_test = [] {
+    hpp_proto::test_preserved::JsonAliasPreservedMessage<> msg;
+
+    // Should still accept camelCase (now as aliases)
+    expect(hpp_proto::read_json(msg, R"({"firstName":"Alice","accountId":456,"statusVal":1})").ok());
+    expect(eq(msg.first_name, "Alice"s));
+    expect(eq(msg.account_id, 456));
+    expect(eq(std::get<2>(msg.test_oneof), 1));
+
+    // Should accept snake_case (now as primary)
+    expect(hpp_proto::read_json(msg, R"({"first_name":"Bob","account_id":789,"status_code":"FAIL"})").ok());
+    expect(eq(msg.first_name, "Bob"s));
+    expect(eq(msg.account_id, 789));
+    expect(eq(std::get<1>(msg.test_oneof), "FAIL"s));
+  };
+
+  "required_field_alias"_test = [] {
+    hpp_proto::test::required::RequiredAliasMessage<> msg;
+    msg.user_id = 1234567890123456789ULL;
+    msg.user_role = "admin"s;
+
+    // Serialization: user_id should be quoted because it's uint64
+    auto json = hpp_proto::write_json(msg).value();
+    expect(eq(json, R"({"userId":"1234567890123456789","userRole":"admin"})"s));
+
+    // Parsing: accept snake_case aliases
+    // user_id (uint64) should accept quoted string even in alias
+    expect(hpp_proto::read_json(msg, R"({"user_id":"9876543210987654321","user_role":"guest"})").ok());
+    expect(eq(msg.user_id, 9876543210987654321ULL));
+    expect(eq(msg.user_role, "guest"s));
+  };
+};
+
+int main() {
+  return static_cast<int>(boost::ut::cfg<>.run({.report_errors = true}));
+}

--- a/tests/json_alias_test.cpp
+++ b/tests/json_alias_test.cpp
@@ -10,7 +10,7 @@
 using namespace boost::ut;
 using namespace std::string_literals;
 
-suite json_alias_tests = [] {
+const suite json_alias_tests = [] {
   "default_naming_serialization"_test = [] {
     hpp_proto::test::JsonAliasMessage<> msg;
     msg.first_name = "John";

--- a/tests/json_alias_test.cpp
+++ b/tests/json_alias_test.cpp
@@ -1,11 +1,11 @@
-#include <boost/ut.hpp>
-#include <hpp_proto/json.hpp>
-#include "json_alias_test.glz.hpp"
-#include "json_alias_test.pb.hpp"
 #include "json_alias_preserved_test.glz.hpp"
 #include "json_alias_preserved_test.pb.hpp"
+#include "json_alias_test.glz.hpp"
+#include "json_alias_test.pb.hpp"
 #include "json_required_alias_test.glz.hpp"
 #include "json_required_alias_test.pb.hpp"
+#include <boost/ut.hpp>
+#include <hpp_proto/json.hpp>
 
 using namespace boost::ut;
 using namespace std::string_literals;
@@ -82,6 +82,4 @@ suite json_alias_tests = [] {
   };
 };
 
-int main() {
-  return static_cast<int>(boost::ut::cfg<>.run({.report_errors = true}));
-}
+int main() { return static_cast<int>(boost::ut::cfg<>.run({.report_errors = true})); }

--- a/tests/json_alias_test.proto
+++ b/tests/json_alias_test.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package hpp_proto.test;
+
+message JsonAliasMessage {
+  string first_name = 1;
+  int32 account_id = 2;
+  oneof test_oneof {
+    string status_code = 3;
+    int32 status_val = 4;
+  }
+}

--- a/tests/json_required_alias_test.proto
+++ b/tests/json_required_alias_test.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+package hpp_proto.test.required;
+
+message RequiredAliasMessage {
+  required uint64 user_id = 1;
+  required string user_role = 2;
+}

--- a/unittests/json_serializer_tests.cpp
+++ b/unittests/json_serializer_tests.cpp
@@ -287,10 +287,8 @@ struct oneof_alias_example {
 template <>
 struct glz::meta<oneof_alias_example> {
   using T = oneof_alias_example;
-  static constexpr auto value = object(
-      "stringField", hpp_proto::as_oneof_member<&T::value, 1>,
-      "string_field", hpp_proto::as_oneof_alias<&T::value, 1>
-  );
+  static constexpr auto value = object("stringField", hpp_proto::as_oneof_member<&T::value, 1>, "string_field",
+                                       hpp_proto::as_oneof_alias<&T::value, 1>);
 };
 
 const ut::suite test_multiple_keys = [] {
@@ -311,28 +309,28 @@ const ut::suite test_multiple_keys = [] {
 
   "oneof_alias_parsing"_test = [] {
     {
-        oneof_alias_example m;
-        const auto json = R"({"stringField":"abc"})";
-        auto status = hpp_proto::read_json(m, json);
-        expect(fatal(status.ok())) << status.message(json);
-        expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();
-        expect(eq(std::get<1>(m.value), "abc"s));
+      oneof_alias_example m;
+      const auto json = R"({"stringField":"abc"})";
+      auto status = hpp_proto::read_json(m, json);
+      expect(fatal(status.ok())) << status.message(json);
+      expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();
+      expect(eq(std::get<1>(m.value), "abc"s));
     }
 
     {
-        oneof_alias_example m;
-        const auto json = R"({"string_field":"def"})";
-        auto status = hpp_proto::read_json(m, json);
-        expect(fatal(status.ok())) << status.message(json);
-        expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();
-        expect(eq(std::get<1>(m.value), "def"s));
+      oneof_alias_example m;
+      const auto json = R"({"string_field":"def"})";
+      auto status = hpp_proto::read_json(m, json);
+      expect(fatal(status.ok())) << status.message(json);
+      expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();
+      expect(eq(std::get<1>(m.value), "def"s));
     }
 
     {
-        oneof_alias_example m;
-        m.value = "xyz"s;
-        auto json = hpp_proto::write_json(m).value();
-        expect(eq(json, R"({"stringField":"xyz"})"s));
+      oneof_alias_example m;
+      m.value = "xyz"s;
+      auto json = hpp_proto::write_json(m).value();
+      expect(eq(json, R"({"stringField":"xyz"})"s));
     }
   };
 };

--- a/unittests/json_serializer_tests.cpp
+++ b/unittests/json_serializer_tests.cpp
@@ -310,7 +310,7 @@ const ut::suite test_multiple_keys = [] {
   "oneof_alias_parsing"_test = [] {
     {
       oneof_alias_example m;
-      const auto json = R"({"stringField":"abc"})";
+      constexpr const char *const json = R"({"stringField":"abc"})";
       auto status = hpp_proto::read_json(m, json);
       expect(fatal(status.ok())) << status.message(json);
       expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();
@@ -319,7 +319,7 @@ const ut::suite test_multiple_keys = [] {
 
     {
       oneof_alias_example m;
-      const auto json = R"({"string_field":"def"})";
+      constexpr const char *const json = R"({"string_field":"def"})";
       auto status = hpp_proto::read_json(m, json);
       expect(fatal(status.ok())) << status.message(json);
       expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();

--- a/unittests/json_serializer_tests.cpp
+++ b/unittests/json_serializer_tests.cpp
@@ -267,6 +267,76 @@ const ut::suite test_always_print = [] {
   };
 };
 
+struct multiple_keys_example {
+  int32_t first_name = 0;
+  bool operator==(const multiple_keys_example &) const = default;
+};
+
+template <>
+struct glz::meta<multiple_keys_example> {
+  using T = multiple_keys_example;
+  // firstName is primary (serializes), first_name is an alias (parse-only)
+  static constexpr auto value = object("firstName", &T::first_name, "first_name", hpp_proto::as_alias<&T::first_name>);
+};
+
+struct oneof_alias_example {
+  std::variant<std::monostate, std::string, int32_t> value;
+  bool operator==(const oneof_alias_example &) const = default;
+};
+
+template <>
+struct glz::meta<oneof_alias_example> {
+  using T = oneof_alias_example;
+  static constexpr auto value = object(
+      "stringField", hpp_proto::as_oneof_member<&T::value, 1>,
+      "string_field", hpp_proto::as_oneof_alias<&T::value, 1>
+  );
+};
+
+const ut::suite test_multiple_keys = [] {
+  using namespace boost::ut;
+  using namespace std::string_literals;
+
+  "multiple_keys_parsing"_test = [] {
+    multiple_keys_example msg;
+
+    // Accepts camelCase
+    expect(hpp_proto::read_json(msg, R"({"firstName":1})").ok());
+    expect(eq(msg.first_name, 1));
+
+    // Accepts snake_case (alias)
+    expect(hpp_proto::read_json(msg, R"({"first_name":2})").ok());
+    expect(eq(msg.first_name, 2));
+  };
+
+  "oneof_alias_parsing"_test = [] {
+    {
+        oneof_alias_example m;
+        const auto json = R"({"stringField":"abc"})";
+        auto status = hpp_proto::read_json(m, json);
+        expect(fatal(status.ok())) << status.message(json);
+        expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();
+        expect(eq(std::get<1>(m.value), "abc"s));
+    }
+
+    {
+        oneof_alias_example m;
+        const auto json = R"({"string_field":"def"})";
+        auto status = hpp_proto::read_json(m, json);
+        expect(fatal(status.ok())) << status.message(json);
+        expect(fatal(m.value.index() == 1_u)) << "Index is " << m.value.index();
+        expect(eq(std::get<1>(m.value), "def"s));
+    }
+
+    {
+        oneof_alias_example m;
+        m.value = "xyz"s;
+        auto json = hpp_proto::write_json(m).value();
+        expect(eq(json, R"({"stringField":"xyz"})"s));
+    }
+  };
+};
+
 const ut::suite test_base64 = [] {
   auto verify = [](std::string_view data, std::string_view encoded) {
     using namespace boost::ut;


### PR DESCRIPTION
## Summary
This PR improves JSON field-name compatibility and configurability across generated and dynamic-message paths.

## What changed
1. Added dual-key JSON support for generated metadata:
- Introduced alias wrappers in `include/hpp_proto/json/field_wrappers.hpp` and `include/hpp_proto/json.hpp`.
- Updated generated metadata mappings in:
  - `include/google/protobuf/descriptor.glz.hpp`
  - `include/google/protobuf/compiler/plugin.glz.hpp`
  - `include/hpp_proto/hpp_options.glz.hpp`
- Result: `read_json` accepts both `json_name` (typically camelCase) and proto field names (typically snake_case).

2. Added preserve-proto-field-name controls:
- Runtime option for dynamic JSON serialization:
  - `include/hpp_proto/json.hpp`
  - `include/hpp_proto/dynamic_message/json.hpp`
- Codegen option for generated serializers:
  - `src/protoc-plugin/hpp_gen.cpp` (`preserve_proto_field_names=true`)
- Documentation:
  - `docs/frontend_apis.md`
  - `docs/Code_Generation_Guide.md`

3. Added schema validation for ambiguous custom JSON names:
- Added descriptor-pool validation in `include/hpp_proto/descriptor_pool.hpp` to reject custom `json_name` key collisions that would create ambiguous parse targets.

## Behavior notes
1. Parsing accepts both naming conventions.
2. Serialization remains canonical to the configured primary naming mode.
3. Dynamic schemas with ambiguous custom `json_name` conflicts now fail at factory initialization.