### PR TITLE
 Support for building with `CPM_LOCAL_PACKAGES_ONLY=ON`

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -73,7 +73,9 @@ jobs:
 
           git clone --depth 1 --branch v1.4.1 https://github.com/simdutf/is_utf8.git /tmp/is_utf8
           sed -i '/add_subdirectory(benchmarks)/d' /tmp/is_utf8/CMakeLists.txt
-          sed -i '/mark_as_advanced(IS_UTF8_INSTALL_CMAKEDIR)/a install(EXPORT is_utf8Targets DESTINATION "${IS_UTF8_INSTALL_CMAKEDIR}" NAMESPACE is_utf8:: COMPONENT is_utf8_Development)' /tmp/is_utf8/CMakeLists.txt
+          cmake_install_export='install(EXPORT is_utf8Targets DESTINATION "@IS_UTF8_INSTALL_CMAKEDIR@" NAMESPACE is_utf8:: COMPONENT is_utf8_Development)'
+          cmake_install_export="${cmake_install_export//@IS_UTF8_INSTALL_CMAKEDIR@/\${IS_UTF8_INSTALL_CMAKEDIR}}"
+          sed -i "/mark_as_advanced(IS_UTF8_INSTALL_CMAKEDIR)/a ${cmake_install_export}" /tmp/is_utf8/CMakeLists.txt
           cmake -S /tmp/is_utf8 -B /tmp/is_utf8-build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=OFF

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -72,10 +72,7 @@ jobs:
           sudo cmake --install /tmp/glaze-build
 
           git clone --depth 1 --branch v1.4.1 https://github.com/simdutf/is_utf8.git /tmp/is_utf8
-          sed -i '/add_subdirectory(benchmarks)/d' /tmp/is_utf8/CMakeLists.txt
-          cmake_install_export='install(EXPORT is_utf8Targets DESTINATION "@IS_UTF8_INSTALL_CMAKEDIR@" NAMESPACE is_utf8:: COMPONENT is_utf8_Development)'
-          cmake_install_export="${cmake_install_export//@IS_UTF8_INSTALL_CMAKEDIR@/\${IS_UTF8_INSTALL_CMAKEDIR}}"
-          sed -i "/mark_as_advanced(IS_UTF8_INSTALL_CMAKEDIR)/a ${cmake_install_export}" /tmp/is_utf8/CMakeLists.txt
+          python3 -c 'from pathlib import Path; p = Path("/tmp/is_utf8/CMakeLists.txt"); s = p.read_text(); s = s.replace("add_subdirectory(benchmarks)\n", ""); marker = "mark_as_advanced(IS_UTF8_INSTALL_CMAKEDIR)\n"; export = "install(EXPORT is_utf8Targets DESTINATION " + chr(34) + "$" + "{IS_UTF8_INSTALL_CMAKEDIR}" + chr(34) + " NAMESPACE is_utf8:: COMPONENT is_utf8_Development)\n"; p.write_text(s.replace(marker, marker + export))'
           cmake -S /tmp/is_utf8 -B /tmp/is_utf8-build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=OFF

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -27,8 +27,10 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         gcc: [13]
+        cpm-local-packages-only: ["OFF", "ON"]
 
     steps:
       - uses: actions/checkout@v6
@@ -44,24 +46,42 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.cpm-local-packages-only }}-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
         uses: actions/cache@v5
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-ccache-${{ github.sha }}
+          key: ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-${{ matrix.cpm-local-packages-only }}-ccache-${{ github.sha }}
           restore-keys: |
-            ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-ccache-
+            ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-${{ matrix.cpm-local-packages-only }}-ccache-
 
       - name: install protoc
         run: |
           sudo apt-get update
           sudo apt install -y git protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
 
