### PR TITLE
Remove CI flag from Codecov uploads

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -105,6 +105,6 @@
           with:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: build/coverage.filtered.info
-            flags: linux,ci
+            flags: linux
             name: linux-coverage
             verbose: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
         run: brew install grpc
         
       - name: install lcov
-        if: matrix.cmake_preset == 'ci-macos-coverage'ƒc
+        if: matrix.cmake_preset == 'ci-macos-coverage'
         run: brew install lcov
 
       - name: configure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
         run: brew install grpc
         
       - name: install lcov
-        if: matrix.cmake_preset == 'ci-macos-coverage'
+        if: matrix.cmake_preset == 'ci-macos-coverage'ƒc
         run: brew install lcov
 
       - name: configure
@@ -104,6 +104,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/coverage.filtered.info
-          flags: macos,ci
+          flags: macos
           name: macos-coverage
           verbose: true


### PR DESCRIPTION
## Summary

This PR updates Codecov upload metadata so coverage reports are tagged only by platform.

## What changed

- Changes Linux coverage uploads from linux,ci to linux.
- Changes macOS coverage uploads from macos,ci to macos.

## Why

Codecov complained "Multiple flags detected. Please ensure one flag per upload."