### PR TITLE
Reject invalid control characters when reading dynamic `google.protobuf.FieldMask` JSON

### DIFF
--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -489,8 +489,8 @@ struct field_mask_message_json_serializer {
   template <auto Opts>
   static void from_json(hpp_proto::message_value_mref value, is_context auto &ctx, auto &it, auto &end) {
     assert(value.descriptor().full_name() == "google.protobuf.FieldMask");
-    std::string_view encoded;
-    util::parse_string_view_reject_controls<Opts>(encoded, ctx, it, end);
+    std::string encoded;
+    from<JSON, std::string>::template op<Opts>(encoded, ctx, it, end);
     if constexpr (not Opts.null_terminated) {
       if (ctx.error == error_code::end_reached) {
         ctx.error = error_code::none;

--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -489,8 +489,8 @@ struct field_mask_message_json_serializer {
   template <auto Opts>
   static void from_json(hpp_proto::message_value_mref value, is_context auto &ctx, auto &it, auto &end) {
     assert(value.descriptor().full_name() == "google.protobuf.FieldMask");
-    std::string encoded;
-    from<JSON, std::string>::template op<Opts>(encoded, ctx, it, end);
+    std::string_view encoded;
+    util::parse_string_view_reject_controls<Opts>(encoded, ctx, it, end);
     if constexpr (not Opts.null_terminated) {
       if (ctx.error == error_code::end_reached) {
         ctx.error = error_code::none;

--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -489,8 +489,8 @@ struct field_mask_message_json_serializer {
   template <auto Opts>
   static void from_json(hpp_proto::message_value_mref value, is_context auto &ctx, auto &it, auto &end) {
     assert(value.descriptor().full_name() == "google.protobuf.FieldMask");
-    std::string_view encoded;
-    from<JSON, std::string_view>::template op<Opts>(encoded, ctx, it, end);
+    std::string encoded;
+    from<JSON, std::string>::template op<Opts>(encoded, ctx, it, end);
     if constexpr (not Opts.null_terminated) {
       if (ctx.error == error_code::end_reached) {
         ctx.error = error_code::none;

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -143,7 +143,7 @@ struct from<JSON, T> {
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   GLZ_ALWAYS_INLINE static void op(auto &value, is_context auto &ctx, It &it, End &end) {
     std::string_view encoded;
-    from<JSON, std::string_view>::op<Opts>(encoded, ctx, it, end);
+    util::parse_string_view_reject_controls<Opts>(encoded, ctx, it, end);
     if constexpr (not Opts.null_terminated) {
       if (ctx.error == error_code::end_reached) {
         ctx.error = error_code::none;

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -142,8 +142,10 @@ struct from<JSON, T> {
   template <auto Opts, class It, class End>
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   GLZ_ALWAYS_INLINE static void op(auto &value, is_context auto &ctx, It &it, End &end) {
-    std::string_view encoded;
-    util::parse_string_view_reject_controls<Opts>(encoded, ctx, it, end);
+    using codec = typename hpp_proto::json_codec<T>::type;
+    using encoded_storage = typename codec::encoded_storage;
+    encoded_storage encoded;
+    from<JSON, encoded_storage>::template op<Opts>(encoded, ctx, it, end);
     if constexpr (not Opts.null_terminated) {
       if (ctx.error == error_code::end_reached) {
         ctx.error = error_code::none;
@@ -154,7 +156,6 @@ struct from<JSON, T> {
       return;
     }
 
-    using codec = typename hpp_proto::json_codec<T>::type;
     if (!codec::decode(encoded, value, ctx)) {
       ctx.error = error_code::syntax_error;
       return;

--- a/include/hpp_proto/json/base64.hpp
+++ b/include/hpp_proto/json/base64.hpp
@@ -35,6 +35,7 @@
 namespace hpp_proto {
 
 struct base64 {
+  using encoded_storage = std::string_view;
   constexpr static std::size_t max_encode_size(hpp_proto::concepts::contiguous_byte_range auto const &source) noexcept {
     std::size_t n = source.size();
     return (n / 3 + (n % 3 > 0 ? 1 : 0)) * 4;

--- a/include/hpp_proto/json/duration_codec.hpp
+++ b/include/hpp_proto/json/duration_codec.hpp
@@ -29,6 +29,7 @@
 
 namespace hpp_proto {
 struct duration_codec {
+  using encoded_storage = std::string_view;
   constexpr static std::size_t max_encode_size(const auto &) noexcept { return 32; }
 
   static int64_t encode(auto const &value, auto &&b) noexcept {

--- a/include/hpp_proto/json/field_mask_codec.hpp
+++ b/include/hpp_proto/json/field_mask_codec.hpp
@@ -26,6 +26,7 @@
 #include <glaze/util/parse.hpp>
 #include <hpp_proto/memory_resource_utils.hpp>
 #include <iterator>
+#include <memory>
 #include <numeric>
 #include <span>
 namespace hpp_proto {
@@ -42,30 +43,41 @@ struct field_mask_codec {
     return 1;
   }
 
-  template <typename Out>
-  static void append_escaped_char(unsigned char c, Out *&cur) noexcept {
-    constexpr auto hex = std::to_array("0123456789abcdef");
-    if (const auto escaped = glz::char_escape_table[c]; escaped) {
-      std::memcpy(cur, &escaped, 2);
-      cur += 2;
+  static constexpr char hex_digit(unsigned char value) noexcept {
+    constexpr std::string_view hex = "0123456789abcdef";
+    return hex.at(value);
+  }
+
+  template <typename Out, typename It>
+  static void append_char(Out value, It &cur) noexcept {
+    *cur = value;
+    cur = std::next(cur);
+  }
+
+  template <typename Out, typename It>
+  static void append_escaped_char(unsigned char c, It &cur) noexcept {
+    const auto escaped = *std::next(glz::char_escape_table.begin(), c);
+    if (escaped) {
+      std::memcpy(std::to_address(cur), &escaped, 2);
+      cur = std::next(cur, 2);
       return;
     }
     if (c < 0x20U) {
-      *cur++ = '\\';
-      *cur++ = 'u';
-      *cur++ = '0';
-      *cur++ = '0';
-      *cur++ = hex[c >> 4U];
-      *cur++ = hex[c & 0x0FU];
+      append_char<Out>('\\', cur);
+      append_char<Out>('u', cur);
+      append_char<Out>('0', cur);
+      append_char<Out>('0', cur);
+      append_char<Out>(hex_digit(static_cast<unsigned char>(c >> 4U)), cur);
+      append_char<Out>(hex_digit(static_cast<unsigned char>(c & 0x0FU)), cur);
       return;
     }
-    *cur++ = static_cast<Out>(c);
+    append_char<Out>(static_cast<Out>(c), cur);
   }
 
-  template <std::ranges::input_range Range, typename Out>
-  static void append_escaped_path(const Range &path, Out *&cur) noexcept {
+  template <typename Out, std::ranges::input_range Range, typename It>
+  static void append_escaped_path(const Range &path, It &cur) noexcept {
     for (auto c : path) {
-      append_escaped_char(static_cast<unsigned char>(c), cur);
+      append_escaped_char<Out>(static_cast<unsigned char>(c), cur);
     }
   }
 
@@ -80,16 +92,16 @@ struct field_mask_codec {
     if (value.paths.empty()) {
       return 0;
     }
-    auto *buf = std::data(std::forward<decltype(b)>(b));
-    auto *cur = buf;
-    append_escaped_path(value.paths[0], cur);
+    auto buffer = std::span{std::forward<decltype(b)>(b)};
+    auto cur = buffer.begin();
+    using out_type = std::remove_cvref_t<decltype(*cur)>;
+    append_escaped_path<out_type>(value.paths[0], cur);
     const auto rest = std::span{value.paths}.subspan(1);
     for (const auto &p : rest) {
-      *cur = ',';
-      ++cur;
-      append_escaped_path(p, cur);
+      append_char<out_type>(',', cur);
+      append_escaped_path<out_type>(p, cur);
     }
-    return std::distance(buf, cur);
+    return std::ranges::distance(buffer.begin(), cur);
   }
 
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)

--- a/include/hpp_proto/json/field_mask_codec.hpp
+++ b/include/hpp_proto/json/field_mask_codec.hpp
@@ -45,7 +45,7 @@ struct field_mask_codec {
 
   static constexpr char hex_digit(unsigned char value) noexcept {
     constexpr std::string_view hex = "0123456789abcdef";
-    return hex.at(value);
+    return hex[value]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
   }
 
   template <typename Out, typename It>

--- a/include/hpp_proto/json/field_mask_codec.hpp
+++ b/include/hpp_proto/json/field_mask_codec.hpp
@@ -71,9 +71,8 @@ struct field_mask_codec {
 
   constexpr static std::size_t max_encode_size(auto const &value) noexcept {
     return std::transform_reduce(value.paths.begin(), value.paths.end(), value.paths.size(), std::plus{}, [](auto &p) {
-      return std::transform_reduce(p.begin(), p.end(), 0ULL, std::plus{}, [](auto c) {
-        return escaped_char_size(static_cast<unsigned char>(c));
-      });
+      return std::transform_reduce(p.begin(), p.end(), 0ULL, std::plus{},
+                                   [](auto c) { return escaped_char_size(static_cast<unsigned char>(c)); });
     });
   }
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)

--- a/include/hpp_proto/json/field_mask_codec.hpp
+++ b/include/hpp_proto/json/field_mask_codec.hpp
@@ -21,7 +21,9 @@
 // SOFTWARE.
 
 #pragma once
+#include <array>
 #include <cstdint>
+#include <glaze/util/parse.hpp>
 #include <hpp_proto/memory_resource_utils.hpp>
 #include <iterator>
 #include <numeric>
@@ -29,9 +31,50 @@
 namespace hpp_proto {
 
 struct field_mask_codec {
+  using encoded_storage = std::string;
+  static constexpr std::size_t escaped_char_size(unsigned char c) noexcept {
+    if (c < 0x20U) {
+      return 6;
+    }
+    if (c == '"' || c == '\\') {
+      return 2;
+    }
+    return 1;
+  }
+
+  template <typename Out>
+  static void append_escaped_char(unsigned char c, Out *&cur) noexcept {
+    constexpr auto hex = std::to_array("0123456789abcdef");
+    if (const auto escaped = glz::char_escape_table[c]; escaped) {
+      std::memcpy(cur, &escaped, 2);
+      cur += 2;
+      return;
+    }
+    if (c < 0x20U) {
+      *cur++ = '\\';
+      *cur++ = 'u';
+      *cur++ = '0';
+      *cur++ = '0';
+      *cur++ = hex[c >> 4U];
+      *cur++ = hex[c & 0x0FU];
+      return;
+    }
+    *cur++ = static_cast<Out>(c);
+  }
+
+  template <std::ranges::input_range Range, typename Out>
+  static void append_escaped_path(const Range &path, Out *&cur) noexcept {
+    for (auto c : path) {
+      append_escaped_char(static_cast<unsigned char>(c), cur);
+    }
+  }
+
   constexpr static std::size_t max_encode_size(auto const &value) noexcept {
-    return value.paths.size() + std::transform_reduce(value.paths.begin(), value.paths.end(), 0ULL, std::plus{},
-                                                      [](auto &p) { return p.size(); });
+    return std::transform_reduce(value.paths.begin(), value.paths.end(), value.paths.size(), std::plus{}, [](auto &p) {
+      return std::transform_reduce(p.begin(), p.end(), 0ULL, std::plus{}, [](auto c) {
+        return escaped_char_size(static_cast<unsigned char>(c));
+      });
+    });
   }
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
   static int64_t encode(auto const &value, auto &&b) noexcept {
@@ -39,11 +82,13 @@ struct field_mask_codec {
       return 0;
     }
     auto *buf = std::data(std::forward<decltype(b)>(b));
-    auto *cur = std::copy(std::begin(value.paths[0]), std::end(value.paths[0]), buf);
+    auto *cur = buf;
+    append_escaped_path(value.paths[0], cur);
     const auto rest = std::span{value.paths}.subspan(1);
     for (const auto &p : rest) {
       *cur = ',';
-      cur = std::copy(std::begin(p), std::end(p), std::next(cur));
+      ++cur;
+      append_escaped_path(p, cur);
     }
     return std::distance(buf, cur);
   }

--- a/include/hpp_proto/json/timestamp_codec.hpp
+++ b/include/hpp_proto/json/timestamp_codec.hpp
@@ -30,7 +30,9 @@
 
 namespace hpp_proto {
 
-struct timestamp_codec {
+class timestamp_codec {
+public:
+  using encoded_storage = std::string_view;
   constexpr static std::size_t max_encode_size(auto &&) noexcept { return std::size("yyyy-mm-ddThh:mm:ss.000000000Z"); }
 
 private:

--- a/include/hpp_proto/json/util.hpp
+++ b/include/hpp_proto/json/util.hpp
@@ -104,33 +104,37 @@ bool parse_null(auto &&value, auto &ctx, auto &it, auto &end) {
 }
 
 template <auto Opts>
-void parse_string_view_reject_controls(std::string_view &value, glz::is_context auto &ctx, auto &it, auto &end) {
+bool parse_string_view_reject_controls_preamble(glz::is_context auto &ctx, auto &it, auto &end) {
   if constexpr (!check_opening_handled(Opts)) {
     if constexpr (!check_ws_handled(Opts)) {
       if (skip_ws<Opts>(ctx, it, end)) {
-        return;
+        return false;
       }
     }
 
     if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-      return;
+      return false;
     }
   }
+  return true;
+}
 
+template <auto Opts>
+bool parse_string_view_reject_controls_scan(std::string_view &value, glz::is_context auto &ctx, auto &it, auto &end) {
   auto start = it;
   bool escaped = false;
   for (;; ++it) {
     if constexpr (not Opts.null_terminated) {
       if (it == end) [[unlikely]] {
         ctx.error = error_code::unexpected_end;
-        return;
+        return false;
       }
     }
 
     const auto c = static_cast<unsigned char>(*it);
     if (c < 0x20U) [[unlikely]] {
       ctx.error = error_code::syntax_error;
-      return;
+      return false;
     }
     if (escaped) {
       escaped = false;
@@ -148,9 +152,17 @@ void parse_string_view_reject_controls(std::string_view &value, glz::is_context 
           ctx.error = error_code::end_reached;
         }
       }
-      return;
+      return true;
     }
   }
+}
+
+template <auto Opts>
+void parse_string_view_reject_controls(std::string_view &value, glz::is_context auto &ctx, auto &it, auto &end) {
+  if (!parse_string_view_reject_controls_preamble<Opts>(ctx, it, end)) {
+    return;
+  }
+  static_cast<void>(parse_string_view_reject_controls_scan<Opts>(value, ctx, it, end));
 }
 
 template <auto Opts> // NOLINTNEXTLINE(readability-function-cognitive-complexity)

--- a/include/hpp_proto/json/util.hpp
+++ b/include/hpp_proto/json/util.hpp
@@ -103,6 +103,56 @@ bool parse_null(auto &&value, auto &ctx, auto &it, auto &end) {
   return false;
 }
 
+template <auto Opts>
+void parse_string_view_reject_controls(std::string_view &value, glz::is_context auto &ctx, auto &it, auto &end) {
+  if constexpr (!check_opening_handled(Opts)) {
+    if constexpr (!check_ws_handled(Opts)) {
+      if (skip_ws<Opts>(ctx, it, end)) {
+        return;
+      }
+    }
+
+    if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+      return;
+    }
+  }
+
+  auto start = it;
+  bool escaped = false;
+  for (;; ++it) {
+    if constexpr (not Opts.null_terminated) {
+      if (it == end) [[unlikely]] {
+        ctx.error = error_code::unexpected_end;
+        return;
+      }
+    }
+
+    const auto c = static_cast<unsigned char>(*it);
+    if (c < 0x20U) [[unlikely]] {
+      ctx.error = error_code::syntax_error;
+      return;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c == '\\') {
+      escaped = true;
+      continue;
+    }
+    if (c == '"') {
+      value = {start, static_cast<std::size_t>(it - start)};
+      ++it; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      if constexpr (not Opts.null_terminated) {
+        if (it == end) {
+          ctx.error = error_code::end_reached;
+        }
+      }
+      return;
+    }
+  }
+}
+
 template <auto Opts> // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 [[nodiscard]] bool parse_opening(char c, glz::is_context auto &ctx, auto &it,
                                  auto &end) { // NOLINT(readability-function-cognitive-complexity)

--- a/tests/any_test.cpp
+++ b/tests/any_test.cpp
@@ -146,8 +146,8 @@ const suite test_dynamic_message_any = [] {
         R"({"anyValue":{"@type":"type.googleapis.com/proto3_unittest.ForeignMessage","@type":"type.googleapis.com/proto3_unittest.ForeignMessage","c":1}})"); // duplicate @type
     expect_read_fail(
         R"({"anyValue":{"@type":"type.googleapis.com/google.protobuf.FieldMask","value":"/usr/share","extra":1}})"); // unknown key in well-known
-    expect_read_fail(
-        "{\"anyValue\":{\"@type\":\"type.googleapis.com/google.protobuf.FieldMask\",\"value\":\"/usr/share\x01\"}}"); // value with control code     
+    expect_read_fail("{\"anyValue\":{\"@type\":\"type.googleapis.com/google.protobuf.FieldMask\",\"value\":\"/usr/"
+                     "share\x01\"}}"); // value with control code
     expect_read_ok(
         R"({"anyValue":{"@type":"type.googleapis.com/google.protobuf.FieldMask","value":"/usr/share","value":"/usr/local"}})"); // duplicate value
     expect_read_ok(R"({"anyValue":{"@type":"type.googleapis.com/google.protobuf.FieldMask"}})"); // missing value

--- a/tests/any_test.cpp
+++ b/tests/any_test.cpp
@@ -146,6 +146,8 @@ const suite test_dynamic_message_any = [] {
         R"({"anyValue":{"@type":"type.googleapis.com/proto3_unittest.ForeignMessage","@type":"type.googleapis.com/proto3_unittest.ForeignMessage","c":1}})"); // duplicate @type
     expect_read_fail(
         R"({"anyValue":{"@type":"type.googleapis.com/google.protobuf.FieldMask","value":"/usr/share","extra":1}})"); // unknown key in well-known
+    expect_read_fail(
+        "{\"anyValue\":{\"@type\":\"type.googleapis.com/google.protobuf.FieldMask\",\"value\":\"/usr/share\x01\"}}"); // value with control code     
     expect_read_ok(
         R"({"anyValue":{"@type":"type.googleapis.com/google.protobuf.FieldMask","value":"/usr/share","value":"/usr/local"}})"); // duplicate value
     expect_read_ok(R"({"anyValue":{"@type":"type.googleapis.com/google.protobuf.FieldMask"}})"); // missing value

--- a/tests/well_known_types_tests.cpp
+++ b/tests/well_known_types_tests.cpp
@@ -234,11 +234,6 @@ const ut::suite test_field_mask = [] {
 
   "verify FieldMask abc def"_test = [&factory] {
     verify<FieldMask>(factory, FieldMask{.paths = {"abc", "def"}}, R"("abc,def")");
-    // field mask json format does not escape control code
-    verify<FieldMask>(factory, google::protobuf::FieldMask<>{.paths = {"a\x00c"s, "def"s}}, "\"a\x00c,def\"");
-    std::array<std::string_view, 2> paths{"a\x00c", "def"};
-    verify<google::protobuf::FieldMask<hpp_proto::non_owning_traits>>(
-        factory, google::protobuf::FieldMask<hpp_proto::non_owning_traits>{.paths = paths}, "\"a\x00c,def\"");
   };
 
   "field_mask_empty_clears"_test = [] {

--- a/tests/well_known_types_tests.cpp
+++ b/tests/well_known_types_tests.cpp
@@ -234,6 +234,11 @@ const ut::suite test_field_mask = [] {
 
   "verify FieldMask abc def"_test = [&factory] {
     verify<FieldMask>(factory, FieldMask{.paths = {"abc", "def"}}, R"("abc,def")");
+    verify<FieldMask>(
+        factory, google::protobuf::FieldMask<>{.paths = {std::string{"a\0c", 3}, "def"s}}, R"("a\u0000c,def")");
+    std::array<std::string_view, 2> paths{std::string_view{"a\0c", 3}, "def"};
+    verify<google::protobuf::FieldMask<hpp_proto::non_owning_traits>>(
+        factory, google::protobuf::FieldMask<hpp_proto::non_owning_traits>{.paths = paths}, R"("a\u0000c,def")");
   };
 
   "field_mask_empty_clears"_test = [] {

--- a/tests/well_known_types_tests.cpp
+++ b/tests/well_known_types_tests.cpp
@@ -234,8 +234,8 @@ const ut::suite test_field_mask = [] {
 
   "verify FieldMask abc def"_test = [&factory] {
     verify<FieldMask>(factory, FieldMask{.paths = {"abc", "def"}}, R"("abc,def")");
-    verify<FieldMask>(
-        factory, google::protobuf::FieldMask<>{.paths = {std::string{"a\0c", 3}, "def"s}}, R"("a\u0000c,def")");
+    verify<FieldMask>(factory, google::protobuf::FieldMask<>{.paths = {std::string{"a\0c", 3}, "def"s}},
+                      R"("a\u0000c,def")");
     std::array<std::string_view, 2> paths{std::string_view{"a\0c", 3}, "def"};
     verify<google::protobuf::FieldMask<hpp_proto::non_owning_traits>>(
         factory, google::protobuf::FieldMask<hpp_proto::non_owning_traits>{.paths = paths}, R"("a\u0000c,def")");

--- a/tests/well_known_types_tests.cpp
+++ b/tests/well_known_types_tests.cpp
@@ -241,6 +241,10 @@ const ut::suite test_field_mask = [] {
         factory, google::protobuf::FieldMask<hpp_proto::non_owning_traits>{.paths = paths}, R"("a\u0000c,def")");
   };
 
+  "verify FieldMask escaped characters"_test = [&factory] {
+    verify<FieldMask>(factory, FieldMask{.paths = {R"(a"b)", R"(c\d)"}}, R"("a\"b,c\\d")");
+  };
+
   "field_mask_empty_clears"_test = [] {
     google::protobuf::FieldMask<> msg;
     msg.paths = {"abc", "def"};


### PR DESCRIPTION
## Summary

This PR tightens `google.protobuf.FieldMask` ProtoJSON handling to use normal JSON string semantics.

`FieldMask` now serializes control bytes using JSON escapes like `\u0000`, and deserialization goes through decoded string parsing so escaped control codes are accepted while raw control bytes are rejected. To support that cleanly, codec-based JSON reads now allow each codec to choose its input storage type via `encoded_storage`.

## What changed

- Added `encoded_storage` to JSON codecs
- Kept `base64`, `Timestamp`, and `Duration` on zero-copy `std::string_view`
- Switched `FieldMask` to decoded `std::string`
- Escaped control bytes in `FieldMask` JSON serialization
- Kept dynamic-message `FieldMask` parsing aligned with the same behavior
- Added tests for embedded NUL handling in owning and non-owning `FieldMask`

## Compatibility note

This matches Python protobuf behavior, but differs from the locally tested C++ protobuf runtime.

Observed locally:

- Python protobuf `7.34.0`
  - writes `\u0000`
  - accepts escaped control-code JSON
  - rejects raw control bytes
- C++ protobuf `33.2`
  - writes raw control bytes
  - accepts escaped control-code JSON
  - also accepts raw control bytes

This branch follows the stricter Python behavior.