### PR TITLE
Strengthen internal serialization preconditions

### DIFF
--- a/include/hpp_proto/binpb/varint.hpp
+++ b/include/hpp_proto/binpb/varint.hpp
@@ -117,7 +117,7 @@ template <concepts::varint VarintType, concepts::byte_type Byte>
 // NOLINTBEGIN
 template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 [[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
-                                      int64_t &res1) -> decltype(std::ranges::cdata(input)) {
+                                                    int64_t &res1) -> decltype(std::ranges::cdata(input)) {
   // The algorithm relies on sign extension for each byte to set all high bits
   // when the varint continues. It also relies on asserting all of the lower
   // bits for each successive byte read. This allows the result to be aggregated
@@ -251,7 +251,7 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 }
 
 [[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                    bool &value) -> decltype(std::ranges::cdata(input)) {
+                                                  bool &value) -> decltype(std::ranges::cdata(input)) {
   // This function is adapted from
   // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_tctable_lite.cc
   auto p = std::ranges::cdata(input);
@@ -309,12 +309,13 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 // NOLINTEND
 
 [[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                    boolean &value) -> decltype(std::ranges::cdata(input)) {
+                                                  boolean &value) -> decltype(std::ranges::cdata(input)) {
   return unchecked_parse_bool(input, value.value);
 }
 
 template <concepts::varint VarintType>
-[[nodiscard]] constexpr auto unchecked_parse_varint(concepts::contiguous_byte_range auto const &input, VarintType &item) {
+[[nodiscard]] constexpr auto unchecked_parse_varint(concepts::contiguous_byte_range auto const &input,
+                                                    VarintType &item) {
   int64_t res; // NOLINT(cppcoreguidelines-init-variables)
   if constexpr (varint_encoding::zig_zag == VarintType::encoding) {
     auto p = shift_mix_parse_varint<typename VarintType::value_type>(input, res);

--- a/include/hpp_proto/binpb/varint.hpp
+++ b/include/hpp_proto/binpb/varint.hpp
@@ -90,7 +90,7 @@ concept varint = requires { requires std::same_as<T, hpp_proto::varint<typename 
 } // namespace concepts
 
 template <concepts::varint VarintType, concepts::byte_type Byte>
-constexpr Byte *unchecked_pack_varint(VarintType item, Byte *data) {
+[[nodiscard]] constexpr Byte *unchecked_pack_varint(VarintType item, Byte *data) {
   auto value = std::make_unsigned_t<typename VarintType::encode_type>(item.value);
   if constexpr (varint_encoding::zig_zag == decltype(item)::encoding) {
     // NOLINTNEXTLINE(hicpp-signed-bitwise)
@@ -116,7 +116,7 @@ constexpr Byte *unchecked_pack_varint(VarintType item, Byte *data) {
 // pointer passed the consumed input data.
 // NOLINTBEGIN
 template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
-constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
+[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
                                       int64_t &res1) -> decltype(std::ranges::cdata(input)) {
   // The algorithm relies on sign extension for each byte to set all high bits
   // when the varint continues. It also relies on asserting all of the lower
@@ -250,7 +250,7 @@ constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const
   return done2();
 }
 
-constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
                                     bool &value) -> decltype(std::ranges::cdata(input)) {
   // This function is adapted from
   // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_tctable_lite.cc
@@ -308,13 +308,13 @@ constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &
 }
 // NOLINTEND
 
-constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
                                     boolean &value) -> decltype(std::ranges::cdata(input)) {
   return unchecked_parse_bool(input, value.value);
 }
 
 template <concepts::varint VarintType>
-constexpr auto unchecked_parse_varint(concepts::contiguous_byte_range auto const &input, VarintType &item) {
+[[nodiscard]] constexpr auto unchecked_parse_varint(concepts::contiguous_byte_range auto const &input, VarintType &item) {
   int64_t res; // NOLINT(cppcoreguidelines-init-variables)
   if constexpr (varint_encoding::zig_zag == VarintType::encoding) {
     auto p = shift_mix_parse_varint<typename VarintType::value_type>(input, res);

--- a/include/hpp_proto/json/field_mask_codec.hpp
+++ b/include/hpp_proto/json/field_mask_codec.hpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #pragma once
+#include <cassert>
 #include <array>
 #include <cstdint>
 #include <glaze/util/parse.hpp>
@@ -92,6 +93,7 @@ struct field_mask_codec {
     if (value.paths.empty()) {
       return 0;
     }
+    assert(b.size() >= max_encode_size(value));
     auto buffer = std::span{std::forward<decltype(b)>(b)};
     auto cur = buffer.begin();
     using out_type = std::remove_cvref_t<decltype(*cur)>;

--- a/include/hpp_proto/json/field_mask_codec.hpp
+++ b/include/hpp_proto/json/field_mask_codec.hpp
@@ -21,8 +21,8 @@
 // SOFTWARE.
 
 #pragma once
-#include <cassert>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <glaze/util/parse.hpp>
 #include <hpp_proto/memory_resource_utils.hpp>

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -300,9 +300,7 @@ public:
   constexpr reference operator[](std::size_t n) { return data()[n]; }
   [[nodiscard]] constexpr std::size_t size() const { return view_.size(); }
   [[nodiscard]] constexpr bool empty() const { return view_.empty(); }
-  [[nodiscard]] constexpr value_type *begin() const {
-    return data();
-  }
+  [[nodiscard]] constexpr value_type *begin() const { return data(); }
   [[nodiscard]] constexpr value_type *end() const { return data() + size(); }
 
   constexpr reference front() { return data()[0]; }

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -297,17 +297,16 @@ public:
     assert(empty() || data_ != nullptr);
     return data_;
   }
-  constexpr reference operator[](std::size_t n) { return data_[n]; }
+  constexpr reference operator[](std::size_t n) { return data()[n]; }
   [[nodiscard]] constexpr std::size_t size() const { return view_.size(); }
   [[nodiscard]] constexpr bool empty() const { return view_.empty(); }
   [[nodiscard]] constexpr value_type *begin() const {
-    assert(empty() || data_ != nullptr);
-    return data_;
+    return data();
   }
-  [[nodiscard]] constexpr value_type *end() const { return data_ + size(); }
+  [[nodiscard]] constexpr value_type *end() const { return data() + size(); }
 
-  constexpr reference front() { return data_[0]; }
-  constexpr reference back() { return data_[size() - 1]; }
+  constexpr reference front() { return data()[0]; }
+  constexpr reference back() { return data()[size() - 1]; }
 
   constexpr void push_back(const value_type &v) { emplace_back(v); }
 

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -22,7 +22,9 @@
 
 #pragma once
 
+#include <cassert>
 #include <concepts>
+#include <functional>
 #include <cstring>
 #include <hpp_proto/field_types.hpp>
 #include <memory_resource>
@@ -102,11 +104,13 @@ public:
   [[nodiscard]] std::pmr::memory_resource &cache_memory_resource() const { return *mr; }
 };
 
+template <std::size_t StackBufferSize = 1024>
 class default_cache_memory_resource {
-  std::array<std::byte, 1024> stack_buffer{};
+  std::array<std::byte, StackBufferSize> stack_buffer{};
   std::pmr::monotonic_buffer_resource mr;
 
 public:
+  // Allocations beyond StackBufferSize fall back to std::pmr::get_default_resource().
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
   default_cache_memory_resource() : mr(stack_buffer.data(), stack_buffer.size(), std::pmr::get_default_resource()) {}
   ~default_cache_memory_resource() = default;
@@ -125,10 +129,14 @@ struct pb_context : T::option_type... {
 
   template <concepts::is_option_type U>
   [[nodiscard]] constexpr auto &get() const {
-    if constexpr (std::derived_from<pb_context, U>) {
-      return static_cast<const U &>(*this);
+    using option_type = std::remove_cvref_t<U>;
+    static_assert(std::derived_from<pb_context, option_type> ||
+                      std::derived_from<pb_context, std::reference_wrapper<option_type>>,
+                  "Requested option type is not stored in pb_context");
+    if constexpr (std::derived_from<pb_context, option_type>) {
+      return static_cast<const option_type &>(*this);
     } else {
-      return static_cast<const std::reference_wrapper<U> &>(*this).get();
+      return static_cast<const std::reference_wrapper<option_type> &>(*this).get();
     }
   }
 
@@ -285,11 +293,17 @@ public:
     return *this;
   }
 
-  [[nodiscard]] constexpr value_type *data() const { return data_; }
+  [[nodiscard]] constexpr value_type *data() const {
+    assert(data_ != nullptr);
+    return data_;
+  }
   constexpr reference operator[](std::size_t n) { return data_[n]; }
   [[nodiscard]] constexpr std::size_t size() const { return view_.size(); }
   [[nodiscard]] constexpr bool empty() const { return view_.empty(); }
-  [[nodiscard]] constexpr value_type *begin() const { return data_; }
+  [[nodiscard]] constexpr value_type *begin() const {
+    assert(data_ != nullptr);
+    return data_;
+  }
   [[nodiscard]] constexpr value_type *end() const { return data_ + size(); }
 
   constexpr reference front() { return data_[0]; }
@@ -351,6 +365,7 @@ public:
   }
 
   constexpr void append_raw_data(concepts::contiguous_byte_range auto const &data) {
+    assert((data.size() % sizeof(value_type)) == 0);
     auto old_size = view_.size();
     auto num_elements = data.size() / sizeof(value_type);
     assign_range_with_size(view_, old_size + num_elements);

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -24,8 +24,8 @@
 
 #include <cassert>
 #include <concepts>
-#include <functional>
 #include <cstring>
+#include <functional>
 #include <hpp_proto/field_types.hpp>
 #include <memory_resource>
 #include <ranges>
@@ -301,7 +301,7 @@ public:
   [[nodiscard]] constexpr std::size_t size() const { return view_.size(); }
   [[nodiscard]] constexpr bool empty() const { return view_.empty(); }
   [[nodiscard]] constexpr value_type *begin() const {
-    assert(empty() || data_ != nullptr );
+    assert(empty() || data_ != nullptr);
     return data_;
   }
   [[nodiscard]] constexpr value_type *end() const { return data_ + size(); }

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -294,14 +294,14 @@ public:
   }
 
   [[nodiscard]] constexpr value_type *data() const {
-    assert(data_ != nullptr);
+    assert(empty() || data_ != nullptr);
     return data_;
   }
   constexpr reference operator[](std::size_t n) { return data_[n]; }
   [[nodiscard]] constexpr std::size_t size() const { return view_.size(); }
   [[nodiscard]] constexpr bool empty() const { return view_.empty(); }
   [[nodiscard]] constexpr value_type *begin() const {
-    assert(data_ != nullptr);
+    assert(empty() || data_ != nullptr );
     return data_;
   }
   [[nodiscard]] constexpr value_type *end() const { return data_ + size(); }


### PR DESCRIPTION
## Summary
This PR tightens a few internal contracts around serialization helpers and PMR-backed utilities.

## Changes
- Marks unchecked varint pack/parse helpers as `[[nodiscard]]` so callers do not accidentally ignore the advanced input/output pointer.
- Adds an assertion that field-mask JSON encoding receives a buffer large enough for `max_encode_size`.
- Makes `default_cache_memory_resource` stack buffer size configurable via a template parameter.
- Makes `pb_context::get<T>()` validate at compile time that the requested option type is actually stored.
- Adds debug assertions for `arena_vector` raw access and raw byte append preconditions.