+      - name: install CPM local packages
+        if: matrix.cpm-local-packages-only == 'ON'
+        run: |
+          git clone --depth 1 --branch v7.2.0 https://github.com/stephenberry/glaze.git /tmp/glaze
+          cmake -S /tmp/glaze -B /tmp/glaze-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -Dglaze_DEVELOPER_MODE=OFF \
+            -Dglaze_BUILD_EXAMPLES=OFF
+          sudo cmake --install /tmp/glaze-build
+
+          git clone --depth 1 --branch v1.4.1 https://github.com/simdutf/is_utf8.git /tmp/is_utf8
+          sed -i '/add_subdirectory(benchmarks)/d' /tmp/is_utf8/CMakeLists.txt
+          sed -i '/mark_as_advanced(IS_UTF8_INSTALL_CMAKEDIR)/a install(EXPORT is_utf8Targets DESTINATION "${IS_UTF8_INSTALL_CMAKEDIR}" NAMESPACE is_utf8:: COMPONENT is_utf8_Development)' /tmp/is_utf8/CMakeLists.txt
+          cmake -S /tmp/is_utf8 -B /tmp/is_utf8-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=OFF
+          sudo cmake --build /tmp/is_utf8-build --target install
+
       - name: build and install library
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DHPP_PROTO_TESTS=OFF
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DHPP_PROTO_TESTS=OFF -DCPM_LOCAL_PACKAGES_ONLY=${{ matrix.cpm-local-packages-only }}
           sudo cmake --build build --target install
 
       - name: configure

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ obj/
 .env.*
 .audit
 fuzz/__pycache__/
+graphify-out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,11 @@ target_sources(hpp_proto_core INTERFACE
   BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
   FILES ${HPP_PROTO_CORE_PUBLIC_HEADERS})
 
