### PR TITLE
Return descriptor pool validation errors for counter mismatches

### DIFF
--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -584,7 +584,7 @@ private:
         .and_then([this] { return build_message_fields_and_extensions(); })
         .and_then([this] { return build_file_extensions(); })
         .and_then([this] { return resolve_field_types(); })
-        .and_then([&] {
+        .and_then([&]() -> std::expected<void, descriptor_pool_errc> {
           if (messages_.size() != counter.messages) {
             return std::unexpected(descriptor_pool_errc::validation_error);
           }

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -584,7 +584,12 @@ private:
         .and_then([this] { return build_message_fields_and_extensions(); })
         .and_then([this] { return build_file_extensions(); })
         .and_then([this] { return resolve_field_types(); })
-        .transform([&] { assert(messages_.size() == counter.messages); });
+        .and_then([&] {
+          if (messages_.size() != counter.messages) {
+            return std::unexpected(descriptor_pool_errc::validation_error);
+          }
+          return std::expected<void, descriptor_pool_errc>{};
+        });
   }
 
   void reserve_storage(const descriptor_counter &counter) {


### PR DESCRIPTION
## Summary

This PR makes descriptor pool initialization report a validation error when the built descriptor graph does not match the precomputed schema counts.

## What changed

- Replaces the final debug-only assert(messages_.size() == counter.messages) with runtime validation.
- Returns descriptor_pool_errc::validation_error when message descriptor construction produces an unexpected count.
- Preserves the existing std::expected<void, descriptor_pool_errc> error flow used by the rest of descriptor pool initialization.
