### PR TITLE
Add HPP_PROTO_USE_SYSTEM_PACKAGES configure option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(HPP_PROTO_CORE_TESTS_ONLY "Build only unittests targets (core tests only)
 # The following options are internal and not part of the public interface.
 option(HPP_PROTO_BENCHMARKS "Enable building benchmarks" OFF)
 option(HPP_PROTO_FUZZER_ONLY "Build only fuzzers and their dependencies" OFF)
+option(HPP_PROTO_USE_SYSTEM_PACKAGES "Use system-installed packages instead of fetching via CPM" OFF)
 
 if(HPP_PROTO_CORE_TESTS_ONLY AND HPP_PROTO_FUZZER_ONLY)
   message(FATAL_ERROR "HPP_PROTO_CORE_TESTS_ONLY and HPP_PROTO_FUZZER_ONLY cannot both be ON")
@@ -87,7 +88,11 @@ target_sources(hpp_proto_core INTERFACE
   BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
   FILES ${HPP_PROTO_CORE_PUBLIC_HEADERS})
 
-target_link_libraries(hpp_proto_core INTERFACE is_utf8)
+if (HPP_PROTO_BUNDLED_IS_UTF8)
+  target_link_libraries(hpp_proto_core INTERFACE is_utf8)
+else()
+  target_link_libraries(hpp_proto_core INTERFACE is_utf8::is_utf8)
+endif()
 add_library(hpp_proto::hpp_proto_core ALIAS hpp_proto_core)
 if(NOT HPP_PROTO_CORE_TESTS_ONLY)
   install(TARGETS hpp_proto_core EXPORT hpp_proto-targets

--- a/cmake/hpp_proto_install_package.cmake
+++ b/cmake/hpp_proto_install_package.cmake
@@ -26,10 +26,12 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpp_proto/hpp_proto-config.
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/protobuf_generate_hpp.cmake"
   DESTINATION "lib/cmake/hpp_proto")
 
-install(
-  TARGETS is_utf8
-  EXPORT hpp_proto-targets
-)
+if(HPP_PROTO_BUNDLED_IS_UTF8)
+  install(
+    TARGETS is_utf8
+    EXPORT hpp_proto-targets
+  )
+endif()
 
 install(EXPORT hpp_proto-targets
   DESTINATION lib/cmake/hpp_proto

--- a/hpp_proto-config.cmake.in
+++ b/hpp_proto-config.cmake.in
@@ -5,6 +5,7 @@ get_filename_component(_hpp_proto_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." AB
 set(HPP_PROTO_ROOT "${_hpp_proto_prefix}")
 
 find_dependency(glaze)
+find_dependency(is_utf8)
 include("${CMAKE_CURRENT_LIST_DIR}/hpp_proto-targets.cmake")
 
 if(NOT TARGET hpp_proto::protoc)

--- a/third-parties.cmake
+++ b/third-parties.cmake
@@ -7,31 +7,47 @@ if(CMAKE_VERSION GREATER_EQUAL 3.25)
 endif()
 
 set(HPP_PROTO_GLAZE_VERSION 7.2.0)
-CPMAddPackage(
-    NAME glaze
-    GIT_TAG v${HPP_PROTO_GLAZE_VERSION}
-    GITHUB_REPOSITORY stephenberry/glaze
-    ${system_package}
-)
-if(glaze_ADDED)
+set(HPP_PROTO_BUNDLED_GLAZE OFF)
+if(HPP_PROTO_USE_SYSTEM_PACKAGES)
+    find_package(glaze CONFIG REQUIRED)
+else()
+    set(HPP_PROTO_BUNDLED_GLAZE ON)
+    CPMAddPackage(
+        NAME glaze
+        GIT_TAG v${HPP_PROTO_GLAZE_VERSION}
+        GITHUB_REPOSITORY stephenberry/glaze
+        ${system_package}
+    )
+endif()
+if(HPP_PROTO_BUNDLED_GLAZE AND glaze_ADDED)
     install(SCRIPT "${glaze_BINARY_DIR}/cmake_install.cmake")
 endif()
 
-CPMAddPackage(
-    NAME is_utf8
-    VERSION 1.4.1
-    GITHUB_REPOSITORY simdutf/is_utf8
-    DOWNLOAD_ONLY ON
-)
-add_subdirectory(${is_utf8_SOURCE_DIR}/src ${is_utf8_BINARY_DIR})
-target_compile_features(is_utf8 PRIVATE cxx_std_20)
-get_target_property(IS_UTF8_COMPILER_OPTIONS is_utf8 COMPILE_OPTIONS)
+set(HPP_PROTO_BUNDLED_IS_UTF8 OFF)
+if(HPP_PROTO_USE_SYSTEM_PACKAGES)
+    find_package(is_utf8 CONFIG REQUIRED)
+else()
+    set(HPP_PROTO_BUNDLED_IS_UTF8 ON)
+    CPMAddPackage(
+        NAME is_utf8
+        VERSION 1.4.1
+        GITHUB_REPOSITORY simdutf/is_utf8
+        DOWNLOAD_ONLY ON
+    )
+    add_subdirectory(${is_utf8_SOURCE_DIR}/src ${is_utf8_BINARY_DIR})
+    target_compile_features(is_utf8 PRIVATE cxx_std_20)
+    get_target_property(IS_UTF8_COMPILER_OPTIONS is_utf8 COMPILE_OPTIONS)
+endif()
 
 if(IS_UTF8_COMPILER_OPTIONS MATCHES "fsanitize=address")
     message(FATAL_ERROR "is_utf8 is not compatible with address sanitizer")
 endif()
 
-set_target_properties(is_utf8 PROPERTIES CXX_CLANG_TIDY "")
+if(HPP_PROTO_BUNDLED_IS_UTF8)
+    set_target_properties(is_utf8 PROPERTIES CXX_CLANG_TIDY "")
+else()
+    set_target_properties(is_utf8::is_utf8 PROPERTIES CXX_CLANG_TIDY "")
+endif()
 
 set(HPP_PROTO_PROTOC_VERSION "34.0")
 


### PR DESCRIPTION
## Summary

Adds new CMake option `HPP_PROTO_USE_SYSTEM_PACKAGES` to detect dependencies with `find_package`

## What changed

- Added new CMake option `HPP_PROTO_USE_SYSTEM_PACKAGES` - off by default

## Why

Installing with `cmake --install` currently also exports glaze headers and the is_utf8 library. I'm hoping to create an MSYS2 package for this library when I get the chance, so it'd be great if there was a way to export only the relevant files instead

## Testing

- Build script: https://github.com/llm96/hpp-proto-system-pkg-test/blob/master/build.sh
- Test log: https://github.com/llm96/hpp-proto-system-pkg-test/actions/runs/24957819041/job/73079052782

Also tested using FetchContent as described in README.md with my fork/branch, which still works as expected

## Notes

N/A