### PR TITLE
Reject overflowing duration seconds during JSON parse

### DIFF
--- a/include/hpp_proto/json/duration_codec.hpp
+++ b/include/hpp_proto/json/duration_codec.hpp
@@ -103,11 +103,14 @@ struct duration_codec {
     };
 
     auto point_pos = s.find('.');
-    if (!from_str_view(s.substr(0, point_pos), value.seconds)) {
+    uint64_t unsigned_seconds=0;
+    if (!from_str_view(s.substr(0, point_pos), unsigned_seconds)) {
       return false;
     }
 
-    if (value.seconds > 315'576'000'000LL) {
+    value.seconds = static_cast<int64_t>(unsigned_seconds);
+
+    if (value.seconds > 315'576'000'000LL || value.seconds < 0) {
       return false;
     }
 

--- a/include/hpp_proto/json/duration_codec.hpp
+++ b/include/hpp_proto/json/duration_codec.hpp
@@ -103,7 +103,7 @@ struct duration_codec {
     };
 
     auto point_pos = s.find('.');
-    uint64_t unsigned_seconds=0;
+    uint64_t unsigned_seconds = 0;
     if (!from_str_view(s.substr(0, point_pos), unsigned_seconds)) {
       return false;
     }

--- a/tests/well_known_types_tests.cpp
+++ b/tests/well_known_types_tests.cpp
@@ -215,6 +215,7 @@ const ut::suite test_duration = [] {
   ut::expect(!hpp_proto::read_json(msg, R"("1000.0000000000000000s")").ok());
   ut::expect(!hpp_proto::read_json(msg, R"("315576000001s")").ok());
   ut::expect(!hpp_proto::read_json(msg, R"("-315576000001s")").ok());
+  ut::expect(!hpp_proto::read_json(msg, R"("--90.0s")").ok());
 
   ut::expect(!hpp_proto::write_json(duration_t{.seconds = 0, .nanos = 1000000000}).has_value());
   ut::expect(!hpp_proto::write_json(duration_t{.seconds = 0, .nanos = -1000000000}).has_value());


### PR DESCRIPTION
## Summary

This change hardens `google.protobuf.Duration` JSON decoding by parsing the seconds field as an unsigned value before applying sign handling and range validation.

Previously, oversized positive values could be parsed directly into `int64_t`, which left an overflow edge case in the decode path. This update ensures the parser rejects invalid second values cleanly before constructing the final signed duration.

## What changed

- Parse duration seconds into `uint64_t` during JSON decode
- Cast to `int64_t` only after successful numeric parsing
- Reject values outside the allowed `Duration` seconds range
- Reject any value that would become negative before explicit sign application

## Why

`google.protobuf.Duration` JSON input should fail cleanly for malformed or out-of-range second values. This change closes that validation gap and makes duration parsing stricter and safer.
