### PR TITLE
flat_map: fix transactional container updates and allocator assumptions

### DIFF
--- a/include/hpp_proto/flat_map.hpp
+++ b/include/hpp_proto/flat_map.hpp
@@ -1068,12 +1068,12 @@ public:
   }
 
 private:
-  template <class MappedIterator, class... Args>
-  MappedIterator guarded_emplace(typename KeyContainer::iterator kit, MappedIterator vit, Args &&...args) {
+  template <class KeyIterator, class MappedIterator, class... Args>
+  MappedIterator guarded_emplace(KeyIterator kit, MappedIterator vit, Args &&...args) {
     try {
       return c_.values.emplace(vit, static_cast<Args &&>(args)...);
     } catch (...) {
-      c_.keys.erase(kit);
+      c_.keys.erase(c_.keys.begin() + (kit - c_.keys.cbegin()));
       throw;
     }
   }

--- a/include/hpp_proto/flat_map.hpp
+++ b/include/hpp_proto/flat_map.hpp
@@ -162,6 +162,16 @@ void sort_together(Compare less, Head &head, Rest &...rest) {
   flatmap_detail::sort_together(less, 0, head.size(), head.begin(), rest.begin()...);
 }
 
+template <class KeyContainer, class KeyIterator, class MappedContainer, class MappedValue>
+void guarded_insert(KeyContainer &keys, KeyIterator kit, MappedContainer &values, MappedValue &&value) {
+  try {
+    values.insert(values.end(), static_cast<MappedValue &&>(value));
+  } catch (...) {
+    keys.erase(kit);
+    throw;
+  }
+}
+
 template <class It, class It2, class Compare>
 It unique_helper(It first, It last, It2 mapped, Compare &compare) {
   It dfirst = first;
@@ -319,6 +329,8 @@ class flat_map {
   static_assert(flatmap_detail::is_random_access_iterator<typename MappedContainer::iterator>::value, "");
   static_assert(std::is_same<Key, typename KeyContainer::value_type>::value, "");
   static_assert(std::is_same<Mapped, typename MappedContainer::value_type>::value, "");
+  static_assert(std::uses_allocator<KeyContainer, typename KeyContainer::allocator_type>::value, "");
+  static_assert(std::uses_allocator<MappedContainer, typename MappedContainer::allocator_type>::value, "");
   static_assert(!std::is_const<KeyContainer>::value && !std::is_const<Key>::value, "");
   static_assert(!std::is_const<MappedContainer>::value && !std::is_const<Mapped>::value, "");
   static_assert(!std::is_reference<KeyContainer>::value && !std::is_reference<Key>::value, "");
@@ -338,8 +350,8 @@ public:
   using const_mapped_reference = typename MappedContainer::const_reference;
   using reference = std::pair<const_key_reference, mapped_reference>;
   using const_reference = std::pair<const_key_reference, const_mapped_reference>;
-  using size_type = size_t;          // TODO: this should be KeyContainer::size_type
-  using difference_type = ptrdiff_t; // TODO: this should be KeyContainer::difference_type
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
   using iterator = flatmap_detail::iter<typename KeyContainer::const_iterator, typename MappedContainer::iterator>;
   using const_iterator =
       flatmap_detail::iter<typename KeyContainer::const_iterator, typename MappedContainer::const_iterator>;
@@ -352,9 +364,7 @@ public:
     friend class flat_map;
 
   protected:
-    // TODO: this should be private
     Compare comp;
-    // TODO: this constructor should be explicit
     value_compare(Compare c) : comp(c) {}
 
   public:
@@ -376,7 +386,6 @@ public:
     this->sort_and_unique_impl();
   }
 
-  // TODO: surely this should use uses-allocator construction
   template <class Alloc, typename std::enable_if<std::uses_allocator<KeyContainer, Alloc>::value &&
                                                      std::uses_allocator<MappedContainer, Alloc>::value,
                                                  int>::type = 0>
@@ -453,14 +462,12 @@ public:
                                                  int>::type = 0>
   explicit flat_map(const Alloc &a) : flat_map(Compare(), a) {}
 
-  // TODO: shouldn't InputIterator be constrained to point to something with "first" and "second" members?
   template <class InputIterator,
             class = typename std::enable_if<flatmap_detail::qualifies_as_input_iterator<InputIterator>::value>::type>
   flat_map(InputIterator first, InputIterator last, const Compare &comp = Compare()) : compare_(comp) {
     for (; first != last; ++first) {
-      c_.keys.insert(c_.keys.end(), first->first);
-      // TODO: we must make this exception-safe if the container insert throws
-      c_.values.insert(c_.values.end(), first->second);
+      auto kit = c_.keys.insert(c_.keys.end(), first->first);
+      flatmap_detail::guarded_insert(c_.keys, kit, c_.values, first->second);
     }
     this->sort_and_unique_impl();
   }
@@ -474,8 +481,8 @@ public:
            flatmap_detail::make_obj_using_allocator<MappedContainer>(a)},
         compare_(comp) {
     for (; first != last; ++first) {
-      c_.keys.insert(c_.keys.end(), first->first);
-      c_.values.insert(c_.values.end(), first->second);
+      auto kit = c_.keys.insert(c_.keys.end(), first->first);
+      flatmap_detail::guarded_insert(c_.keys, kit, c_.values, first->second);
     }
     this->sort_and_unique_impl();
   }
@@ -490,8 +497,8 @@ public:
             class = typename std::enable_if<flatmap_detail::qualifies_as_input_iterator<InputIterator>::value>::type>
   flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Compare &comp = Compare()) : compare_(comp) {
     for (; first != last; ++first) {
-      c_.keys.insert(c_.keys.end(), first->first);
-      c_.values.insert(c_.values.end(), first->second);
+      auto kit = c_.keys.insert(c_.keys.end(), first->first);
+      flatmap_detail::guarded_insert(c_.keys, kit, c_.values, first->second);
     }
   }
 
