### PR TITLE
Fix timestamp JSON validation for invalid day values

### DIFF
--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -319,7 +319,6 @@ struct from<JSON, hpp_proto::optional_indirect_view_ref<T>> {
       void *addr = ctx.memory_resource().allocate(sizeof(type), alignof(type));
       static_assert(std::is_nothrow_constructible_v<type>);
       auto *obj = new (addr) type; // NOLINT(cppcoreguidelines-owning-memory)
-      constexpr auto Opts = ws_handled_off<Options>();
       parse<JSON>::op<Options>(*obj, ctx, it, end);
       value.ref = obj;
     }

--- a/include/hpp_proto/json/timestamp_codec.hpp
+++ b/include/hpp_proto/json/timestamp_codec.hpp
@@ -76,7 +76,7 @@ private:
     if (yy <= 0 || mm <= 0 || dd <= 0 || hh < 0 || mn < 0 || ss < 0) {
       return false;
     }
-    if (mm > 12 || hh > 23 || mn > 59 || ss > 59) {
+    if (mm > 12 || dd > 31 || hh > 23 || mn > 59 || ss > 59) {
       return false;
     }
     return true;


### PR DESCRIPTION
**Summary**

- Reject malformed timestamp strings with day values greater than `31`.
- Remove an unused local `Opts` constant from JSON parsing code.

**Details**

- `timestamp_codec` already validated year, month, hour, minute, and second ranges, but did not reject impossible day values like `2024-01-99T00:00:00Z`.
- This adds the missing `dd > 31` guard to the timestamp component validation.
- Also removes an unused `Opts` variable in `include/hpp_proto/json.hpp`.