-target_link_libraries(hpp_proto_core INTERFACE is_utf8)
+if(is_utf8_ADDED)
+  target_link_libraries(hpp_proto_core INTERFACE is_utf8)
+else()
+  target_link_libraries(hpp_proto_core INTERFACE is_utf8::is_utf8)
+endif()
 add_library(hpp_proto::hpp_proto_core ALIAS hpp_proto_core)
 if(NOT HPP_PROTO_CORE_TESTS_ONLY)
   install(TARGETS hpp_proto_core EXPORT hpp_proto-targets

--- a/README.md
+++ b/README.md
@@ -186,6 +186,33 @@ cmake --build build
 
 You should see output indicating that both binary and JSON round-trips were successful.
 
+### Using System-Installed Dependencies
+
+By default, `hpp-proto` uses CPM to fetch missing third-party dependencies. If you want the build to use only packages that are already installed on the system, configure with `CPM_LOCAL_PACKAGES_ONLY=ON`:
+
+```bash
+cmake -B build \
+  -DCPM_LOCAL_PACKAGES_ONLY=ON \
+  -DHPP_PROTO_TESTS=OFF
+```
+
+In this mode, both `glaze` and `is_utf8` must be discoverable through CMake package config files before configuring `hpp-proto`:
+
+```cmake
+find_package(glaze CONFIG REQUIRED)
+find_package(is_utf8 CONFIG REQUIRED)
+```
+
+`glaze` v7.2.0 installs a usable CMake package config. As of `simdutf/is_utf8` v1.4.1, the upstream install rules need a small fix before `find_package(is_utf8 CONFIG REQUIRED)` works: `is_utf8-config.cmake` includes `is_utf8Targets.cmake`, but the project does not install that export file by default. When packaging or installing `is_utf8` yourself, add an export install rule equivalent to:
+
+```cmake
+install(EXPORT is_utf8Targets
+  DESTINATION "${IS_UTF8_INSTALL_CMAKEDIR}"
+  NAMESPACE is_utf8::)
+```
+
+The install workflow in this repository applies that local patch when testing `CPM_LOCAL_PACKAGES_ONLY=ON`.
+
 ## Documentation
 
 * [Front-End API Guide](docs/frontend_apis.md): `read/write` binary+JSON APIs, sink modes, and allocator/cache options.

--- a/cmake/hpp_proto_install_package.cmake
+++ b/cmake/hpp_proto_install_package.cmake
@@ -18,18 +18,18 @@ if(HPP_PROTO_PROTOC STREQUAL "compile")
 endif()
 
 
-
-
 configure_file(hpp_proto-config.cmake.in lib/cmake/hpp_proto/hpp_proto-config.cmake @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpp_proto/hpp_proto-config.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/hpp_proto/hpp_proto-config-version.cmake"
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/protobuf_generate_hpp.cmake"
   DESTINATION "lib/cmake/hpp_proto")
 
-install(
-  TARGETS is_utf8
-  EXPORT hpp_proto-targets
-)
+if(is_utf8_ADDED)
+  install(
+    TARGETS is_utf8
+    EXPORT hpp_proto-targets
+  )
+endif()
 
 install(EXPORT hpp_proto-targets
   DESTINATION lib/cmake/hpp_proto

--- a/hpp_proto-config.cmake.in
+++ b/hpp_proto-config.cmake.in
@@ -5,6 +5,9 @@ get_filename_component(_hpp_proto_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." AB
 set(HPP_PROTO_ROOT "${_hpp_proto_prefix}")
 
 find_dependency(glaze)
+if(NOT @is_utf8_ADDED@)
+    find_dependency(is_utf8)
+endif()
 include("${CMAKE_CURRENT_LIST_DIR}/hpp_proto-targets.cmake")
 
 if(NOT TARGET hpp_proto::protoc)

--- a/third-parties.cmake
+++ b/third-parties.cmake
@@ -17,21 +17,27 @@ if(glaze_ADDED)
     install(SCRIPT "${glaze_BINARY_DIR}/cmake_install.cmake")
 endif()
 
-CPMAddPackage(
-    NAME is_utf8
-    VERSION 1.4.1
-    GITHUB_REPOSITORY simdutf/is_utf8
-    DOWNLOAD_ONLY ON
-)
-add_subdirectory(${is_utf8_SOURCE_DIR}/src ${is_utf8_BINARY_DIR})
-target_compile_features(is_utf8 PRIVATE cxx_std_20)
-get_target_property(IS_UTF8_COMPILER_OPTIONS is_utf8 COMPILE_OPTIONS)
+if(NOT CPM_LOCAL_PACKAGES_ONLY)
+    CPMAddPackage(
+        NAME is_utf8
+        VERSION 1.4.1
+        GITHUB_REPOSITORY simdutf/is_utf8
+        DOWNLOAD_ONLY ON
+    )
+    add_subdirectory(${is_utf8_SOURCE_DIR}/src ${is_utf8_BINARY_DIR})
+    add_library(is_utf8::is_utf8 ALIAS is_utf8)
+    target_compile_features(is_utf8 PRIVATE cxx_std_20)
+    get_target_property(IS_UTF8_COMPILER_OPTIONS is_utf8 COMPILE_OPTIONS)
 
-if(IS_UTF8_COMPILER_OPTIONS MATCHES "fsanitize=address")
-    message(FATAL_ERROR "is_utf8 is not compatible with address sanitizer")
+    if(IS_UTF8_COMPILER_OPTIONS MATCHES "fsanitize=address")
+        message(FATAL_ERROR "is_utf8 is not compatible with address sanitizer")
+    endif()
+
+    set_target_properties(is_utf8 PROPERTIES CXX_CLANG_TIDY "")
+else()
+    find_package(is_utf8 CONFIG REQUIRED)
+    set(is_utf8_ADDED OFF)
 endif()
-
-set_target_properties(is_utf8 PROPERTIES CXX_CLANG_TIDY "")
 
 set(HPP_PROTO_PROTOC_VERSION "34.0")
 


### PR DESCRIPTION
**Summary**

- Add support for building `hpp-proto` with `CPM_LOCAL_PACKAGES_ONLY=ON`.
- Allow `is_utf8` to be consumed as a system-installed CMake package instead of always being bundled by CPM.
- Update install CI to test both CPM fallback mode and local-package-only mode.
- Document how to use system-installed `glaze` and `is_utf8`.

**Details**

- `third-parties.cmake` now uses `find_package(is_utf8 CONFIG REQUIRED)` when `CPM_LOCAL_PACKAGES_ONLY=ON`.
- `hpp_proto_core` links either the bundled `is_utf8` target or external `is_utf8::is_utf8`, depending on how the dependency was resolved.
- Installed `hpp_proto-config.cmake` now calls `find_dependency(is_utf8)` only when `is_utf8` is external.
- `is_utf8` is only installed/exported as part of `hpp-proto` when it was bundled by CPM.
- `.github/workflows/install.yml` now runs an `OFF`/`ON` matrix for `CPM_LOCAL_PACKAGES_ONLY`.
- The `ON` CI leg explicitly builds and installs `glaze` and `is_utf8`.
- The workflow patches `simdutf/is_utf8` v1.4.1 locally because upstream’s config references `is_utf8Targets.cmake` but does not install that export file.