@@ -504,8 +511,8 @@ public:
            flatmap_detail::make_obj_using_allocator<MappedContainer>(a)},
         compare_(comp) {
     for (; first != last; ++first) {
-      c_.keys.insert(c_.keys.end(), first->first);
-      c_.values.insert(c_.values.end(), first->second);
+      auto kit = c_.keys.insert(c_.keys.end(), first->first);
+      flatmap_detail::guarded_insert(c_.keys, kit, c_.values, first->second);
     }
   }
 
@@ -516,8 +523,6 @@ public:
   flat_map(sorted_unique_t s, InputIterator first, InputIterator last, const Alloc &a)
       : flat_map(s, first, last, Compare(), a) {}
 
-  // TODO: should this be conditionally noexcept?
-  // TODO: surely this should use uses-allocator construction
   template <class Alloc, typename std::enable_if<std::uses_allocator<KeyContainer, Alloc>::value &&
                                                      std::uses_allocator<MappedContainer, Alloc>::value,
                                                  int>::type = 0>
@@ -526,7 +531,6 @@ public:
            MappedContainer(static_cast<MappedContainer &&>(m.c_.values), a)},
         compare_(std::move(m.compare_)) {}
 
-  // TODO: surely this should use uses-allocator construction
   template <class Alloc, typename std::enable_if<std::uses_allocator<KeyContainer, Alloc>::value &&
                                                      std::uses_allocator<MappedContainer, Alloc>::value,
                                                  int>::type = 0>
