### PR TITLE
docs: clarify sink chunked-write contract and align docs with current API behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This guide will walk you through creating a simple application using `hpp-proto`
 ### Prerequisites
 
 * A C++23-compatible compiler (e.g., Clang 19+, GCC 13+).
-* CMake (version 3.24 or newer).
+* CMake (version 3.25 or newer).
 * The `protoc` compiler. You can download it from the [official Protocol Buffers releases page](https://protobuf.dev/downloads).
 
 ### Step 1: Define Your Protocol Format
@@ -282,10 +282,6 @@ auto result = hpp_proto::read_binpb(
     hpp_proto::padded_input
 );
 ```
-
-## Limitations
-
-* **JSON Options**: Lacks support for some of the extended JSON print options found in Google's C++ implementation, like `preserve_proto_field_names`.
 
 ---
 

--- a/docs/dynamic_message.md
+++ b/docs/dynamic_message.md
@@ -16,7 +16,7 @@ Before you can work with dynamic messages, you need a binary representation of y
 ```bash
 protoc --include_imports --descriptor_set_out=addressbook_proto3.desc.binpb addressbook_proto3.proto
 ```
-This command will create `addressbook_proto3.desc.binpb`, a binary file containing the descriptor information for your `addressbook.proto` file and all its imported dependencies.
+This command will create `addressbook_proto3.desc.binpb`, a binary file containing the descriptor information for your `addressbook_proto3.proto` file and all its imported dependencies.
 
 ## 1) Build a Factory
 
@@ -124,7 +124,7 @@ Once the factory is initialized, you can create dynamic message instances. Each 
     try {
         int id_val = msg.field_value_by_number<std::int32_t>(2).value();
         std::cout << "Person ID (untyped access, exception style): " << id_val << "\n";
-    } catch (const std::bad_expected_access& e) {
+    } catch (const std::bad_expected_access<hpp_proto::dynamic_message_errc>& e) {
         std::cerr << "Error getting ID: " << e.what() << "\n";
     }
 
@@ -302,7 +302,7 @@ Every mutable reference (`_mref`) has a corresponding constant sibling (`_cref`)
 `hpp-proto` embraces `std::expected` for error handling, allowing for a no-exception style of programming.
 
 *   **No-exception style**: Chain operations using `.and_then()` on `std::expected` returns, and check `.has_value()` or `.error()` to handle errors explicitly. Helpers like `hpp_proto::expected_message_mref` are designed for this fluent style.
-*   **Exception style**: If exceptions are preferred, simply call `.value()` on the `std::expected` return types. This will throw `std::bad_optional_access` if the `expected` holds an error.
+*   **Exception style**: If exceptions are preferred, simply call `.value()` on the `std::expected` return types. This throws `std::bad_expected_access` if the `expected` holds an error.
 
 ## 7) Full Example (`tutorial_proto3_dynamic.cpp`)
 

--- a/docs/frontend_apis.md
+++ b/docs/frontend_apis.md
@@ -39,6 +39,26 @@ my_sink sink;
 auto st = hpp_proto::write_binpb(message, sink, hpp_proto::adaptive_mode);
 ```
 
+`sink` is an output adapter that receives serialized bytes in one or more writable chunks.  
+The sink must satisfy the `out_sink` concept:
+
+- `sink.set_message_size(std::size_t) -> void`
+- `sink.next_chunk() -> std::span<std::byte>`
+- `sink.chunk_size() -> std::size_t`
+- `sink::slice_type` type alias
+
+Write flow:
+
+1. `write_binpb` computes encoded size and calls `sink.set_message_size(size)`.
+2. Based on selected mode, it uses either a single chunk write or a chunk-by-chunk write.
+3. In chunked path, serializer repeatedly calls `sink.next_chunk()` to get writable spans and fills them until done.
+
+Practical guidance:
+
+- `next_chunk()` should return writable storage that remains valid until the serializer moves to the next chunk.
+- Returning an empty span means no writable capacity and will fail serialization.
+- `chunk_size()` should reflect the typical/guaranteed chunk capacity, used by `adaptive_mode` to decide contiguous vs chunked path.
+
 Supported mode options:
 
 - `hpp_proto::contiguous_mode`: one-shot write into first chunk; fastest when sink chunk is large enough.
@@ -46,6 +66,23 @@ Supported mode options:
 - `hpp_proto::adaptive_mode` (default for sink): contiguous if message fits one sink chunk, otherwise chunked.
 
 > Mode options only affect sink-based `write_binpb`. Contiguous-buffer writes are always contiguous.
+
+Minimal sink skeleton:
+
+```cpp
+struct my_sink {
+  using slice_type = std::span<std::byte>;
+
+  void set_message_size(std::size_t n) { /* reserve/begin frame */ }
+
+  std::size_t chunk_size() const { return 4096; }
+
+  std::span<std::byte> next_chunk() {
+    // Return next writable window in your output target.
+    return {/* ptr */, /* len */};
+  }
+};
+```
 
 ### Read from contiguous/chunked input
 


### PR DESCRIPTION
## Summary
This PR improves documentation clarity and fixes a few inconsistencies across core docs.

## Changes
- Expanded sink/chunked-write documentation in `docs/frontend_apis.md`:
  - Defined the sink concept and required interface (`set_message_size`, `next_chunk`, `chunk_size`, `slice_type`)
  - Documented serialization flow for contiguous/chunked/adaptive modes
  - Added practical guidance and a minimal sink skeleton example
- Corrected docs/API mismatches:
  - `README.md`: updated CMake minimum version to `3.25`
  - `docs/dynamic_message.md`:
    - fixed proto filename reference (`addressbook_proto3.proto`)
    - corrected `std::expected` exception text (`std::bad_expected_access`)
    - fixed sample catch type to `std::bad_expected_access<hpp_proto::dynamic_message_errc>`
