### PR TITLE
Preserve allocator-aware optional_indirect swap semantics

### DIFF
--- a/include/hpp_proto/binpb/varint.hpp
+++ b/include/hpp_proto/binpb/varint.hpp
@@ -116,8 +116,8 @@ template <concepts::varint VarintType, concepts::byte_type Byte>
 // pointer passed the consumed input data.
 // NOLINTBEGIN
 template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
-[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input, int64_t &res1)
-    -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
+                                                    int64_t &res1) -> decltype(std::ranges::cdata(input)) {
   // The algorithm relies on sign extension for each byte to set all high bits
   // when the varint continues. It also relies on asserting all of the lower
   // bits for each successive byte read. This allows the result to be aggregated
@@ -250,8 +250,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
   return done2();
 }
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, bool &value)
-    -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
+                                                  bool &value) -> decltype(std::ranges::cdata(input)) {
   // This function is adapted from
   // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_tctable_lite.cc
   auto p = std::ranges::cdata(input);
@@ -308,8 +308,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 }
 // NOLINTEND
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, boolean &value)
-    -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
+                                                  boolean &value) -> decltype(std::ranges::cdata(input)) {
   return unchecked_parse_bool(input, value.value);
 }
 

--- a/include/hpp_proto/binpb/varint.hpp
+++ b/include/hpp_proto/binpb/varint.hpp
@@ -116,8 +116,8 @@ template <concepts::varint VarintType, concepts::byte_type Byte>
 // pointer passed the consumed input data.
 // NOLINTBEGIN
 template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
-[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
-                                                    int64_t &res1) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input, int64_t &res1)
+    -> decltype(std::ranges::cdata(input)) {
   // The algorithm relies on sign extension for each byte to set all high bits
   // when the varint continues. It also relies on asserting all of the lower
   // bits for each successive byte read. This allows the result to be aggregated
@@ -250,8 +250,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
   return done2();
 }
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                                  bool &value) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, bool &value)
+    -> decltype(std::ranges::cdata(input)) {
   // This function is adapted from
   // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_tctable_lite.cc
   auto p = std::ranges::cdata(input);
@@ -308,12 +308,16 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 }
 // NOLINTEND
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                                  boolean &value) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, boolean &value)
+    -> decltype(std::ranges::cdata(input)) {
   return unchecked_parse_bool(input, value.value);
 }
 
 template <concepts::varint VarintType>
+// This parser writes the decoded value into `item` before the caller knows
+// whether the input was fully consumed. Callers must check the returned
+// pointer against the input end before using `item`; on failure, the stored
+// value should be treated as invalid.
 [[nodiscard]] constexpr auto unchecked_parse_varint(concepts::contiguous_byte_range auto const &input,
                                                     VarintType &item) {
   int64_t res; // NOLINT(cppcoreguidelines-init-variables)

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -245,6 +245,9 @@ struct message_merger {
     requires requires { typename T::mapped_type; }
   // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
   constexpr void insert_or_replace(T &dest, T &&source) {
+    // After this swap, `source` holds the previous contents of `dest`.
+    // The reinsertion below intentionally uses that moved-from object as the
+    // temporary buffer for restoring the old entries.
     source.swap(dest);
     if constexpr (requires { dest.insert(sorted_unique, source.begin(), source.end()); }) {
       // flat_map

--- a/include/hpp_proto/optional_indirect.hpp
+++ b/include/hpp_proto/optional_indirect.hpp
@@ -192,20 +192,20 @@ public:
     return emplace_impl(std::forward<Args>(args)...);
   }
 
-  constexpr void swap(optional_indirect &other) noexcept(allocator_traits::is_always_equal::value ||
-                                                         (allocator_traits::propagate_on_container_swap::value &&
-                                                          std::is_nothrow_swappable_v<allocator_type>)) {
+  constexpr void swap(optional_indirect &other) noexcept((allocator_traits::propagate_on_container_swap::value &&
+                                                           std::is_nothrow_swappable_v<allocator_type>) ||
+                                                          (!allocator_traits::propagate_on_container_swap::value &&
+                                                           allocator_traits::is_always_equal::value)) {
     if (this == &other) {
       return;
     }
     using std::swap;
+    if constexpr (allocator_traits::propagate_on_container_swap::value) {
+      swap(alloc_, other.alloc_);
+    }
     if constexpr (allocator_traits::is_always_equal::value) {
       swap(obj_, other.obj_);
       return;
-    }
-
-    if constexpr (allocator_traits::propagate_on_container_swap::value) {
-      swap(alloc_, other.alloc_);
     }
     if (alloc_ == other.alloc_) {
       swap(obj_, other.obj_);
@@ -338,13 +338,16 @@ public:
 private:
   template <class... Args>
   constexpr T &emplace_impl(Args &&...args) {
-    reset();
     auto *new_obj = allocator_traits::allocate(alloc_, 1);
     try {
       allocator_traits::construct(alloc_, std::to_address(new_obj), std::forward<Args>(args)...);
     } catch (...) {
       allocator_traits::deallocate(alloc_, new_obj, 1);
       throw;
+    }
+    if (obj_) {
+      allocator_traits::destroy(alloc_, std::to_address(obj_));
+      allocator_traits::deallocate(alloc_, obj_, 1);
     }
     obj_ = new_obj;
     return *raw_ptr();

--- a/include/hpp_proto/optional_indirect.hpp
+++ b/include/hpp_proto/optional_indirect.hpp
@@ -192,10 +192,9 @@ public:
     return emplace_impl(std::forward<Args>(args)...);
   }
 
-  constexpr void swap(optional_indirect &other) noexcept((allocator_traits::propagate_on_container_swap::value &&
-                                                           std::is_nothrow_swappable_v<allocator_type>) ||
-                                                          (!allocator_traits::propagate_on_container_swap::value &&
-                                                           allocator_traits::is_always_equal::value)) {
+  constexpr void swap(optional_indirect &other) noexcept(
+      (allocator_traits::propagate_on_container_swap::value && std::is_nothrow_swappable_v<allocator_type>) ||
+      (!allocator_traits::propagate_on_container_swap::value && allocator_traits::is_always_equal::value)) {
     if (this == &other) {
       return;
     }


### PR DESCRIPTION
## Summary
This PR tightens allocator-sensitive behavior and documents a couple of internal invariants.

## What Changed
- Updates `optional_indirect::swap` so allocator swapping happens before value pointer swapping when allocator propagation is enabled.
- Adjusts the `swap` `noexcept` condition to reflect the allocator propagation path more precisely.
- Makes `optional_indirect::emplace_impl` allocate and construct the replacement before destroying the existing value, preserving the old value if construction throws.
- Documents that unchecked varint parsing writes into the output before the caller validates full input consumption.
- Documents the swap-based reinsertion invariant in merge map handling.