@@ -622,9 +626,8 @@ public:
     if (it == end() || compare_(t.first, it->first)) {
       auto kit = it.private_impl_getkey();
       auto vit = it.private_impl_getmapped();
-      // TODO: we must make this exception-safe
       kit = c_.keys.emplace(kit, static_cast<Key &&>(t.first));
-      vit = c_.values.emplace(vit, static_cast<Mapped &&>(t.second));
+      vit = this->guarded_emplace(kit, vit, static_cast<Mapped &&>(t.second));
       auto result = flatmap_detail::make_iterator(kit, vit);
       return {std::move(result), true};
     } else {
@@ -660,7 +663,6 @@ public:
   template <class InputIterator,
             class = typename std::enable_if<flatmap_detail::qualifies_as_input_iterator<InputIterator>::value>::type>
   void insert(InputIterator first, InputIterator last) {
-    // TODO: if we're inserting lots of elements, stick them at the end and then sort
     while (first != last) {
       this->insert(*first);
       ++first;
@@ -670,8 +672,6 @@ public:
   template <class InputIterator,
             class = typename std::enable_if<flatmap_detail::qualifies_as_input_iterator<InputIterator>::value>::type>
   void insert(stdext::sorted_unique_t, InputIterator first, InputIterator last) {
-    // TODO: if InputIterator is bidirectional, this loop should (go backward??)
-    // TODO: if we're inserting lots of elements, stick them at the end and then sort
     auto it = begin();
     while (first != last) {
       std::pair<Key, Mapped> t(*first);
@@ -690,19 +690,14 @@ public:
     this->insert(s, il.begin(), il.end());
   }
 
-  // TODO: as specified, this function fails to preserve the allocator, and has UB for std::pmr containers
   containers extract() && {
-    try {
-      containers result{static_cast<KeyContainer &&>(c_.keys), static_cast<MappedContainer &&>(c_.values)};
-      this->clear();
-      return result;
-    } catch (...) {
-      this->clear();
-      throw;
-    }
+    containers result{KeyContainer(c_.keys.get_allocator()), MappedContainer(c_.values.get_allocator())};
+    using std::swap;
+    swap(result.keys, c_.keys);
+    swap(result.values, c_.values);
+    return result;
   }
 
-  // TODO: why by rvalue reference and not by-value?
   void replace(KeyContainer &&keys, MappedContainer &&values) {
     try {
       c_.keys = static_cast<KeyContainer &&>(keys);
@@ -719,8 +714,7 @@ public:
     auto vit = c_.values.begin() + (kit - c_.keys.begin());
     if (kit == c_.keys.end() || compare_(k, *kit)) {
       kit = c_.keys.insert(kit, k);
-      // TODO: we must make this exception-safe if the container throws
-      vit = c_.values.emplace(vit, static_cast<Args &&>(args)...);
+      vit = this->guarded_emplace(kit, vit, static_cast<Args &&>(args)...);
       return {flatmap_detail::make_iterator(kit, vit), true};
     } else {
       return {flatmap_detail::make_iterator(kit, vit), false};
@@ -733,15 +727,13 @@ public:
     auto vit = c_.values.begin() + (kit - c_.keys.begin());
     if (kit == c_.keys.end() || compare_(k, *kit)) {
       kit = c_.keys.insert(kit, static_cast<Key &&>(k));
-      // TODO: we must make this exception-safe if the container throws
-      vit = c_.values.emplace(vit, static_cast<Args &&>(args)...);
+      vit = this->guarded_emplace(kit, vit, static_cast<Args &&>(args)...);
       return {flatmap_detail::make_iterator(kit, vit), true};
     } else {
       return {flatmap_detail::make_iterator(kit, vit), false};
     }
   }
 
-  // TODO: make this exception-safe if either container operation throws.
   template <class... Args>
   iterator try_emplace(const_iterator hint, const Key &k, Args &&...args) {
     auto equivalent = [&](const Key &lhs, const Key &rhs) {
@@ -763,20 +755,19 @@ public:
       if (bool(compare_(*prev, k)) && (hkit == c_.keys.end() || bool(compare_(k, *hkit)))) {
         auto vit = c_.values.begin() + (hkit - c_.keys.begin());
         auto kit = c_.keys.insert(hkit, k);
-        vit = c_.values.emplace(vit, static_cast<Args &&>(args)...);
+        vit = this->guarded_emplace(kit, vit, static_cast<Args &&>(args)...);
         return flatmap_detail::make_iterator(kit, vit);
       }
     } else if (hkit == c_.keys.end() || bool(compare_(k, *hkit))) {
       auto vit = c_.values.begin();
       auto kit = c_.keys.insert(hkit, k);
-      vit = c_.values.emplace(vit, static_cast<Args &&>(args)...);
+      vit = this->guarded_emplace(kit, vit, static_cast<Args &&>(args)...);
       return flatmap_detail::make_iterator(kit, vit);
     }
 
     return try_emplace(k, static_cast<Args &&>(args)...).first;
   }
 
-  // TODO: make this exception-safe if either container operation throws.
   template <class... Args>
   iterator try_emplace(const_iterator hint, Key &&k, Args &&...args) {
     auto equivalent = [&](const Key &lhs, const Key &rhs) {
@@ -798,13 +789,13 @@ public:
       if (bool(compare_(*prev, k)) && (hkit == c_.keys.end() || bool(compare_(k, *hkit)))) {
         auto vit = c_.values.begin() + (hkit - c_.keys.begin());
         auto kit = c_.keys.insert(hkit, static_cast<Key &&>(k));
-        vit = c_.values.emplace(vit, static_cast<Args &&>(args)...);
+        vit = this->guarded_emplace(kit, vit, static_cast<Args &&>(args)...);
         return flatmap_detail::make_iterator(kit, vit);
       }
     } else if (hkit == c_.keys.end() || bool(compare_(k, *hkit))) {
       auto vit = c_.values.begin();
       auto kit = c_.keys.insert(hkit, static_cast<Key &&>(k));
-      vit = c_.values.emplace(vit, static_cast<Args &&>(args)...);
+      vit = this->guarded_emplace(kit, vit, static_cast<Args &&>(args)...);
       return flatmap_detail::make_iterator(kit, vit);
     }
 
@@ -860,18 +851,24 @@ public:
   iterator erase(iterator position) {
     auto kit = position.private_impl_getkey();
     auto vit = position.private_impl_getmapped();
-    // TODO: what if either of these next two lines throws an exception?
-    auto kitmut = c_.keys.erase(kit);
-    auto vitmut = c_.values.erase(vit);
+    containers copy{c_.keys, c_.values};
+    auto kitmut = copy.keys.erase(copy.keys.begin() + (kit - c_.keys.begin()));
+    auto vitmut = copy.values.erase(copy.values.begin() + (vit - c_.values.begin()));
+    using std::swap;
+    swap(c_.keys, copy.keys);
+    swap(c_.values, copy.values);
     return flatmap_detail::make_iterator(kitmut, vitmut);
   }
 
   iterator erase(const_iterator position) {
     auto kit = position.private_impl_getkey();
     auto vit = position.private_impl_getmapped();
-    // TODO: what if either of these next two lines throws an exception?
-    auto kitmut = c_.keys.erase(kit);
-    auto vitmut = c_.values.erase(vit);
+    containers copy{c_.keys, c_.values};
+    auto kitmut = copy.keys.erase(copy.keys.begin() + (kit - c_.keys.begin()));
+    auto vitmut = copy.values.erase(copy.values.begin() + (vit - c_.values.begin()));
+    using std::swap;
+    swap(c_.keys, copy.keys);
+    swap(c_.values, copy.values);
     return flatmap_detail::make_iterator(kitmut, vitmut);
   }
 
@@ -889,9 +886,14 @@ public:
     auto vfirst = first.private_impl_getmapped();
     auto klast = last.private_impl_getkey();
     auto vlast = last.private_impl_getmapped();
-    // TODO: what if either of these next two lines throws an exception?
-    auto kitmut = c_.keys.erase(kfirst, klast);
-    auto vitmut = c_.values.erase(vfirst, vlast);
+    containers copy{c_.keys, c_.values};
+    auto kitmut =
+        copy.keys.erase(copy.keys.begin() + (kfirst - c_.keys.begin()), copy.keys.begin() + (klast - c_.keys.begin()));
+    auto vitmut = copy.values.erase(copy.values.begin() + (vfirst - c_.values.begin()),
+                                    copy.values.begin() + (vlast - c_.values.begin()));
+    using std::swap;
+    swap(c_.keys, copy.keys);
+    swap(c_.values, copy.values);
     return flatmap_detail::make_iterator(kitmut, vitmut);
   }
 
@@ -1066,6 +1068,16 @@ public:
   }
 
 private:
+  template <class MappedIterator, class... Args>
+  MappedIterator guarded_emplace(typename KeyContainer::iterator kit, MappedIterator vit, Args &&...args) {
+    try {
+      return c_.values.emplace(vit, static_cast<Args &&>(args)...);
+    } catch (...) {
+      c_.keys.erase(kit);
+      throw;
+    }
+  }
+
   void sort_and_unique_impl() {
     flatmap_detail::sort_together(compare_, c_.keys, c_.values);
     auto kit = flatmap_detail::unique_helper(c_.keys.begin(), c_.keys.end(), c_.values.begin(), compare_);
@@ -1078,7 +1090,6 @@ private:
   Compare compare_;
 };
 
-// TODO: all six comparison operators should be invisible friends
 template <class Key, class Mapped, class Compare, class KeyContainer, class MappedContainer>
 bool operator==(const flat_map<Key, Mapped, Compare, KeyContainer, MappedContainer> &x,
                 const flat_map<Key, Mapped, Compare, KeyContainer, MappedContainer> &y) {
@@ -1123,18 +1134,16 @@ void swap(flat_map<Key, Mapped, Compare, KeyContainer, MappedContainer> &x,
 
 #if defined(__cpp_deduction_guides)
 
-// TODO: this deduction guide should maybe be constrained by qualifies_as_range
 template <class Container, class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value>>
 flat_map(Container) -> flat_map<flatmap_detail::cont_key_type<Container>, flatmap_detail::cont_mapped_type<Container>>;
 
 template <class KeyContainer, class MappedContainer,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<KeyContainer>::value &&
                                    !flatmap_detail::qualifies_as_allocator<MappedContainer>::value>>
-flat_map(KeyContainer,
-         MappedContainer) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                      std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(KeyContainer, MappedContainer)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
-// TODO: all these deduction guides that ignore the Allocator parameter are wrong, but especially this one
 template <class Container, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value &&
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value &&
@@ -1148,20 +1157,20 @@ template <class KeyContainer, class MappedContainer, class Allocator,
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value &&
                                    std::uses_allocator<KeyContainer, Allocator>::value &&
                                    std::uses_allocator<MappedContainer, Allocator>::value>>
-flat_map(KeyContainer, MappedContainer,
-         Allocator) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(KeyContainer, MappedContainer, Allocator)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value>>
-flat_map(sorted_unique_t,
-         Container) -> flat_map<flatmap_detail::cont_key_type<Container>, flatmap_detail::cont_mapped_type<Container>>;
+flat_map(sorted_unique_t, Container)
+    -> flat_map<flatmap_detail::cont_key_type<Container>, flatmap_detail::cont_mapped_type<Container>>;
 
 template <class KeyContainer, class MappedContainer,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<KeyContainer>::value &&
                                    !flatmap_detail::qualifies_as_allocator<MappedContainer>::value>>
-flat_map(sorted_unique_t, KeyContainer,
-         MappedContainer) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                      std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(sorted_unique_t, KeyContainer, MappedContainer)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value &&
@@ -1176,9 +1185,9 @@ template <class KeyContainer, class MappedContainer, class Allocator,
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value &&
                                    std::uses_allocator<KeyContainer, Allocator>::value &&
                                    std::uses_allocator<MappedContainer, Allocator>::value>>
-flat_map(sorted_unique_t, KeyContainer, MappedContainer,
-         Allocator) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(sorted_unique_t, KeyContainer, MappedContainer, Allocator)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class InputIterator, class Compare = std::less<flatmap_detail::iter_key_type<InputIterator>>,
           class = std::enable_if_t<flatmap_detail::qualifies_as_input_iterator<InputIterator>::value &&
@@ -1233,19 +1242,19 @@ flat_map(std::initializer_list<std::pair<const Key, T>>, Allocator, int = 0 /*to
 
 template <class Key, class T, class Compare = std::less<Key>,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Compare>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>,
-         Compare = Compare()) -> flat_map<Key, T, Compare>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare = Compare())
+    -> flat_map<Key, T, Compare>;
 
 template <class Key, class T, class Compare, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Compare>::value &&
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare,
-         Allocator) -> flat_map<Key, T, Compare>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare, Allocator)
+    -> flat_map<Key, T, Compare>;
 
 template <class Key, class T, class Allocator,
           class = std::enable_if_t<flatmap_detail::qualifies_as_allocator<Allocator>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Allocator,
-         int = 0 /*to please MSVC*/) -> flat_map<Key, T>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Allocator, int = 0 /*to please MSVC*/)
+    -> flat_map<Key, T>;
 
 #endif
 

--- a/include/hpp_proto/flat_map.hpp
+++ b/include/hpp_proto/flat_map.hpp
@@ -1140,9 +1140,9 @@ flat_map(Container) -> flat_map<flatmap_detail::cont_key_type<Container>, flatma
 template <class KeyContainer, class MappedContainer,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<KeyContainer>::value &&
                                    !flatmap_detail::qualifies_as_allocator<MappedContainer>::value>>
-flat_map(KeyContainer, MappedContainer)
-    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(KeyContainer,
+         MappedContainer) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                                      std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value &&
@@ -1157,20 +1157,20 @@ template <class KeyContainer, class MappedContainer, class Allocator,
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value &&
                                    std::uses_allocator<KeyContainer, Allocator>::value &&
                                    std::uses_allocator<MappedContainer, Allocator>::value>>
-flat_map(KeyContainer, MappedContainer, Allocator)
-    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(KeyContainer, MappedContainer,
+         Allocator) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value>>
-flat_map(sorted_unique_t, Container)
-    -> flat_map<flatmap_detail::cont_key_type<Container>, flatmap_detail::cont_mapped_type<Container>>;
+flat_map(sorted_unique_t,
+         Container) -> flat_map<flatmap_detail::cont_key_type<Container>, flatmap_detail::cont_mapped_type<Container>>;
 
 template <class KeyContainer, class MappedContainer,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<KeyContainer>::value &&
                                    !flatmap_detail::qualifies_as_allocator<MappedContainer>::value>>
-flat_map(sorted_unique_t, KeyContainer, MappedContainer)
-    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(sorted_unique_t, KeyContainer,
+         MappedContainer) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                                      std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value &&
@@ -1185,9 +1185,9 @@ template <class KeyContainer, class MappedContainer, class Allocator,
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value &&
                                    std::uses_allocator<KeyContainer, Allocator>::value &&
                                    std::uses_allocator<MappedContainer, Allocator>::value>>
-flat_map(sorted_unique_t, KeyContainer, MappedContainer, Allocator)
-    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(sorted_unique_t, KeyContainer, MappedContainer,
+         Allocator) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class InputIterator, class Compare = std::less<flatmap_detail::iter_key_type<InputIterator>>,
           class = std::enable_if_t<flatmap_detail::qualifies_as_input_iterator<InputIterator>::value &&
@@ -1242,19 +1242,19 @@ flat_map(std::initializer_list<std::pair<const Key, T>>, Allocator, int = 0 /*to
 
 template <class Key, class T, class Compare = std::less<Key>,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Compare>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare = Compare())
-    -> flat_map<Key, T, Compare>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>,
+         Compare = Compare()) -> flat_map<Key, T, Compare>;
 
 template <class Key, class T, class Compare, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Compare>::value &&
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare, Allocator)
-    -> flat_map<Key, T, Compare>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare,
+         Allocator) -> flat_map<Key, T, Compare>;
 
 template <class Key, class T, class Allocator,
           class = std::enable_if_t<flatmap_detail::qualifies_as_allocator<Allocator>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Allocator, int = 0 /*to please MSVC*/)
-    -> flat_map<Key, T>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Allocator,
+         int = 0 /*to please MSVC*/) -> flat_map<Key, T>;
 
 #endif
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -16,6 +16,29 @@ add_hpp_proto_test(
     SOURCES merge_message_tests.cpp
     LINK_LIBRARIES hpp_proto::hpp_proto_core Boost::ut)
 
+set(HPP_PROTO_STD_FLAT_MAP_CHECK_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/std_flat_map_check.cpp")
+file(WRITE "${HPP_PROTO_STD_FLAT_MAP_CHECK_SOURCE}" "
+#include <version>
+#ifdef __cpp_lib_flat_map
+#include <flat_map>
+int main() { return 0; }
+#else
+#error __cpp_lib_flat_map is not defined
+#endif
+")
+try_compile(HPP_PROTO_HAS_STD_FLAT_MAP
+    "${CMAKE_CURRENT_BINARY_DIR}/std_flat_map_check"
+    SOURCES "${HPP_PROTO_STD_FLAT_MAP_CHECK_SOURCE}"
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON)
+
+if(NOT HPP_PROTO_HAS_STD_FLAT_MAP)
+    add_hpp_proto_test(
+        NAME flat_map_tests
+        SOURCES flat_map_tests.cpp
+        LINK_LIBRARIES hpp_proto::hpp_proto_core Boost::ut)
+endif()
+
 add_hpp_proto_test(
     NAME optional_indirect_tests
     SOURCES optional_indirect_tests.cpp

--- a/unittests/flat_map_tests.cpp
+++ b/unittests/flat_map_tests.cpp
@@ -1,5 +1,6 @@
 #include <boost/ut.hpp>
 #include <hpp_proto/flat_map.hpp>
+#include <iterator>
 #include <stdexcept>
 #include <vector>
 
@@ -20,6 +21,7 @@ struct throwing_mapped {
     }
   }
   throwing_mapped(throwing_mapped &&) noexcept = default;
+  ~throwing_mapped() = default;
   throwing_mapped &operator=(const throwing_mapped &) = default;
   throwing_mapped &operator=(throwing_mapped &&) noexcept = default;
 
@@ -34,11 +36,13 @@ struct throwing_int_vector : std::vector<int> {
 
   throwing_int_vector() = default;
   throwing_int_vector(std::initializer_list<int> values) : std::vector<int>(values) {}
-  throwing_int_vector(std::vector<int> values) : std::vector<int>(std::move(values)) {}
+  explicit throwing_int_vector(std::vector<int> values) : std::vector<int>(std::move(values)) {}
   throwing_int_vector(const throwing_int_vector &) = default;
   throwing_int_vector(throwing_int_vector &&) noexcept = default;
+  ~throwing_int_vector() = default;
 
   throwing_int_vector &operator=(const throwing_int_vector &) = default;
+  // NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations,hicpp-noexcept-move,performance-noexcept-move-constructor)
   throwing_int_vector &operator=(throwing_int_vector &&other) {
     if (throw_on_move_assign) {
       throw std::runtime_error("move assignment failed");
@@ -151,7 +155,7 @@ const boost::ut::suite flat_map_tests = [] {
     };
     input[1].second.throw_on_copy = true;
 
-    expect(throws<std::runtime_error>([&] { [[maybe_unused]] Map values{input, input + 2}; }));
+    expect(throws<std::runtime_error>([&] { [[maybe_unused]] Map values{std::begin(input), std::end(input)}; }));
   };
 
   "try_emplace_rolls_back_key_when_mapped_emplace_throws"_test = [] {
@@ -159,13 +163,13 @@ const boost::ut::suite flat_map_tests = [] {
 
     expect(throws<std::runtime_error>([&] { (void)values.try_emplace(2, 20, true); }));
     expect(values.size() == 2U);
-    expect(values.find(2) == values.end());
+    expect(!values.contains(2));
     expect(values.find(1)->second.value == 10);
     expect(values.find(3)->second.value == 30);
   };
 
   "replace_clears_when_mapped_container_assignment_throws"_test = [] {
-    using Map = stdext::flat_map<int, int, std::less<int>, std::vector<int>, throwing_int_vector>;
+    using Map = stdext::flat_map<int, int, std::less<>, std::vector<int>, throwing_int_vector>;
     Map values{{1, 10}, {2, 20}};
     throwing_int_vector::throw_on_move_assign = true;
 

--- a/unittests/flat_map_tests.cpp
+++ b/unittests/flat_map_tests.cpp
@@ -1,0 +1,194 @@
+#include <boost/ut.hpp>
+#include <hpp_proto/flat_map.hpp>
+#include <stdexcept>
+#include <vector>
+
+struct throwing_mapped {
+  int value = 0;
+  bool throw_on_copy = false;
+  bool throw_on_int = false;
+
+  throwing_mapped() = default;
+  explicit throwing_mapped(int v, bool should_throw = false) : value(v), throw_on_int(should_throw) {
+    if (throw_on_int) {
+      throw std::runtime_error("int construction failed");
+    }
+  }
+  throwing_mapped(const throwing_mapped &other) : value(other.value), throw_on_copy(other.throw_on_copy) {
+    if (throw_on_copy) {
+      throw std::runtime_error("copy construction failed");
+    }
+  }
+  throwing_mapped(throwing_mapped &&) noexcept = default;
+  throwing_mapped &operator=(const throwing_mapped &) = default;
+  throwing_mapped &operator=(throwing_mapped &&) noexcept = default;
+
+  bool operator==(const throwing_mapped &) const = default;
+};
+
+struct throwing_int_vector : std::vector<int> {
+  using std::vector<int>::vector;
+  using std::vector<int>::operator=;
+
+  inline static bool throw_on_move_assign = false;
+
+  throwing_int_vector() = default;
+  throwing_int_vector(std::initializer_list<int> values) : std::vector<int>(values) {}
+  throwing_int_vector(std::vector<int> values) : std::vector<int>(std::move(values)) {}
+  throwing_int_vector(const throwing_int_vector &) = default;
+  throwing_int_vector(throwing_int_vector &&) noexcept = default;
+
+  throwing_int_vector &operator=(const throwing_int_vector &) = default;
+  throwing_int_vector &operator=(throwing_int_vector &&other) {
+    if (throw_on_move_assign) {
+      throw std::runtime_error("move assignment failed");
+    }
+    std::vector<int>::operator=(std::move(other));
+    return *this;
+  }
+};
+
+const boost::ut::suite flat_map_tests = [] {
+  using namespace boost::ut;
+
+  "const_at_throws_for_missing_key"_test = [] {
+    const stdext::flat_map<int, int> values{{1, 10}};
+
+    expect(throws<std::out_of_range>([&] { (void)values.at(2); }));
+  };
+
+  "emplace_with_existing_key_returns_existing_iterator"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}};
+
+    auto result = values.emplace(1, 20);
+
+    expect(!result.second);
+    expect(result.first->first == 1);
+    expect(result.first->second == 10);
+    expect(values == stdext::flat_map<int, int>{{1, 10}});
+  };
+
+  "try_emplace_with_lvalue_key_uses_valid_middle_hint"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+    const int key = 2;
+
+    auto it = values.try_emplace(values.find(3), key, 20);
+
+    expect(it->first == 2);
+    expect(it->second == 20);
+    expect(values == stdext::flat_map<int, int>{{1, 10}, {2, 20}, {3, 30}});
+  };
+
+  "try_emplace_with_rvalue_key_uses_valid_middle_hint"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+
+    auto it = values.try_emplace(values.find(3), 2, 20);
+
+    expect(it->first == 2);
+    expect(it->second == 20);
+    expect(values == stdext::flat_map<int, int>{{1, 10}, {2, 20}, {3, 30}});
+  };
+
+  "try_emplace_with_existing_key_returns_existing_iterator"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+    const int key = 1;
+
+    auto result = values.try_emplace(key, 20);
+
+    expect(!result.second);
+    expect(result.first->first == 1);
+    expect(result.first->second == 10);
+    expect(values == stdext::flat_map<int, int>{{1, 10}, {3, 30}});
+  };
+
+  "try_emplace_with_lvalue_key_returns_exact_hint_match"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+    const int key = 1;
+
+    auto it = values.try_emplace(values.find(1), key, 20);
+
+    expect(it->first == 1);
+    expect(it->second == 10);
+    expect(values == stdext::flat_map<int, int>{{1, 10}, {3, 30}});
+  };
+
+  "try_emplace_with_lvalue_key_returns_previous_hint_match"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+    const int key = 1;
+
+    auto it = values.try_emplace(values.find(3), key, 20);
+
+    expect(it->first == 1);
+    expect(it->second == 10);
+    expect(values == stdext::flat_map<int, int>{{1, 10}, {3, 30}});
+  };
+
+  "try_emplace_with_rvalue_key_returns_exact_hint_match"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+
+    auto it = values.try_emplace(values.find(1), 1, 20);
+
+    expect(it->first == 1);
+    expect(it->second == 10);
+    expect(values == stdext::flat_map<int, int>{{1, 10}, {3, 30}});
+  };
+
+  "try_emplace_with_rvalue_key_returns_previous_hint_match"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+
+    auto it = values.try_emplace(values.find(3), 1, 20);
+
+    expect(it->first == 1);
+    expect(it->second == 10);
+    expect(values == stdext::flat_map<int, int>{{1, 10}, {3, 30}});
+  };
+
+  "range_constructor_rolls_back_key_when_mapped_insert_throws"_test = [] {
+    using Map = stdext::flat_map<int, throwing_mapped>;
+    std::pair<int, throwing_mapped> input[] = {
+        {1, throwing_mapped{10}},
+        {2, throwing_mapped{20}},
+    };
+    input[1].second.throw_on_copy = true;
+
+    expect(throws<std::runtime_error>([&] { [[maybe_unused]] Map values{input, input + 2}; }));
+  };
+
+  "try_emplace_rolls_back_key_when_mapped_emplace_throws"_test = [] {
+    stdext::flat_map<int, throwing_mapped> values{{1, throwing_mapped{10}}, {3, throwing_mapped{30}}};
+
+    expect(throws<std::runtime_error>([&] { (void)values.try_emplace(2, 20, true); }));
+    expect(values.size() == 2U);
+    expect(values.find(2) == values.end());
+    expect(values.find(1)->second.value == 10);
+    expect(values.find(3)->second.value == 30);
+  };
+
+  "replace_clears_when_mapped_container_assignment_throws"_test = [] {
+    using Map = stdext::flat_map<int, int, std::less<int>, std::vector<int>, throwing_int_vector>;
+    Map values{{1, 10}, {2, 20}};
+    throwing_int_vector::throw_on_move_assign = true;
+
+    expect(throws<std::runtime_error>(
+        [&] { values.replace(std::vector<int>{3, 4}, throwing_int_vector{30, 40}); }));
+
+    throwing_int_vector::throw_on_move_assign = false;
+    expect(values.empty());
+  };
+
+  "insert_or_assign_with_lvalue_key_and_existing_hint_assigns_value"_test = [] {
+    stdext::flat_map<int, int> values{{1, 10}, {3, 30}};
+    const int key = 1;
+
+    auto it = values.insert_or_assign(values.find(1), key, 20);
+
+    expect(it->first == 1);
+    expect(it->second == 20);
+    expect(values == stdext::flat_map<int, int>{{1, 20}, {3, 30}});
+  };
+};
+
+int main() {
+  const auto result = boost::ut::cfg<>.run({.report_errors = true});
+  return static_cast<int>(result);
+}

--- a/unittests/flat_map_tests.cpp
+++ b/unittests/flat_map_tests.cpp
@@ -169,8 +169,7 @@ const boost::ut::suite flat_map_tests = [] {
     Map values{{1, 10}, {2, 20}};
     throwing_int_vector::throw_on_move_assign = true;
 
-    expect(throws<std::runtime_error>(
-        [&] { values.replace(std::vector<int>{3, 4}, throwing_int_vector{30, 40}); }));
+    expect(throws<std::runtime_error>([&] { values.replace(std::vector<int>{3, 4}, throwing_int_vector{30, 40}); }));
 
     throwing_int_vector::throw_on_move_assign = false;
     expect(values.empty());


### PR DESCRIPTION
## Summary

Improve `flat_map` consistency when mapped-value insertion throws, and tighten allocator assumptions for the paired key/value containers.

## What changed

- Added guarded insertion/emplacement paths that erase the inserted key if inserting the mapped value throws.
- Updated range constructors and `emplace`/`try_emplace` paths to use the guarded mapped-container update helper.
- Reworked `extract()` to preserve container allocators by swapping into allocator-compatible empty containers.
- Added allocator-related static assertions and cleaned up stale TODO comments/formatting.

## Why

`flat_map` stores keys and mapped values in separate containers, so any operation that inserts into the key container before the mapped container must roll back the key on failure. This keeps the two containers aligned and avoids a corrupted map state after exceptions.
