### PR TITLE
use std::unreachable directly

### DIFF
--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -32,19 +32,6 @@
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 namespace hpp_proto {
-
-[[noreturn]] inline void unreachable() {
-#if __cpp_lib_unreachable
-  std::unreachable();
-#else
-#if defined(_MSC_VER) && !defined(__clang__) // MSVC
-  __assume(false);
-#else                                        // GCC, Clang
-  __builtin_unreachable();
-#endif
-#endif
-}
-
 namespace concepts {
 template <typename T>
 concept is_padded_input_context = is_pb_context<T> && requires { typename T::padded_input; };
@@ -1245,7 +1232,7 @@ constexpr status deserialize_oneof(uint32_t tag, auto &&item, concepts::is_basic
       return deserialize_oneof<Index + 1, Meta>(tag, std::forward<decltype(item)>(item), archive, unknown_fields);
     }
   } else {
-    unreachable();
+    std::unreachable();
     return {};
   }
 }

--- a/include/hpp_proto/dynamic_message/field_visit.hpp
+++ b/include/hpp_proto/dynamic_message/field_visit.hpp
@@ -112,7 +112,7 @@ inline auto field_cref::visit(auto &&visitor) const {
   case KIND_REPEATED_SINT64:
     return visitor(repeated_sint64_field_cref{*descriptor_, *storage_});
   }
-  unreachable();
+  std::unreachable();
 }
 
 inline auto field_mref::visit(auto &&visitor) const {
@@ -186,7 +186,7 @@ inline auto field_mref::visit(auto &&visitor) const {
   case KIND_REPEATED_SINT64:
     return visitor(repeated_sint64_field_mref{*descriptor_, *storage_, *memory_resource_});
   }
-  unreachable();
+  std::unreachable();
 }
 
 inline void field_mref::clone_from(const field_cref &other) const {

--- a/include/hpp_proto/json/util.hpp
+++ b/include/hpp_proto/json/util.hpp
@@ -405,7 +405,7 @@ template <auto Opts>
       }
     }
   }
-  unreachable();
+  std::unreachable();
 }
 
 template <auto Opts>


### PR DESCRIPTION
## Summary

Replace the local unreachable helper with direct calls to `std::unreachable`. This keeps unreachable code paths on the standard library facility and removes the custom compiler-specific fallback.

## What changed

- Removed the custom `hpp_proto::unreachable()` helper from `binpb/deserialize.hpp`
- Replaced unreachable paths in binary protobuf deserialization with `std::unreachable()`
- Replaced unreachable paths in dynamic field visitation and JSON utility code with `std::unreachable()`

## Why

The project can now rely on `std::unreachable`, so the local wrapper and compiler-specific fallback are no longer needed. Using the standard facility simplifies the code and avoids maintaining duplicate unreachable handling.

## Testing

- Not run; PR description drafted from commit `d3277c4`
- Existing behavior should be unchanged for valid control flow

## Notes

- Requires compiler/library support for `std::unreachable`
- No user-facing behavior changes expected
