### PR TITLE
Upgrade glaze to `7.2.0` and align dependency pins

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,7 @@ class HppProtoConan(ConanFile):
             check_min_cppstd(self, "23")
 
     def requirements(self):
-        self.requires("glaze/7.0.2")
+        self.requires("glaze/7.2.0")
 
     def build_requirements(self):
         self.protoc_mode = self.conf.get("user.hpp_proto:protoc", default="find")

--- a/ports/README.md
+++ b/ports/README.md
@@ -13,7 +13,7 @@ This directory contains local vcpkg overlay ports used by this repository.
 - `ports/hpp-proto`: local port for this project.
   - Default mode is `find` (looks for `protoc` on system `PATH`).
   - Feature `vcpkg-protobuf` uses `protobuf`/`protoc` from vcpkg host tools.
-- `ports/glaze`: pinned overlay port for `glaze` `7.1.1`.
+- `ports/glaze`: pinned overlay port for `glaze` `7.2.0`.
   - This overrides the registry `glaze` port when `--overlay-ports` points to this directory.
 
 ## How Overlay Resolution Works

--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 964affe09bdb98b46e01d9e376fe4c12b20a3df19e2f5a3593a58bc5f66b0d5958d7fcd8cc5911f5cb0fa33abd12dcf12d8e7ab80596ec0ac459712e5027b15c
+    SHA512 16b79f22321d31cc5eec696307113c2287f705e45bf057f51079d4e58389bcad7abaf6a024d08992f84c70bdc265dcf996ef1d383eb6500d82d837baabd6cc52
     HEAD_REF main
 )
 

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/third-parties.cmake
+++ b/third-parties.cmake
@@ -6,7 +6,7 @@ if(CMAKE_VERSION GREATER_EQUAL 3.25)
     set(system_package SYSTEM)
 endif()
 
-set(HPP_PROTO_GLAZE_VERSION 7.1.1)
+set(HPP_PROTO_GLAZE_VERSION 7.2.0)
 CPMAddPackage(
     NAME glaze
     GIT_TAG v${HPP_PROTO_GLAZE_VERSION}

--- a/tutorial/conanfile.txt
+++ b/tutorial/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 hpp_proto/1.0.0
-glaze/7.0.2
+glaze/7.2.0
 
 [generators]
 CMakeDeps


### PR DESCRIPTION
This PR updates the repository’s glaze dependency from `7.1.1`/`7.0.2` to `7.2.0` and brings all package manifests into alignment.

**Changes**
- Updated the CPM pin in [third-parties.cmake](/Users/huangh/opensource/hpp-proto/third-parties.cmake)
- Updated the Conan requirement in [conanfile.py](/Users/huangh/opensource/hpp-proto/conanfile.py)
- Updated the vcpkg overlay port version in [ports/glaze/vcpkg.json](/Users/huangh/opensource/hpp-proto/ports/glaze/vcpkg.json)
- Updated the overlay-port note in [ports/README.md](/Users/huangh/opensource/hpp-proto/ports/README.md)
