### PR TITLE
Fix merge move semantics and tighten deserialization invariants

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+Briefly describe the change and the user-facing impact.
+
+## What changed
+
+- 
+- 
+- 
+
+## Why
+
+Explain the problem this change addresses and why this approach was chosen.
+
+## Testing
+
+- 
+- 
+
+## Notes
+
+- Link any related issue, discussion, or follow-up work here.
+- Call out any behavior changes, compatibility concerns, or required migrations.

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -277,12 +277,6 @@ struct basic_in {
     return {};
   }
 
-  template <typename T>
-    requires concepts::is_enum<T> && (sizeof(T) > 1)
-  constexpr status deserialize(T &item) {
-    return deserialize(varint{static_cast<int64_t>(item)});
-  }
-
   template <concepts::varint T>
   constexpr status deserialize(T &item) {
     if (auto p = unchecked_parse_varint(current, item); p <= current._end) [[likely]] {

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -317,6 +317,7 @@ struct from<JSON, hpp_proto::optional_indirect_view_ref<T>> {
     if (!util::parse_null<Options>(value, ctx, it, end)) {
       using type = std::remove_const_t<typename T::value_type>;
       void *addr = ctx.memory_resource().allocate(sizeof(type), alignof(type));
+      static_assert(std::is_nothrow_constructible_v<type>);
       auto *obj = new (addr) type; // NOLINT(cppcoreguidelines-owning-memory)
       constexpr auto Opts = ws_handled_off<Options>();
       parse<JSON>::op<Options>(*obj, ctx, it, end);

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -58,10 +58,18 @@ struct message_merger {
   template <concepts::has_meta T, typename U>
     requires concepts::isomorphic_message<T, std::decay_t<U>>
   constexpr void perform(T &dest, U &&source) {
+
+    auto conditional_move = [&](auto &src_field) -> decltype(auto) {
+      if constexpr (std::is_rvalue_reference_v<U &&>) {
+        return std::move(src_field);
+      } else {
+        return (src_field);
+      }
+    };
+
     return std::apply(
-        [this, &dest, &source](auto &&...metas) {
-          // NOLINTNEXTLINE(bugprone-use-after-move,hicpp-invalid-access-moved)
-          (this->perform(metas, metas.first.get(dest), metas.second.get(std::forward<U>(source))), ...);
+        [&, this](auto &&...metas) {
+          (this->perform(metas, metas.first.get(dest), conditional_move(metas.second.get(source))), ...);
         },
         detail::zip_tuples(typename util::meta_of<T>::type{}, typename util::meta_of<std::decay_t<U>>::type{}));
   }

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -70,9 +70,7 @@ struct message_merger {
 
     return std::apply(
         [&, this](auto &&...metas) {
-          (this->perform(metas, metas.first.get(dest),
-                         conditional_move(metas.second.get(source_ref))),
-           ...);
+          (this->perform(metas, metas.first.get(dest), conditional_move(metas.second.get(source_ref))), ...);
         },
         detail::zip_tuples(typename util::meta_of<T>::type{}, typename util::meta_of<std::decay_t<U>>::type{}));
   }

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -66,10 +66,13 @@ struct message_merger {
         return (src_field);
       }
     };
+    auto &&source_ref = std::forward<U>(source);
 
     return std::apply(
         [&, this](auto &&...metas) {
-          (this->perform(metas, metas.first.get(dest), conditional_move(metas.second.get(source))), ...);
+          (this->perform(metas, metas.first.get(dest),
+                         conditional_move(metas.second.get(source_ref))),
+           ...);
         },
         detail::zip_tuples(typename util::meta_of<T>::type{}, typename util::meta_of<std::decay_t<U>>::type{}));
   }


### PR DESCRIPTION
## Summary

Tighten merge semantics and deserialization behavior, and add a compile-time guard for JSON parsing of `optional_indirect_view_ref`.

## What changed

- Updated `merge.hpp` so source fields are moved only when `merge()` is called with an rvalue source.
- Removed the redundant enum-specific `basic_in::deserialize()` overload in `binpb/deserialize.hpp` so enum decoding uses the shared varint path.
- Added a `static_assert` in `json.hpp` to require nothrow-constructible types when parsing `optional_indirect_view_ref`.

## Why

These changes make the implementation more precise and safer:

- lvalue merges should preserve reference semantics and avoid unintended moves
- enum deserialization should follow the same shared path as the rest of the varint-based decoder
- allocator-backed JSON construction for indirect views should fail at compile time for unsupported types instead of deferring to a runtime failure

## Testing

- Not run in this pass

## Notes

- The merge change is intended to preserve existing lvalue behavior while allowing efficient moves from rvalue sources.
- The JSON guard is a compile-time constraint only; it does not change runtime behavior for supported types.