### PR TITLE
Fix  clang-tidy 22 failures

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,7 @@ Checks: "*,
         -concurrency-mt-unsafe,
         -cppcoreguidelines-non-private-member-variables-in-classes,
         -bugprone-exception-escape,
+        -bugprone-throwing-static-initialization,
         -misc-non-private-member-variables-in-classes,
         -misc-confusable-identifiers,
         -misc-include-cleaner,
@@ -23,6 +24,7 @@ Checks: "*,
         -cppcoreguidelines-avoid-magic-numbers,
         -readability-magic-numbers,
         -cppcoreguidelines-avoid-c-arrays,
+        -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
         -hicpp-avoid-c-arrays,
         -modernize-avoid-c-arrays,
         -misc-const-correctness,
@@ -54,4 +56,3 @@ ExtraArgs:
   - -Wno-unknown-warning-option
   - -Wno-ignored-optimization-argument
   - -Wno-unused-command-line-argument
-

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup required C++ tools
         uses: aminya/setup-cpp@v1.8.0
         with:
-          compiler: llvm-21
+          compiler: llvm-22
           cmake: "3.31.0"
           ninja: true
           ccache: true

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: Clang-Tidy 21
+name: Clang-Tidy 22
 
 on:
   workflow_dispatch:

--- a/include/google/protobuf/compiler/plugin.msg.hpp
+++ b/include/google/protobuf/compiler/plugin.msg.hpp
@@ -22,7 +22,7 @@ struct Version {
   std::int32_t major = {};
   std::int32_t minor = {};
   std::int32_t patch = {};
-  typename Traits::string_t suffix;
+  Traits::string_t suffix;
 
   [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
   bool operator == (const Version&) const = default;
@@ -43,9 +43,9 @@ namespace CodeGeneratorResponse_ {
   template <typename Traits = ::hpp_proto::default_traits>
   struct File {
     using hpp_proto_traits_type = Traits;
-    typename Traits::string_t name;
-    typename Traits::string_t insertion_point;
-    typename Traits::string_t content;
+    Traits::string_t name;
+    Traits::string_t insertion_point;
+    Traits::string_t content;
     std::optional<google::protobuf::GeneratedCodeInfo<Traits>> generated_code_info;
 
     [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
@@ -60,7 +60,7 @@ struct CodeGeneratorResponse {
   using Feature = google::protobuf::compiler::CodeGeneratorResponse_::Feature;
   using File = CodeGeneratorResponse_::File<Traits>;
 
-  typename Traits::string_t error;
+  Traits::string_t error;
   std::uint64_t supported_features = {};
   std::int32_t minimum_edition = {};
   std::int32_t maximum_edition = {};
@@ -74,7 +74,7 @@ template <typename Traits = ::hpp_proto::default_traits>
 struct CodeGeneratorRequest {
   using hpp_proto_traits_type = Traits;
   Traits::template repeated_t<typename Traits::string_t> file_to_generate;
-  typename Traits::string_t parameter;
+  Traits::string_t parameter;
   Traits::template repeated_t<google::protobuf::FileDescriptorProto<Traits>> proto_file;
   Traits::template repeated_t<google::protobuf::FileDescriptorProto<Traits>> source_file_descriptors;
   std::optional<google::protobuf::compiler::Version<Traits>> compiler_version;

--- a/include/google/protobuf/descriptor.msg.hpp
+++ b/include/google/protobuf/descriptor.msg.hpp
@@ -52,7 +52,7 @@ namespace UninterpretedOption_ {
   template <typename Traits = ::hpp_proto::default_traits>
   struct NamePart {
     using hpp_proto_traits_type = Traits;
-    typename Traits::string_t name_part;
+    Traits::string_t name_part;
     bool is_extension = {};
 
     [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
@@ -67,12 +67,12 @@ struct UninterpretedOption {
   using NamePart = UninterpretedOption_::NamePart<Traits>;
 
   Traits::template repeated_t<NamePart> name;
-  typename Traits::string_t identifier_value;
+  Traits::string_t identifier_value;
   std::uint64_t positive_int_value = {};
   std::int64_t negative_int_value = {};
   double double_value = {};
-  typename Traits::bytes_t string_value;
-  typename Traits::string_t aggregate_value;
+  Traits::bytes_t string_value;
+  Traits::string_t aggregate_value;
 
   [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
   bool operator == (const UninterpretedOption&) const = default;
@@ -228,8 +228,8 @@ namespace SourceCodeInfo_ {
     using hpp_proto_traits_type = Traits;
     Traits::template repeated_t<std::int32_t> path;
     Traits::template repeated_t<std::int32_t> span;
-    typename Traits::string_t leading_comments;
-    typename Traits::string_t trailing_comments;
+    Traits::string_t leading_comments;
+    Traits::string_t trailing_comments;
     Traits::template repeated_t<typename Traits::string_t> leading_detached_comments;
 
     [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
@@ -281,7 +281,7 @@ namespace GeneratedCodeInfo_ {
     using hpp_proto_traits_type = Traits;
     using Semantic = google::protobuf::GeneratedCodeInfo_::Annotation_::Semantic;
     Traits::template repeated_t<std::int32_t> path;
-    typename Traits::string_t source_file;
+    Traits::string_t source_file;
     std::int32_t begin = {};
     std::int32_t end = {};
     Semantic semantic = Semantic::NONE;
@@ -495,7 +495,7 @@ namespace FieldOptions_ {
   struct EditionDefault {
     using hpp_proto_traits_type = Traits;
     google::protobuf::Edition edition = google::protobuf::Edition::EDITION_UNKNOWN;
-    typename Traits::string_t value;
+    Traits::string_t value;
 
     [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
     bool operator == (const EditionDefault&) const = default;
@@ -506,7 +506,7 @@ namespace FieldOptions_ {
     using hpp_proto_traits_type = Traits;
     google::protobuf::Edition edition_introduced = google::protobuf::Edition::EDITION_UNKNOWN;
     google::protobuf::Edition edition_deprecated = google::protobuf::Edition::EDITION_UNKNOWN;
-    typename Traits::string_t deprecation_warning;
+    Traits::string_t deprecation_warning;
     google::protobuf::Edition edition_removed = google::protobuf::Edition::EDITION_UNKNOWN;
 
     [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
@@ -602,25 +602,25 @@ template <typename Traits = ::hpp_proto::default_traits>
 struct FileOptions {
   using hpp_proto_traits_type = Traits;
   using OptimizeMode = google::protobuf::FileOptions_::OptimizeMode;
-  typename Traits::string_t java_package;
-  typename Traits::string_t java_outer_classname;
+  Traits::string_t java_package;
+  Traits::string_t java_outer_classname;
   bool java_multiple_files = false;
   bool java_generate_equals_and_hash = {};
   bool java_string_check_utf8 = false;
   OptimizeMode optimize_for = OptimizeMode::SPEED;
-  typename Traits::string_t go_package;
+  Traits::string_t go_package;
   bool cc_generic_services = false;
   bool java_generic_services = false;
   bool py_generic_services = false;
   bool deprecated = false;
   bool cc_enable_arenas = true;
-  typename Traits::string_t objc_class_prefix;
-  typename Traits::string_t csharp_namespace;
-  typename Traits::string_t swift_prefix;
-  typename Traits::string_t php_class_prefix;
-  typename Traits::string_t php_namespace;
-  typename Traits::string_t php_metadata_namespace;
-  typename Traits::string_t ruby_package;
+  Traits::string_t objc_class_prefix;
+  Traits::string_t csharp_namespace;
+  Traits::string_t swift_prefix;
+  Traits::string_t php_class_prefix;
+  Traits::string_t php_namespace;
+  Traits::string_t php_metadata_namespace;
+  Traits::string_t ruby_package;
   std::optional<google::protobuf::FeatureSet<Traits>> features;
   Traits::template repeated_t<google::protobuf::UninterpretedOption<Traits>> uninterpreted_option;
 
@@ -643,9 +643,9 @@ struct FileOptions {
 template <typename Traits = ::hpp_proto::default_traits>
 struct MethodDescriptorProto {
   using hpp_proto_traits_type = Traits;
-  typename Traits::string_t name;
-  typename Traits::string_t input_type;
-  typename Traits::string_t output_type;
+  Traits::string_t name;
+  Traits::string_t input_type;
+  Traits::string_t output_type;
   std::optional<google::protobuf::MethodOptions<Traits>> options;
   bool client_streaming = false;
   bool server_streaming = false;
@@ -657,7 +657,7 @@ struct MethodDescriptorProto {
 template <typename Traits = ::hpp_proto::default_traits>
 struct ServiceDescriptorProto {
   using hpp_proto_traits_type = Traits;
-  typename Traits::string_t name;
+  Traits::string_t name;
   Traits::template repeated_t<google::protobuf::MethodDescriptorProto<Traits>> method;
   std::optional<google::protobuf::ServiceOptions<Traits>> options;
 
@@ -668,7 +668,7 @@ struct ServiceDescriptorProto {
 template <typename Traits = ::hpp_proto::default_traits>
 struct OneofDescriptorProto {
   using hpp_proto_traits_type = Traits;
-  typename Traits::string_t name;
+  Traits::string_t name;
   std::optional<google::protobuf::OneofOptions<Traits>> options;
 
   [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
@@ -720,15 +720,15 @@ struct FieldDescriptorProto {
   using hpp_proto_traits_type = Traits;
   using Type = google::protobuf::FieldDescriptorProto_::Type;
   using Label = google::protobuf::FieldDescriptorProto_::Label;
-  typename Traits::string_t name;
+  Traits::string_t name;
   std::int32_t number = {};
   Label label = Label::LABEL_OPTIONAL;
   Type type = Type::TYPE_DOUBLE;
-  typename Traits::string_t type_name;
-  typename Traits::string_t extendee;
-  typename Traits::string_t default_value;
+  Traits::string_t type_name;
+  Traits::string_t extendee;
+  Traits::string_t default_value;
   ::hpp_proto::optional<std::int32_t> oneof_index;
-  typename Traits::string_t json_name;
+  Traits::string_t json_name;
   std::optional<google::protobuf::FieldOptions<Traits>> options;
   bool proto3_optional = {};
 
@@ -751,8 +751,8 @@ namespace ExtensionRangeOptions_ {
   struct Declaration {
     using hpp_proto_traits_type = Traits;
     std::int32_t number = {};
-    typename Traits::string_t full_name;
-    typename Traits::string_t type;
+    Traits::string_t full_name;
+    Traits::string_t type;
     bool reserved = {};
     bool repeated = {};
 
@@ -817,7 +817,7 @@ struct EnumValueOptions {
 template <typename Traits = ::hpp_proto::default_traits>
 struct EnumValueDescriptorProto {
   using hpp_proto_traits_type = Traits;
-  typename Traits::string_t name;
+  Traits::string_t name;
   std::int32_t number = {};
   std::optional<google::protobuf::EnumValueOptions<Traits>> options;
 
@@ -843,7 +843,7 @@ struct EnumDescriptorProto {
   using hpp_proto_traits_type = Traits;
   using EnumReservedRange = EnumDescriptorProto_::EnumReservedRange<Traits>;
 
-  typename Traits::string_t name;
+  Traits::string_t name;
   Traits::template repeated_t<google::protobuf::EnumValueDescriptorProto<Traits>> value;
   std::optional<google::protobuf::EnumOptions<Traits>> options;
   Traits::template repeated_t<EnumReservedRange> reserved_range;
@@ -885,7 +885,7 @@ struct DescriptorProto {
 
   using ReservedRange = DescriptorProto_::ReservedRange<Traits>;
 
-  typename Traits::string_t name;
+  Traits::string_t name;
   Traits::template repeated_t<google::protobuf::FieldDescriptorProto<Traits>> field;
   Traits::template repeated_t<google::protobuf::FieldDescriptorProto<Traits>> extension;
   Traits::template recursive_repeated_t<DescriptorProto> nested_type;
@@ -904,8 +904,8 @@ struct DescriptorProto {
 template <typename Traits = ::hpp_proto::default_traits>
 struct FileDescriptorProto {
   using hpp_proto_traits_type = Traits;
-  typename Traits::string_t name;
-  typename Traits::string_t package;
+  Traits::string_t name;
+  Traits::string_t package;
   Traits::template repeated_t<typename Traits::string_t> dependency;
   Traits::template repeated_t<std::int32_t> public_dependency;
   Traits::template repeated_t<std::int32_t> weak_dependency;
@@ -916,7 +916,7 @@ struct FileDescriptorProto {
   Traits::template repeated_t<google::protobuf::FieldDescriptorProto<Traits>> extension;
   std::optional<google::protobuf::FileOptions<Traits>> options;
   std::optional<google::protobuf::SourceCodeInfo<Traits>> source_code_info;
-  typename Traits::string_t syntax;
+  Traits::string_t syntax;
   google::protobuf::Edition edition = google::protobuf::Edition::EDITION_UNKNOWN;
 
   [[no_unique_address]] ::hpp_proto::pb_unknown_fields<Traits> unknown_fields_;

--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -304,7 +304,7 @@ struct extension_base {
   status set_to(Extendee<Traits> &extendee, concepts::is_option_type auto &&...option) const {
     auto &fields = pb_serializer::get_unknown_fields(extendee);
     using fields_type = std::decay_t<decltype(fields)>;
-    using bytes_type = typename fields_type::value_type::second_type;
+    using bytes_type = fields_type::value_type::second_type;
     bytes_type data;
 
     pb_context ctx{std::forward<decltype(option)>(option)...};

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1418,8 +1418,8 @@ struct contiguous_input_archive<Context, Byte> : padded_input_archive_base<Byte>
 };
 
 template <concepts::contiguous_byte_range Buffer, concepts::is_pb_context Context>
-contiguous_input_archive(const Buffer &, Context &)
-    -> contiguous_input_archive<Context, std::ranges::range_value_t<Buffer>>;
+contiguous_input_archive(const Buffer &,
+                         Context &) -> contiguous_input_archive<Context, std::ranges::range_value_t<Buffer>>;
 
 constexpr status deserialize(auto &item, std::span<const std::byte> buffer, concepts::is_pb_context auto &context) {
   contiguous_input_archive archive{buffer, context};

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -327,7 +327,7 @@ struct basic_in {
   }
 
   constexpr status deserialize_packed(std::size_t n, auto &&item) {
-    using value_type = typename std::remove_cvref_t<decltype(item)>::value_type;
+    using value_type = std::remove_cvref_t<decltype(item)>::value_type;
     std::size_t nbytes = n * sizeof(value_type);
     if (std::cmp_less(in_avail(), nbytes)) [[unlikely]] {
       return std::errc::bad_message;
@@ -482,7 +482,9 @@ struct basic_in {
   constexpr status read_bytes(uint32_t length, T &item) {
     assert(std::cmp_greater_equal(region_size(), length));
     auto data = current.consume(length);
-    item = T{(const typename T::value_type *)data.data(), length};
+    using value_type = T::value_type;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    item = T{reinterpret_cast<const value_type *>(data.data()), length};
     return {};
   }
 
@@ -602,7 +604,7 @@ constexpr status deserialize_unknown_fields(concepts::uint32_pair_contiguous_ran
                           [field_num](const auto &e) { return e.first == field_num; });
 
   using fields_type = std::remove_cvref_t<decltype(unknown_fields)>;
-  using bytes_type = typename fields_type::value_type::second_type;
+  using bytes_type = fields_type::value_type::second_type;
 
   if (itr == unknown_fields.end() && archive.in_avail() == archive.region_size()) [[likely]] {
     bytes_type field_span;
@@ -641,7 +643,7 @@ constexpr void deserialize_unknown_enum(auto &unknown_fields, uint32_t field_num
     if (itr == unknown_fields.end()) {
       unknown_fields.push_back({field_num, field_span});
     } else {
-      using bytes_type = typename unknown_fields_t::value_type::second_type;
+      using bytes_type = unknown_fields_t::value_type::second_type;
       decltype(auto) v = detail::as_modifiable(archive.context, const_cast<bytes_type &>(itr->second));
       util::append_range(v, field_span);
     }
@@ -780,7 +782,7 @@ constexpr status deserialize_packed_repeated_unpadded(Meta meta, Item &item, Arc
 template <typename Meta, concepts::is_basic_in Archive>
 constexpr status deserialize_packed_repeated(Meta meta, auto &&item, Archive &archive, auto &unknown_fields) {
   using type = std::remove_reference_t<decltype(item)>;
-  using value_type = typename type::value_type;
+  using value_type = type::value_type;
 
   using encode_type =
       std::conditional_t<std::same_as<typename Meta::type, void> || concepts::char_or_byte<value_type> ||
@@ -813,7 +815,7 @@ template <typename Meta, typename EncodeType, typename Archive, typename Item, t
 constexpr status deserialize_packed_repeated_unpadded(Meta, Item &item, Archive &archive, vuint32_t byte_count,
                                                       UnknownFields &unknown_fields) {
   using type = std::remove_reference_t<Item>;
-  using value_type = typename type::value_type;
+  using value_type = type::value_type;
 
   if (byte_count == 0) {
     if constexpr (concepts::char_or_byte<value_type>) {
@@ -876,8 +878,8 @@ constexpr status deserialize_packed_repeated_with_byte_count(concepts::resizable
 template <typename Meta, concepts::associative_container V>
 constexpr status deserialize_unpacked_associative_element(Meta, V &v, auto &hint, auto &archive) {
   using type = std::remove_reference_t<V>;
-  using value_type = typename type::value_type;
-  using element_type = typename Meta::type::mutable_type;
+  using value_type = type::value_type;
+  using element_type = Meta::type::mutable_type;
 
   element_type element;
   if (auto result = deserialize_sized(element, archive); !result.ok()) {
@@ -896,15 +898,15 @@ struct deserialize_element_type {
 
 template <concepts::is_map_entry MetaType, typename ValueType>
 struct deserialize_element_type<MetaType, ValueType> {
-  using type = typename MetaType::mutable_type;
+  using type = MetaType::mutable_type;
 };
 
 template <typename Meta, typename V, typename UnknownFields, typename Archive>
 constexpr status deserialize_unpacked_sequence_element(Meta meta, uint32_t tag, V &v, std::size_t index,
                                                        UnknownFields &unknown_fields, Archive &archive) {
   using type = std::remove_reference_t<V>;
-  using value_type = typename type::value_type;
-  using element_type = typename deserialize_element_type<typename Meta::type, value_type>::type;
+  using value_type = type::value_type;
+  using element_type = deserialize_element_type<typename Meta::type, value_type>::type;
 
   auto deserialize_element = [&](auto &element) {
     if constexpr (concepts::has_meta<element_type>) {
@@ -970,7 +972,7 @@ template <typename Meta>
 constexpr status deserialize_unpacked_repeated(Meta meta, uint32_t tag, auto &&item,
                                                concepts::is_basic_in auto &archive, auto &unknown_fields) {
   using type = std::remove_reference_t<decltype(item)>;
-  using value_type = typename type::value_type;
+  using value_type = type::value_type;
 
   decltype(auto) v = detail::as_modifiable(archive.context, item);
   if (tag_type(tag) !=
@@ -1144,7 +1146,7 @@ template <typename Meta>
 constexpr status deserialize_field(concepts::arithmetic auto &item, Meta meta, uint32_t tag,
                                    concepts::is_basic_in auto &archive, auto &unknown_fields) {
   using type = std::remove_reference_t<decltype(item)>;
-  using serialize_type = typename util::get_serialize_type<Meta, type>::type;
+  using serialize_type = util::get_serialize_type<Meta, type>::type;
   if constexpr (!std::same_as<type, serialize_type>) {
     serialize_type value;
     if (auto result = deserialize_field(value, meta, tag, archive, unknown_fields); !result.ok()) [[unlikely]] {
@@ -1207,7 +1209,7 @@ template <std::size_t Index, concepts::tuple Meta>
 constexpr status deserialize_oneof(uint32_t tag, auto &&item, concepts::is_basic_in auto &archive,
                                    auto &unknown_fields) {
   if constexpr (Index < std::tuple_size_v<Meta>) {
-    using meta = typename std::tuple_element_t<Index, Meta>;
+    using meta = std::tuple_element_t<Index, Meta>;
     if (meta::number == tag_number(tag)) {
       if constexpr (meta::closed_enum()) {
         std::variant_alternative_t<Index + 1, std::decay_t<decltype(item)>> v;
@@ -1242,7 +1244,7 @@ constexpr status deserialize_field_by_index(uint32_t tag, concepts::has_meta aut
                                             concepts::is_basic_in auto &archive, auto &&unknown_fields) {
   if constexpr (Index != UINT32_MAX) {
     using type = std::remove_reference_t<decltype(item)>;
-    using Meta = typename util::field_meta_of<type, Index>::type;
+    using Meta = util::field_meta_of<type, Index>::type;
     return deserialize_field(Meta::get(item), Meta(), tag, archive, unknown_fields);
   } else if (archive.in_avail() > 0) {
     return skip_field(tag, archive, unknown_fields);
@@ -1381,6 +1383,7 @@ struct contiguous_input_archive_base {
 };
 
 template <concepts::is_pb_context Context, typename Byte>
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct contiguous_input_archive : contiguous_input_archive_base<Byte>, basic_in<Byte, Context, true> {
   constexpr contiguous_input_archive(const auto &buffer, Context &context) noexcept
       : contiguous_input_archive_base<Byte>(buffer),
@@ -1402,6 +1405,7 @@ struct padded_input_archive_base {
 };
 
 template <concepts::is_padded_input_context Context, typename Byte>
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct contiguous_input_archive<Context, Byte> : padded_input_archive_base<Byte>, basic_in<Byte, Context, true> {
   constexpr contiguous_input_archive(const auto &buffer, Context &context) noexcept
       : padded_input_archive_base<Byte>(buffer), basic_in<Byte, Context, true>(this->region, {}, 0, context) {
@@ -1414,8 +1418,8 @@ struct contiguous_input_archive<Context, Byte> : padded_input_archive_base<Byte>
 };
 
 template <concepts::contiguous_byte_range Buffer, concepts::is_pb_context Context>
-contiguous_input_archive(const Buffer &,
-                         Context &) -> contiguous_input_archive<Context, std::ranges::range_value_t<Buffer>>;
+contiguous_input_archive(const Buffer &, Context &)
+    -> contiguous_input_archive<Context, std::ranges::range_value_t<Buffer>>;
 
 constexpr status deserialize(auto &item, std::span<const std::byte> buffer, concepts::is_pb_context auto &context) {
   contiguous_input_archive archive{buffer, context};

--- a/include/hpp_proto/binpb/meta.hpp
+++ b/include/hpp_proto/binpb/meta.hpp
@@ -133,7 +133,7 @@ constexpr auto tag_type() {
 }
 
 constexpr auto make_tag(uint32_t number, wire_type type) {
-  return varint{(number << 3U) | std::underlying_type_t<wire_type>(type)};
+  return varint{(number << 3U) | static_cast<std::underlying_type_t<wire_type>>(type)};
 }
 
 template <typename Type, typename Meta>
@@ -191,8 +191,8 @@ struct map_entry {
   using key_type = KeyType;
   using mapped_type = MappedType;
   struct mutable_type {
-    typename serialize_type<KeyType>::type key = {};
-    typename serialize_type<MappedType>::type value = {};
+    serialize_type<KeyType>::type key = {};
+    serialize_type<MappedType>::type value = {};
     constexpr static bool is_map_entry() { return true; }
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -217,14 +217,16 @@ struct map_entry {
   };
 
   struct read_only_type {
-    typename serialize_type<KeyType>::read_type key;
-    typename serialize_type<MappedType>::read_type value;
+    using key_convertible_type = serialize_type<KeyType>::convertible_type;
+    using mapped_convertible_type = serialize_type<MappedType>::convertible_type;
+
+    serialize_type<KeyType>::read_type key;
+    serialize_type<MappedType>::read_type value;
     constexpr static bool is_map_entry() { return true; }
 
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     constexpr read_only_type(auto &k, auto &v)
-        : key((typename serialize_type<KeyType>::convertible_type)k),
-          value((typename serialize_type<MappedType>::convertible_type)v) {}
+        : key(static_cast<key_convertible_type>(k)), value(static_cast<mapped_convertible_type>(v)) {}
     ~read_only_type() = default;
     read_only_type(const read_only_type &) = delete;
     read_only_type(read_only_type &&) = delete;
@@ -256,7 +258,7 @@ struct meta_of;
 
 template <concepts::has_local_meta Type>
 struct meta_of<Type> {
-  using type = typename Type::pb_meta;
+  using type = Type::pb_meta;
 };
 
 template <concepts::has_explicit_meta Type>
@@ -266,7 +268,7 @@ struct meta_of<Type> {
 
 template <concepts::has_meta Type, std::size_t Index>
 struct field_meta_of {
-  using type = typename std::tuple_element_t<Index, typename meta_of<Type>::type>;
+  using type = std::tuple_element_t<Index, typename meta_of<Type>::type>;
 };
 
 template <typename Meta, typename Type>
@@ -279,7 +281,7 @@ struct get_serialize_type<Meta, Type> {
 };
 
 template <typename Meta, typename Type>
-using get_map_entry = typename Meta::type;
+using get_map_entry = Meta::type;
 
 template <typename T, std::size_t M, std::size_t N>
 constexpr std::array<T, M + N> operator<<(std::array<T, M> lhs, std::array<T, N> rhs) {

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -79,7 +79,7 @@ struct contiguous_out {
   template <std::ranges::contiguous_range T>
   constexpr bool serialize(const T &item) {
     using type = std::remove_cvref_t<T>;
-    using value_type = typename type::value_type;
+    using value_type = type::value_type;
     static_assert(concepts::byte_serializable<value_type>);
     if (!std::is_constant_evaluated() && (!endian_swapped || sizeof(value_type) == 1)) {
       if (!item.empty()) {
@@ -147,7 +147,7 @@ struct chunked_out {
   template <std::ranges::contiguous_range T>
   bool serialize(const T &item) {
     using type = std::remove_cvref_t<T>;
-    using value_type = typename type::value_type;
+    using value_type = type::value_type;
     static_assert(concepts::byte_serializable<value_type>);
     if (!endian_swapped || sizeof(value_type) == 1) {
       auto bytes = std::as_bytes(std::span(item.data(), item.size()));
@@ -204,7 +204,7 @@ template <concepts::has_meta T>
 struct size_cache_counter<T> {
   constexpr static std::size_t count(concepts::has_meta auto const &item) {
     using type = std::remove_cvref_t<decltype(item)>;
-    using meta_type = typename util::meta_of<type>::type;
+    using meta_type = util::meta_of<type>::type;
     if constexpr (std::tuple_size_v<meta_type> == 0) {
       return 0;
     } else {
@@ -236,7 +236,7 @@ struct size_cache_counter<T> {
     if constexpr (concepts::contiguous_byte_range<type>) {
       return 0;
     }
-    using value_type = typename std::ranges::range_value_t<type>;
+    using value_type = std::ranges::range_value_t<type>;
     if constexpr (concepts::has_meta<value_type> || !meta.is_packed() || meta.is_delimited()) {
       return util::transform_accumulate(item, [](const auto &elem) constexpr { return count(elem, Meta{}); });
     } else {
@@ -255,10 +255,10 @@ struct size_cache_counter<T> {
   template <typename Meta>
   constexpr static std::size_t count(concepts::is_pair auto const &item, Meta) {
     using type = std::remove_cvref_t<decltype(item)>;
-    using serialize_type = typename util::get_serialize_type<Meta, type>::type;
+    using serialize_type = util::get_serialize_type<Meta, type>::type;
 
     static_assert(concepts::is_map_entry<serialize_type>);
-    using mapped_type = typename serialize_type::mapped_type;
+    using mapped_type = serialize_type::mapped_type;
     if constexpr (requires { *item.second; }) {
       return count(*item.second) + 2;
     } else if constexpr (concepts::has_meta<mapped_type>) {
@@ -359,7 +359,7 @@ struct message_size_calculator<T> {
 
   constexpr static uint64_t field_size(concepts::pb_unknown_fields auto const &item, auto,
                                        concepts::is_size_cache_iterator auto &) {
-    using range_t = typename std::remove_reference_t<decltype(item)>::unknown_fields_range_t;
+    using range_t = std::remove_reference_t<decltype(item)>::unknown_fields_range_t;
     if constexpr (requires { item.fields.size(); }) {
       return item.fields.size();
     } else if constexpr (concepts::contiguous_byte_range<range_t>) {
@@ -383,7 +383,7 @@ struct message_size_calculator<T> {
   constexpr static uint64_t field_size(concepts::byte_serializable auto item, Meta meta,
                                        concepts::is_size_cache_iterator auto &) {
     using type = decltype(item);
-    using serialize_type = typename util::get_serialize_type<Meta, type>::type;
+    using serialize_type = util::get_serialize_type<Meta, type>::type;
 
     constexpr auto tag_size = static_cast<uint64_t>(varint_size(meta.number << 3U));
     if constexpr (concepts::byte_serializable<serialize_type>) {
@@ -421,8 +421,8 @@ struct message_size_calculator<T> {
   constexpr static uint64_t field_size(concepts::is_pair auto const &item, Meta meta,
                                        concepts::is_size_cache_iterator auto &cache_itr) {
     using type = std::remove_cvref_t<decltype(item)>;
-    using serialize_type = typename util::get_serialize_type<Meta, type>::type;
-    using value_type = typename serialize_type::read_only_type;
+    using serialize_type = util::get_serialize_type<Meta, type>::type;
+    using value_type = serialize_type::read_only_type;
 
     constexpr auto tag_size = static_cast<uint64_t>(varint_size(meta.number << 3U));
     auto &[key, value] = item;
@@ -441,7 +441,7 @@ struct message_size_calculator<T> {
       const auto len = item.size();
       return tag_size + len_size(len);
     } else {
-      using value_type = typename std::ranges::range_value_t<type>;
+      using value_type = std::ranges::range_value_t<type>;
       if constexpr (concepts::has_meta<value_type> || !meta.is_packed() || meta.is_delimited()) {
         return util::transform_accumulate(
             item, [&cache_itr](const auto &elem) constexpr { return field_size(elem, Meta{}, cache_itr); });
@@ -617,7 +617,7 @@ status serialize(const T &item, Sink &sink, Context &context) {
 template <concepts::has_meta T>
 [[nodiscard]] constexpr bool serialize(const T &item, concepts::is_size_cache_iterator auto &cache_itr, auto &archive) {
   using type = std::remove_cvref_t<decltype(item)>;
-  using metas = typename util::meta_of<type>::type;
+  using metas = util::meta_of<type>::type;
   auto serialize_field_if_not_empty = [&](auto meta) {
     return meta.omit_value(meta.get(item)) || serialize_field(meta.get(item), meta, cache_itr, archive);
   };
@@ -642,7 +642,7 @@ template <typename Meta>
 
 [[nodiscard]] constexpr bool serialize_field(concepts::pb_unknown_fields auto const &item, auto,
                                              concepts::is_size_cache_iterator auto &, auto &archive) {
-  using range_t = typename std::remove_reference_t<decltype(item)>::unknown_fields_range_t;
+  using range_t = std::remove_reference_t<decltype(item)>::unknown_fields_range_t;
   if constexpr (concepts::contiguous_byte_range<range_t>) {
     return archive(item.fields);
   } else {
@@ -662,7 +662,7 @@ template <typename Meta>
 
 [[nodiscard]] constexpr bool serialize_field(concepts::arithmetic auto item, auto meta,
                                              concepts::is_size_cache_iterator auto &, auto &archive) {
-  using serialize_type = typename util::get_serialize_type<decltype(meta), decltype(item)>::type;
+  using serialize_type = util::get_serialize_type<decltype(meta), decltype(item)>::type;
   return archive(make_tag<serialize_type>(meta), serialize_type{item});
 }
 
@@ -694,9 +694,9 @@ template <concepts::dereferenceable T>
     auto len = varint{consume_size_cache_entry(cache_itr)};
     return archive(make_tag<decltype(item)>(meta), len) && serialize(item, cache_itr, archive);
   } else {
-    return archive(varint{(meta.number << 3U) | std::underlying_type_t<wire_type>(wire_type::sgroup)}) &&
+    return archive(varint{(meta.number << 3U) | static_cast<std::underlying_type_t<wire_type>>(wire_type::sgroup)}) &&
            serialize(item, cache_itr, archive) &&
-           archive(varint{(meta.number << 3U) | std::underlying_type_t<wire_type>(wire_type::egroup)});
+           archive(varint{(meta.number << 3U) | static_cast<std::underlying_type_t<wire_type>>(wire_type::egroup)});
   }
 }
 
@@ -704,7 +704,7 @@ template <concepts::dereferenceable T>
                                              concepts::is_size_cache_iterator auto &cache_itr, auto &archive) {
   using Meta = decltype(meta);
   using type = std::remove_cvref_t<decltype(item)>;
-  using value_type = typename std::ranges::range_value_t<type>;
+  using value_type = std::ranges::range_value_t<type>;
   using element_type =
       std::conditional_t<std::same_as<typename Meta::type, void> || concepts::contiguous_byte_range<type>, value_type,
                          typename Meta::type>;
@@ -730,7 +730,7 @@ template <typename Meta>
                                              concepts::is_size_cache_iterator auto &cache_itr, auto &archive) {
   using type = std::remove_cvref_t<decltype(item)>;
   constexpr auto tag = make_tag<type>(meta);
-  using value_type = typename util::get_map_entry<Meta, type>::read_only_type;
+  using value_type = util::get_map_entry<Meta, type>::read_only_type;
   static_assert(concepts::has_meta<value_type>);
   auto &&[key, value] = item;
   auto len = varint{consume_size_cache_entry(cache_itr)};

--- a/include/hpp_proto/binpb/varint.hpp
+++ b/include/hpp_proto/binpb/varint.hpp
@@ -116,8 +116,8 @@ template <concepts::varint VarintType, concepts::byte_type Byte>
 // pointer passed the consumed input data.
 // NOLINTBEGIN
 template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
-[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input, int64_t &res1)
-    -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
+                                                    int64_t &res1) -> decltype(std::ranges::cdata(input)) {
   // The algorithm relies on sign extension for each byte to set all high bits
   // when the varint continues. It also relies on asserting all of the lower
   // bits for each successive byte read. This allows the result to be aggregated
@@ -250,8 +250,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
   return done2();
 }
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, bool &value)
-    -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
+                                                  bool &value) -> decltype(std::ranges::cdata(input)) {
   // This function is adapted from
   // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_tctable_lite.cc
   auto p = std::ranges::cdata(input);
@@ -308,8 +308,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 }
 // NOLINTEND
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, boolean &value)
-    -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
+                                                  boolean &value) -> decltype(std::ranges::cdata(input)) {
   return unchecked_parse_bool(input, value.value);
 }
 

--- a/include/hpp_proto/binpb/varint.hpp
+++ b/include/hpp_proto/binpb/varint.hpp
@@ -41,8 +41,8 @@ enum class varint_encoding : uint8_t {
 template <varint_encoding Encoding = varint_encoding::normal>
 constexpr auto varint_size(auto value) {
   if constexpr (Encoding == varint_encoding::zig_zag) {
-    // NOLINTNEXTLINE(hicpp-signed-bitwise)
-    return varint_size(std::make_unsigned_t<decltype(value)>((value << 1) ^ (value >> (sizeof(value) * CHAR_BIT - 1))));
+    return varint_size(std::make_unsigned_t<decltype(value)>(
+        (value << 1) ^ (value >> ((sizeof(value) * CHAR_BIT) - 1)))); // // NOLINT(hicpp-signed-bitwise)
   } else {
     return ((sizeof(value) * CHAR_BIT) -
             static_cast<unsigned>(std::countl_zero(std::make_unsigned_t<decltype(value)>(value) | 1U)) +
@@ -94,7 +94,7 @@ template <concepts::varint VarintType, concepts::byte_type Byte>
   auto value = std::make_unsigned_t<typename VarintType::encode_type>(item.value);
   if constexpr (varint_encoding::zig_zag == decltype(item)::encoding) {
     // NOLINTNEXTLINE(hicpp-signed-bitwise)
-    value = (value << 1U) ^ static_cast<decltype(value)>(item.value >> (sizeof(value) * CHAR_BIT - 1U));
+    value = (value << 1U) ^ static_cast<decltype(value)>(item.value >> ((sizeof(value) * CHAR_BIT) - 1U));
   }
 
   // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
@@ -116,8 +116,8 @@ template <concepts::varint VarintType, concepts::byte_type Byte>
 // pointer passed the consumed input data.
 // NOLINTBEGIN
 template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
-[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
-                                                    int64_t &res1) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input, int64_t &res1)
+    -> decltype(std::ranges::cdata(input)) {
   // The algorithm relies on sign extension for each byte to set all high bits
   // when the varint continues. It also relies on asserting all of the lower
   // bits for each successive byte read. This allows the result to be aggregated
@@ -250,8 +250,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
   return done2();
 }
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                                  bool &value) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, bool &value)
+    -> decltype(std::ranges::cdata(input)) {
   // This function is adapted from
   // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_tctable_lite.cc
   auto p = std::ranges::cdata(input);
@@ -308,8 +308,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 }
 // NOLINTEND
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                                  boolean &value) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, boolean &value)
+    -> decltype(std::ranges::cdata(input)) {
   return unchecked_parse_bool(input, value.value);
 }
 
@@ -325,11 +325,11 @@ template <concepts::varint VarintType>
     auto p = shift_mix_parse_varint<typename VarintType::value_type>(input, res);
     auto ures = static_cast<uint64_t>(res);
     auto sign = static_cast<int64_t>(ures & 0x1ULL);
-    item = static_cast<typename VarintType::value_type>((ures >> 1U) ^ static_cast<uint64_t>(-sign));
+    item = static_cast<VarintType::value_type>((ures >> 1U) ^ static_cast<uint64_t>(-sign));
     return p;
   } else {
     auto p = shift_mix_parse_varint<typename VarintType::value_type>(input, res);
-    item = static_cast<typename VarintType::value_type>(res);
+    item = static_cast<VarintType::value_type>(res);
     return p;
   }
 }

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -74,7 +74,7 @@ class descriptor_pool {
 
 public:
   // NOLINTBEGIN(bugprone-unchecked-optional-access)
-  using traits_type = typename AddOns::traits_type;
+  using traits_type = AddOns::traits_type;
   using FieldDescriptorProto = google::protobuf::FieldDescriptorProto<traits_type>;
   using FieldOptions = google::protobuf::FieldOptions<traits_type>;
   using FeatureSet = google::protobuf::FeatureSet<traits_type>;
@@ -221,6 +221,7 @@ public:
     FieldOptions options_;
   };
 
+  // NOLINTNEXTLINE(misc-multiple-inheritance)
   class field_descriptor_t : public field_descriptor_base,
                              public AddOns::template field_descriptor<field_descriptor_t> {
   public:
@@ -265,6 +266,7 @@ public:
     OneofOptions options_;
   };
 
+  // NOLINTNEXTLINE(misc-multiple-inheritance)
   class oneof_descriptor_t : public oneof_descriptor_base,
                              public AddOns::template oneof_descriptor<oneof_descriptor_t> {
     using addon_type = AddOns::template oneof_descriptor<oneof_descriptor_t>;
@@ -312,6 +314,7 @@ public:
     EnumOptions options_;
   };
 
+  // NOLINTNEXTLINE(misc-multiple-inheritance)
   class enum_descriptor_t : public enum_descriptor_base, public AddOns::template enum_descriptor<enum_descriptor_t> {
   public:
     using addon_type = AddOns::template enum_descriptor<enum_descriptor_t>;
@@ -374,6 +377,7 @@ public:
     MessageOptions options_;
   };
 
+  // NOLINTNEXTLINE(misc-multiple-inheritance)
   class message_descriptor_t : public message_descriptor_base,
                                public AddOns::template message_descriptor<message_descriptor_t> {
   public:
@@ -422,6 +426,7 @@ public:
     FileOptions options_;
   };
 
+  // NOLINTNEXTLINE(misc-multiple-inheritance)
   class file_descriptor_t : public file_descriptor_base, public AddOns::template file_descriptor<file_descriptor_t> {
   public:
     using addon_type = AddOns::template file_descriptor<file_descriptor_t>;
@@ -945,7 +950,7 @@ private:
   }
 
   template <typename FlatMap>
-  typename FlatMap::mapped_type find_type(FlatMap &types, std::string_view qualified_name) {
+  FlatMap::mapped_type find_type(FlatMap &types, std::string_view qualified_name) {
     auto itr = types.find(qualified_name);
     return itr == types.end() ? nullptr : itr->second;
   }

--- a/include/hpp_proto/dynamic_message/expected_message_mref.hpp
+++ b/include/hpp_proto/dynamic_message/expected_message_mref.hpp
@@ -62,11 +62,11 @@ struct callable_arg<Ret (ClassType::*)(Arg) const, void> {
 // functor/lambda fallback: peel off operator()
 template <typename T>
 struct callable_arg<T, std::void_t<decltype(&T::operator())>> {
-  using type = typename callable_arg<decltype(&T::operator())>::type;
+  using type = callable_arg<decltype(&T::operator())>::type;
 };
 
 template <typename T>
-using callable_arg_t = typename callable_arg<T>::type;
+using callable_arg_t = callable_arg<T>::type;
 
 } // namespace util
 

--- a/include/hpp_proto/dynamic_message/factory_addons.hpp
+++ b/include/hpp_proto/dynamic_message/factory_addons.hpp
@@ -253,9 +253,9 @@ struct dynamic_message_factory_addons {
 };
 
 using descriptor_pool_t = descriptor_pool<dynamic_message_factory_addons>;
-using field_descriptor_t = typename descriptor_pool_t::field_descriptor_t;
-using enum_descriptor_t = typename descriptor_pool_t::enum_descriptor_t;
-using oneof_descriptor_t = typename descriptor_pool_t::oneof_descriptor_t;
-using message_descriptor_t = typename descriptor_pool_t::message_descriptor_t;
-using file_descriptor_t = typename descriptor_pool_t::file_descriptor_t;
+using field_descriptor_t = descriptor_pool_t::field_descriptor_t;
+using enum_descriptor_t = descriptor_pool_t::enum_descriptor_t;
+using oneof_descriptor_t = descriptor_pool_t::oneof_descriptor_t;
+using message_descriptor_t = descriptor_pool_t::message_descriptor_t;
+using file_descriptor_t = descriptor_pool_t::file_descriptor_t;
 } // namespace hpp_proto

--- a/include/hpp_proto/dynamic_message/field_visit.hpp
+++ b/include/hpp_proto/dynamic_message/field_visit.hpp
@@ -192,7 +192,7 @@ inline auto field_mref::visit(auto &&visitor) const {
 inline void field_mref::clone_from(const field_cref &other) const {
   assert(this->descriptor_ == &other.descriptor());
   this->visit([&](const auto &specific_mref) {
-    using cref_type = typename std::decay_t<decltype(specific_mref)>::cref_type;
+    using cref_type = std::decay_t<decltype(specific_mref)>::cref_type;
     specific_mref.clone_from(cref_type{*descriptor_, *other.storage_});
   });
 }

--- a/include/hpp_proto/dynamic_message/repeated_bytes_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_bytes_fields.hpp
@@ -110,12 +110,18 @@ public:
     s.size = static_cast<uint32_t>(n);
   }
 
-  [[nodiscard]] bool empty() const noexcept { return storage_->of_repeated_bytes.size == 0; } // NOLINT(bugprone-derived-method-shadowing-base-method)
-  [[nodiscard]] std::size_t size() const noexcept { return storage_->of_repeated_bytes.size; } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  [[nodiscard]] bool empty() const noexcept {
+    return storage_->of_repeated_bytes.size == 0;
+  } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  [[nodiscard]] std::size_t size() const noexcept {
+    return storage_->of_repeated_bytes.size;
+  } // NOLINT(bugprone-derived-method-shadowing-base-method)
   [[nodiscard]] std::size_t capacity() const noexcept { return storage_->of_repeated_bytes.capacity; }
   [[nodiscard]] iterator begin() const noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() const noexcept { return {this, storage_->of_repeated_bytes.size}; }
-  [[nodiscard]] bytes_view *data() const noexcept { return storage_->of_repeated_bytes.content; } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  [[nodiscard]] bytes_view *data() const noexcept {
+    return storage_->of_repeated_bytes.content;
+  } // NOLINT(bugprone-derived-method-shadowing-base-method)
 
   [[nodiscard]] reference operator[](std::size_t index) const noexcept {
     auto values = content_span();

--- a/include/hpp_proto/dynamic_message/repeated_bytes_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_bytes_fields.hpp
@@ -110,18 +110,18 @@ public:
     s.size = static_cast<uint32_t>(n);
   }
 
-  [[nodiscard]] bool empty() const noexcept {
+  [[nodiscard]] bool empty() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
     return storage_->of_repeated_bytes.size == 0;
-  } // NOLINT(bugprone-derived-method-shadowing-base-method)
-  [[nodiscard]] std::size_t size() const noexcept {
+  }
+  [[nodiscard]] std::size_t size() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
     return storage_->of_repeated_bytes.size;
-  } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  }
   [[nodiscard]] std::size_t capacity() const noexcept { return storage_->of_repeated_bytes.capacity; }
   [[nodiscard]] iterator begin() const noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() const noexcept { return {this, storage_->of_repeated_bytes.size}; }
-  [[nodiscard]] bytes_view *data() const noexcept {
+  [[nodiscard]] bytes_view *data() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
     return storage_->of_repeated_bytes.content;
-  } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  }
 
   [[nodiscard]] reference operator[](std::size_t index) const noexcept {
     auto values = content_span();

--- a/include/hpp_proto/dynamic_message/repeated_bytes_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_bytes_fields.hpp
@@ -110,12 +110,12 @@ public:
     s.size = static_cast<uint32_t>(n);
   }
 
-  [[nodiscard]] bool empty() const noexcept { return storage_->of_repeated_bytes.size == 0; }
-  [[nodiscard]] std::size_t size() const noexcept { return storage_->of_repeated_bytes.size; }
+  [[nodiscard]] bool empty() const noexcept { return storage_->of_repeated_bytes.size == 0; } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  [[nodiscard]] std::size_t size() const noexcept { return storage_->of_repeated_bytes.size; } // NOLINT(bugprone-derived-method-shadowing-base-method)
   [[nodiscard]] std::size_t capacity() const noexcept { return storage_->of_repeated_bytes.capacity; }
   [[nodiscard]] iterator begin() const noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() const noexcept { return {this, storage_->of_repeated_bytes.size}; }
-  [[nodiscard]] bytes_view *data() const noexcept { return storage_->of_repeated_bytes.content; }
+  [[nodiscard]] bytes_view *data() const noexcept { return storage_->of_repeated_bytes.content; } // NOLINT(bugprone-derived-method-shadowing-base-method)
 
   [[nodiscard]] reference operator[](std::size_t index) const noexcept {
     auto values = content_span();

--- a/include/hpp_proto/dynamic_message/repeated_enum_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_enum_fields.hpp
@@ -203,8 +203,10 @@ public:
   constexpr static bool is_repeated = true;
 
   template <typename U>
+  // NOLINTBEGIN(readability-redundant-typename)
   static constexpr bool settable_from_v =
       requires { typename U::is_enum_numbers_range; } || requires { typename U::is_enum_names_range; };
+  // NOLINTEND(readability-redundant-typename)
 
   repeated_enum_field_mref(const field_descriptor_t &descriptor, value_storage &storage,
                            std::pmr::monotonic_buffer_resource &mr) noexcept

--- a/include/hpp_proto/dynamic_message/repeated_enum_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_enum_fields.hpp
@@ -137,11 +137,17 @@ public:
   repeated_enum_field_cref &operator=(repeated_enum_field_cref &&) noexcept = default;
   ~repeated_enum_field_cref() = default;
 
-  [[nodiscard]] bool empty() const noexcept { return storage_->of_repeated_int32.size == 0; }
-  [[nodiscard]] std::size_t size() const noexcept { return storage_->of_repeated_int32.size; }
+  [[nodiscard]] bool empty() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
+    return storage_->of_repeated_int32.size == 0;
+  }
+  [[nodiscard]] std::size_t size() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
+    return storage_->of_repeated_int32.size;
+  }
   [[nodiscard]] iterator begin() const noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() const noexcept { return {this, storage_->of_repeated_int32.size}; }
-  [[nodiscard]] const int32_t *data() const noexcept { return storage_->of_repeated_int32.content; }
+  [[nodiscard]] const int32_t *data() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
+    return storage_->of_repeated_int32.content;
+  }
 
   [[nodiscard]] bool is_present_or_explicit_default() const noexcept { return !empty(); }
 
@@ -253,12 +259,18 @@ public:
     s.size = static_cast<uint32_t>(n);
   }
 
-  [[nodiscard]] bool empty() const noexcept { return storage_->of_repeated_int32.size == 0; }
-  [[nodiscard]] std::size_t size() const noexcept { return storage_->of_repeated_int32.size; }
+  [[nodiscard]] bool empty() const noexcept {
+    return storage_->of_repeated_int32.size == 0;
+  } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  [[nodiscard]] std::size_t size() const noexcept {
+    return storage_->of_repeated_int32.size;
+  } // NOLINT(bugprone-derived-method-shadowing-base-method)
   [[nodiscard]] std::size_t capacity() const noexcept { return storage_->of_repeated_int32.capacity; }
   [[nodiscard]] iterator begin() const noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() const noexcept { return {this, storage_->of_repeated_int32.size}; }
-  [[nodiscard]] int32_t *data() const noexcept { return storage_->of_repeated_int32.content; }
+  [[nodiscard]] int32_t *data() const noexcept {
+    return storage_->of_repeated_int32.content;
+  } // NOLINT(bugprone-derived-method-shadowing-base-method)
 
   [[nodiscard]] reference operator[](std::size_t index) const noexcept {
     assert(index < size());

--- a/include/hpp_proto/dynamic_message/repeated_enum_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_enum_fields.hpp
@@ -259,18 +259,18 @@ public:
     s.size = static_cast<uint32_t>(n);
   }
 
-  [[nodiscard]] bool empty() const noexcept {
+  [[nodiscard]] bool empty() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
     return storage_->of_repeated_int32.size == 0;
-  } // NOLINT(bugprone-derived-method-shadowing-base-method)
-  [[nodiscard]] std::size_t size() const noexcept {
+  }
+  [[nodiscard]] std::size_t size() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
     return storage_->of_repeated_int32.size;
-  } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  }
   [[nodiscard]] std::size_t capacity() const noexcept { return storage_->of_repeated_int32.capacity; }
   [[nodiscard]] iterator begin() const noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() const noexcept { return {this, storage_->of_repeated_int32.size}; }
-  [[nodiscard]] int32_t *data() const noexcept {
+  [[nodiscard]] int32_t *data() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
     return storage_->of_repeated_int32.content;
-  } // NOLINT(bugprone-derived-method-shadowing-base-method)
+  }
 
   [[nodiscard]] reference operator[](std::size_t index) const noexcept {
     assert(index < size());

--- a/include/hpp_proto/dynamic_message/repeated_field_iterator.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_field_iterator.hpp
@@ -36,9 +36,9 @@ class repeated_field_iterator {
 
 public:
   using iterator_category = std::random_access_iterator_tag;
-  using value_type = typename Field::reference;
+  using value_type = Field::reference;
   using difference_type = std::ptrdiff_t;
-  using reference = typename Field::reference;
+  using reference = Field::reference;
   using pointer = void;
   repeated_field_iterator() = default;
   repeated_field_iterator(const Field *field, std::size_t index) noexcept : field_(field), index_(index) {}

--- a/include/hpp_proto/dynamic_message/repeated_scalar_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_scalar_fields.hpp
@@ -46,7 +46,7 @@ template <typename T, field_kind_t Kind>
 class repeated_scalar_field_cref : public std::ranges::view_interface<repeated_scalar_field_cref<T, Kind>> {
 public:
   using encode_type = T;
-  using value_type = typename std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
+  using value_type = std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
   using storage_type = repeated_storage_base<value_type>;
   using difference_type = std::ptrdiff_t;
   using size_type = std::size_t;
@@ -139,7 +139,7 @@ template <typename T, field_kind_t Kind>
 class repeated_scalar_field_mref : public std::ranges::view_interface<repeated_scalar_field_mref<T, Kind>> {
 public:
   using encode_type = T;
-  using value_type = typename std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
+  using value_type = std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
   using storage_type = repeated_storage_base<value_type>;
   using difference_type = std::ptrdiff_t;
   using reference = value_type &;

--- a/include/hpp_proto/dynamic_message/repeated_string_fields.hpp
+++ b/include/hpp_proto/dynamic_message/repeated_string_fields.hpp
@@ -110,12 +110,18 @@ public:
     s.size = static_cast<uint32_t>(n);
   }
 
-  [[nodiscard]] bool empty() const noexcept { return storage_->of_repeated_string.size == 0; }
-  [[nodiscard]] std::size_t size() const noexcept { return storage_->of_repeated_string.size; }
+  [[nodiscard]] bool empty() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
+    return storage_->of_repeated_string.size == 0;
+  }
+  [[nodiscard]] std::size_t size() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
+    return storage_->of_repeated_string.size;
+  }
   [[nodiscard]] std::size_t capacity() const noexcept { return storage_->of_repeated_string.capacity; }
   [[nodiscard]] iterator begin() const noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() const noexcept { return {this, storage_->of_repeated_string.size}; }
-  [[nodiscard]] std::string_view *data() const noexcept { return storage_->of_repeated_string.content; }
+  [[nodiscard]] std::string_view *data() const noexcept { // NOLINT(bugprone-derived-method-shadowing-base-method)
+    return storage_->of_repeated_string.content;
+  }
 
   [[nodiscard]] bool is_present_or_explicit_default() const noexcept { return !empty(); }
 

--- a/include/hpp_proto/dynamic_message/scalar_fields.hpp
+++ b/include/hpp_proto/dynamic_message/scalar_fields.hpp
@@ -43,7 +43,7 @@ template <typename T, field_kind_t Kind>
 class scalar_field_cref {
 public:
   using encode_type = T;
-  using value_type = typename std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
+  using value_type = std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
   using storage_type = scalar_storage_base<value_type>;
   constexpr static field_kind_t field_kind = Kind;
   constexpr static bool is_mutable = false;
@@ -127,7 +127,7 @@ class scalar_field_mref {
 
 public:
   using encode_type = T;
-  using value_type = typename std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
+  using value_type = std::conditional_t<concepts::varint<T>, T, value_type_identity<T>>::value_type;
   using storage_type = scalar_storage_base<value_type>;
   using cref_type = scalar_field_cref<T, Kind>;
 

--- a/include/hpp_proto/dynamic_message/types.hpp
+++ b/include/hpp_proto/dynamic_message/types.hpp
@@ -55,7 +55,7 @@ struct range_value_or_void<U, std::void_t<std::ranges::range_value_t<U>>> {
   using type = std::ranges::range_value_t<U>;
 };
 template <typename U>
-using range_value_or_void_t = typename range_value_or_void<U>::type;
+using range_value_or_void_t = range_value_or_void<U>::type;
 
 template <typename T>
 struct get_traits {

--- a/include/hpp_proto/field_types.hpp
+++ b/include/hpp_proto/field_types.hpp
@@ -132,7 +132,7 @@ public:
       return unwrap(Default);
     } else {
       static_assert(sizeof(typename T::value_type) == 1);
-      auto data = static_cast<const typename T::value_type *>(Default.data());
+      auto data = static_cast<const T::value_type *>(Default.data());
       return T{data, data + Default.size()}; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     }
   }
@@ -262,6 +262,7 @@ public:
 
   template <typename... Args>
   constexpr T &emplace(Args &&...args) {
+    // NOLINTNEXTLINE(bugprone-invalid-enum-default-initialization)
     _value = T{std::forward<Args>(args)...};
     _present = true;
     return _value;
@@ -308,7 +309,8 @@ public:
   static constexpr bool default_value() { return as_bool(Default); }
 
 private:
-  static constexpr std::uint8_t default_state = 0x80U | std::uint8_t(default_value()); // use 0x80 to denote empty state
+  static constexpr std::uint8_t default_state =
+      0x80U | static_cast<std::uint8_t>(default_value()); // use 0x80 to denote empty state
   bool_proxy deref() { return bool_proxy{impl}; }
   uint8_t impl = default_state;
 
@@ -316,7 +318,7 @@ public:
   using value_type = bool;
   constexpr optional() noexcept = default;
   constexpr ~optional() noexcept = default;
-  constexpr optional(bool v) noexcept : impl(std::uint8_t(v)) {};
+  constexpr optional(bool v) noexcept : impl(static_cast<std::uint8_t>(v)) {};
   constexpr optional(const optional &) noexcept = default;
   constexpr optional(optional &&) noexcept = default;
   constexpr optional &operator=(const optional &) noexcept = default;
@@ -326,19 +328,19 @@ public:
   constexpr bool operator*() const noexcept { return value(); }
 
   bool_proxy emplace() noexcept {
-    impl = std::uint8_t(default_value());
+    impl = static_cast<std::uint8_t>(default_value());
     return deref();
   }
 
   bool_proxy emplace(bool v) noexcept {
-    impl = std::uint8_t(v);
+    impl = static_cast<std::uint8_t>(v);
     return deref();
   }
 
   [[nodiscard]] constexpr bool value() const { return static_cast<bool>(impl & 0x01U); }
 
   constexpr optional &operator=(bool v) noexcept {
-    impl = std::uint8_t(v);
+    impl = static_cast<std::uint8_t>(v);
     return *this;
   }
   constexpr bool operator==(const optional &other) const = default;
@@ -530,8 +532,8 @@ concept flat_map = requires(T t) {
 };
 
 template <typename T>
-concept reservable_flat_map = flat_map<T> && requires(std::size_t size, typename T::key_container_type keys,
-                                                      typename T::mapped_container_type values) {
+concept reservable_flat_map = flat_map<T> && requires(std::size_t size, T::key_container_type keys,
+                                                      T::mapped_container_type values) {
   keys.reserve(size);
   values.reserve(size);
 };
@@ -614,8 +616,8 @@ constexpr static void reserve(T &mut, std::size_t size) {
 }
 template <typename Traits>
 struct pb_unknown_fields {
-  using unknown_fields_range_t = typename Traits::unknown_fields_range_t;
-  [[no_unique_address]] typename Traits::unknown_fields_range_t fields;
+  using unknown_fields_range_t = Traits::unknown_fields_range_t;
+  [[no_unique_address]] Traits::unknown_fields_range_t fields;
   bool operator==(const pb_unknown_fields &) const = default;
 };
 
@@ -639,7 +641,7 @@ struct vector_trait<bool, Allocator> {
 template <typename Key, typename Mapped, template <typename> class Allocator>
 struct stable_map_trait {
   template <typename T>
-  using repeated_t = typename vector_trait<T, Allocator>::type;
+  using repeated_t = vector_trait<T, Allocator>::type;
   using type = hpp_proto::flat_map<typename repeated_t<Key>::value_type, typename repeated_t<Mapped>::value_type,
                                    std::less<Key>, repeated_t<Key>, // NOLINT(modernize-use-transparent-functors)
                                    repeated_t<Mapped>>;
@@ -659,11 +661,11 @@ struct basic_map_trait<Key, Mapped, Allocator> {
 template <template <typename> class Allocator>
 struct basic_default_traits {
   template <typename T>
-  using repeated_t = typename vector_trait<T, Allocator>::type;
+  using repeated_t = vector_trait<T, Allocator>::type;
   template <typename T>
-  using recursive_repeated_t = typename vector_trait<T, Allocator>::type;
+  using recursive_repeated_t = vector_trait<T, Allocator>::type;
   using string_t = std::basic_string<char, std::char_traits<char>, Allocator<char>>;
-  using bytes_t = typename vector_trait<std::byte, Allocator>::type;
+  using bytes_t = vector_trait<std::byte, Allocator>::type;
 
   template <typename T>
   using optional_indirect_t = hpp_proto::optional_indirect<T, Allocator<T>>;
@@ -682,7 +684,7 @@ struct basic_default_traits {
 template <template <typename> class Allocator>
 struct basic_stable_traits : basic_default_traits<Allocator> {
   template <typename Key, typename Mapped>
-  using map_t = typename stable_map_trait<Key, Mapped, Allocator>::type;
+  using map_t = stable_map_trait<Key, Mapped, Allocator>::type;
 };
 
 using default_traits = basic_default_traits<std::allocator>;

--- a/include/hpp_proto/field_types.hpp
+++ b/include/hpp_proto/field_types.hpp
@@ -532,11 +532,11 @@ concept flat_map = requires(T t) {
 };
 
 template <typename T>
-concept reservable_flat_map = flat_map<T> && requires(std::size_t size, T::key_container_type keys,
-                                                      T::mapped_container_type values) {
-  keys.reserve(size);
-  values.reserve(size);
-};
+concept reservable_flat_map =
+    flat_map<T> && requires(std::size_t size, T::key_container_type keys, T::mapped_container_type values) {
+      keys.reserve(size);
+      values.reserve(size);
+    };
 
 template <typename T>
 concept is_option_type = requires { typename std::decay_t<T>::option_type; };

--- a/include/hpp_proto/grpc/client.hpp
+++ b/include/hpp_proto/grpc/client.hpp
@@ -64,6 +64,7 @@ template <typename ServiceMethods>
 class Stub {
   class GrpcMethod : public ::grpc::internal::RpcMethod {
   public:
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
     GrpcMethod() : ::grpc::internal::RpcMethod(nullptr, RpcType::NORMAL_RPC) {}
     void set(const char *name, const char *suffix_for_stats, RpcType type,
              const std::shared_ptr<::grpc::ChannelInterface> &channel) {
@@ -135,7 +136,7 @@ public:
 
 template <typename Method>
 class ClientCallbackReactor : public ClientCallbackSelector<static_cast<RpcType>(Method::rpc_type)>::reactor {
-  using base = typename ClientCallbackSelector<static_cast<RpcType>(Method::rpc_type)>::reactor;
+  using base = ClientCallbackSelector<static_cast<RpcType>(Method::rpc_type)>::reactor;
   ::grpc::ByteBuffer request_;
   ::grpc::ByteBuffer response_;
 
@@ -146,7 +147,7 @@ public:
 
   template <typename Stub, typename Traits>
     requires(rpc_type == RpcType::NORMAL_RPC)
-  void prepare(const Stub &stub, ::grpc::ClientContext &context, const typename Method::template request_t<Traits> &req,
+  void prepare(const Stub &stub, ::grpc::ClientContext &context, const Method::template request_t<Traits> &req,
                hpp_proto::concepts::is_option_type auto &&...option) {
     auto result = ::hpp_proto::grpc::write_binpb(req, request_, std::forward<decltype(option)>(option)...);
     if (result.ok()) {
@@ -166,7 +167,7 @@ public:
 
   template <typename Stub, typename Traits>
     requires(rpc_type == RpcType::SERVER_STREAMING)
-  void prepare(const Stub &stub, ::grpc::ClientContext &context, const typename Method::template request_t<Traits> &req,
+  void prepare(const Stub &stub, ::grpc::ClientContext &context, const Method::template request_t<Traits> &req,
                hpp_proto::concepts::is_option_type auto &&...option) {
     auto result = ::hpp_proto::grpc::write_binpb(req, request_, std::forward<decltype(option)>(option)...);
     if (result.ok()) {
@@ -192,7 +193,7 @@ public:
   }
 
   template <typename Traits>
-  ::grpc::Status write(typename Method::template request_t<Traits> &req, ::grpc::WriteOptions options,
+  ::grpc::Status write(Method::template request_t<Traits> &req, ::grpc::WriteOptions options,
                        hpp_proto::concepts::is_option_type auto &&...ser_option)
     requires Method::client_streaming
   {
@@ -204,7 +205,7 @@ public:
   }
 
   template <typename Traits>
-  ::grpc::Status write(typename Method::template request_t<Traits> &req,
+  ::grpc::Status write(Method::template request_t<Traits> &req,
                        hpp_proto::concepts::is_option_type auto &&...ser_option)
     requires Method::client_streaming
   {
@@ -212,7 +213,7 @@ public:
   }
 
   template <typename Traits>
-  ::grpc::Status write_last(typename Method::template request_t<Traits> &req, ::grpc::WriteOptions options,
+  ::grpc::Status write_last(Method::template request_t<Traits> &req, ::grpc::WriteOptions options,
                             hpp_proto::concepts::is_option_type auto &&...ser_option)
     requires Method::client_streaming
   {
@@ -239,13 +240,13 @@ public:
   }
 
   template <typename Traits>
-  ::grpc::Status get_response(typename Method::template response_t<Traits> &response,
+  ::grpc::Status get_response(Method::template response_t<Traits> &response,
                               hpp_proto::concepts::is_option_type auto &&...option) {
     return ::hpp_proto::grpc::read_binpb(response, response_, std::forward<decltype(option)>(option)...);
   }
 
   template <typename Traits>
-  ::grpc::Status get_response(typename Method::template response_t<Traits> &response,
+  ::grpc::Status get_response(Method::template response_t<Traits> &response,
                               hpp_proto::concepts::is_pb_context auto &context) {
     return ::hpp_proto::grpc::read_binpb(response, response_, context);
   }

--- a/include/hpp_proto/grpc/server.hpp
+++ b/include/hpp_proto/grpc/server.hpp
@@ -30,7 +30,7 @@ public:
   RequestToken &operator=(RequestToken &&) = default;
 
   template <typename Traits>
-  ::grpc::Status get(typename Method::template request_t<Traits> &request,
+  ::grpc::Status get(Method::template request_t<Traits> &request,
                      hpp_proto::concepts::is_option_type auto &&...option) const {
     return ::hpp_proto::grpc::read_binpb(request, *req_buf_, std::forward<decltype(option)>(option)...);
   }
@@ -63,7 +63,7 @@ public:
   void finish(::grpc::Status s) { this->Finish(std::move(s)); }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply, ::grpc::Status s,
+  void finish(const Method::template response_t<Traits> &reply, ::grpc::Status s,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     auto result = ::hpp_proto::grpc::write_binpb(reply, *resp_buf_,
                                                  std::forward<decltype(serialization_option)>(serialization_option)...);
@@ -71,7 +71,7 @@ public:
   }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply,
+  void finish(const Method::template response_t<Traits> &reply,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     auto result = ::hpp_proto::grpc::write_binpb(reply, *resp_buf_,
                                                  std::forward<decltype(serialization_option)>(serialization_option)...);
@@ -103,7 +103,7 @@ public:
   void finish(::grpc::Status s) { this->Finish(std::move(s)); }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply,
+  void finish(const Method::template response_t<Traits> &reply,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     auto result =
         ::hpp_proto::grpc::write_binpb(reply, *resp_buf_, std::forward<serialization_option>(serialization_option)...);
@@ -128,7 +128,7 @@ public:
   void finish(::grpc::Status s) { this->Finish(std::move(s)); }
 
   template <typename Traits>
-  void write(const typename Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
+  void write(const Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
              hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     auto result =
         ::hpp_proto::grpc::write_binpb(reply, response_, std::forward<serialization_option>(serialization_option)...);
@@ -140,7 +140,7 @@ public:
   }
 
   template <typename Traits>
-  void write(const typename Method::template response_t<Traits> &reply,
+  void write(const Method::template response_t<Traits> &reply,
              hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     this->write(reply, ::grpc::WriteOptions{}, std::forward<serialization_option>(serialization_option)...);
   }
@@ -151,7 +151,7 @@ public:
   }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply, ::grpc::WriteOptions options, ::grpc::Status s,
+  void finish(const Method::template response_t<Traits> &reply, ::grpc::WriteOptions options, ::grpc::Status s,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     auto result =
         ::hpp_proto::grpc::write_binpb(reply, response_, std::forward<serialization_option>(serialization_option)...);
@@ -163,14 +163,14 @@ public:
   }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply,
+  void finish(const Method::template response_t<Traits> &reply,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     this->finish(reply, ::grpc::WriteOptions{}, ::grpc::Status{},
                  std::forward<serialization_option>(serialization_option)...);
   }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
+  void finish(const Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     this->finish(reply, options, ::grpc::Status{}, std::forward<serialization_option>(serialization_option)...);
   }
@@ -201,7 +201,7 @@ public:
   void finish(::grpc::Status s) { this->Finish(std::move(s)); }
 
   template <typename Traits>
-  void write(const typename Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
+  void write(const Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
              hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     auto result =
         ::hpp_proto::grpc::write_binpb(reply, response_, std::forward<serialization_option>(serialization_option)...);
@@ -213,7 +213,7 @@ public:
   }
 
   template <typename Traits>
-  void write(const typename Method::template response_t<Traits> &reply,
+  void write(const Method::template response_t<Traits> &reply,
              hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     this->write(reply, ::grpc::WriteOptions{}, std::forward<serialization_option>(serialization_option)...);
   }
@@ -224,7 +224,7 @@ public:
   }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply, ::grpc::WriteOptions options, ::grpc::Status s,
+  void finish(const Method::template response_t<Traits> &reply, ::grpc::WriteOptions options, ::grpc::Status s,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     auto result = ::hpp_proto::grpc::write_binpb(reply, response_,
                                                  std::forward<decltype(serialization_option)>(serialization_option)...);
@@ -236,14 +236,14 @@ public:
   }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
+  void finish(const Method::template response_t<Traits> &reply, ::grpc::WriteOptions options,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     this->finish(reply, options, ::grpc::Status{},
                  std::forward<decltype(serialization_option)>(serialization_option)...);
   }
 
   template <typename Traits>
-  void finish(const typename Method::template response_t<Traits> &reply,
+  void finish(const Method::template response_t<Traits> &reply,
               hpp_proto::concepts::is_option_type auto &&...serialization_option) {
     this->finish(reply, ::grpc::WriteOptions{}, ::grpc::Status{},
                  std::forward<decltype(serialization_option)>(serialization_option)...);

--- a/include/hpp_proto/indirect.hpp
+++ b/include/hpp_proto/indirect.hpp
@@ -12,12 +12,12 @@ template <typename T, typename Allocator = std::allocator<T>>
 class indirect {
 public:
   using value_type = T;
-  using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
+  using allocator_type = std::allocator_traits<Allocator>::template rebind_alloc<T>;
   using allocator_arg_t = std::allocator_arg_t;
 
 private:
   using allocator_traits = std::allocator_traits<allocator_type>;
-  using pointer = typename allocator_traits::pointer;
+  using pointer = allocator_traits::pointer;
 
   [[no_unique_address]] allocator_type alloc_{};
   pointer obj_;

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -42,6 +42,7 @@ template <typename T>
 concept is_json_context = requires { typename T::is_json_context; };
 } // namespace concepts
 template <typename... AuxContext>
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct json_context : glz::context, pb_context<AuxContext...> {
   using is_json_context = void;
   const char *error_message_name = nullptr;
@@ -65,7 +66,7 @@ concept has_nested_codec = requires { typename T::json_codec; };
 
 template <concepts::has_nested_codec T>
 struct json_codec<T> {
-  using type = typename T::json_codec;
+  using type = T::json_codec;
 };
 
 struct use_base64 {
@@ -88,7 +89,7 @@ struct to<JSON, T> {
   template <auto Opts, class B>
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   GLZ_ALWAYS_INLINE static void op(auto const &value, is_context auto &ctx, B &b, auto &ix) noexcept {
-    using codec = typename hpp_proto::json_codec<T>::type;
+    using codec = hpp_proto::json_codec<T>::type;
     if constexpr (resizable<B>) {
       std::size_t const encoded_size = codec::max_encode_size(value);
       if ((ix + 2 + encoded_size) >= b.size()) {
@@ -142,8 +143,8 @@ struct from<JSON, T> {
   template <auto Opts, class It, class End>
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   GLZ_ALWAYS_INLINE static void op(auto &value, is_context auto &ctx, It &it, End &end) {
-    using codec = typename hpp_proto::json_codec<T>::type;
-    using encoded_storage = typename codec::encoded_storage;
+    using codec = hpp_proto::json_codec<T>::type;
+    using encoded_storage = codec::encoded_storage;
     encoded_storage encoded;
     from<JSON, encoded_storage>::template op<Opts>(encoded, ctx, it, end);
     if constexpr (not Opts.null_terminated) {
@@ -541,7 +542,7 @@ inline json_status read_json(concepts::read_json_supported auto &value, concepts
       return read_json_buffer<opts>(value, view, std::forward<decltype(option)>(option)...);
     }
   } else if constexpr (requires { str.c_str(); }) {
-    using char_type = typename buffer_type::value_type;
+    using char_type = buffer_type::value_type;
     std::basic_string_view<char_type> view{str};
     return read_json_buffer<opts>(value, view, std::forward<decltype(option)>(option)...);
   } else if constexpr (std::is_pointer_v<buffer_type>) {

--- a/include/hpp_proto/json/base64.hpp
+++ b/include/hpp_proto/json/base64.hpp
@@ -38,7 +38,7 @@ struct base64 {
   using encoded_storage = std::string_view;
   constexpr static std::size_t max_encode_size(hpp_proto::concepts::contiguous_byte_range auto const &source) noexcept {
     std::size_t n = source.size();
-    return (n / 3 + (n % 3 > 0 ? 1 : 0)) * 4;
+    return ((n / 3) + (n % 3 > 0 ? 1 : 0)) * 4;
   }
 
   // @returns The number bytes written to b, -1 for error

--- a/include/hpp_proto/json/field_wrappers.hpp
+++ b/include/hpp_proto/json/field_wrappers.hpp
@@ -157,7 +157,7 @@ constexpr decltype(auto) as_optional_ref_impl() noexcept {
 }
 
 template <auto MemPtr, auto Default = std::monostate{}>
-constexpr auto as_optional_ref = as_optional_ref_impl<MemPtr, Default>();
+constexpr auto as_optional_ref = as_optional_ref_impl<MemPtr, Default>(); // NOLINT(modernize-avoid-c-style-cast)
 
 template <auto MemPtr, int Index>
 constexpr decltype(auto) as_oneof_member_impl() noexcept {

--- a/include/hpp_proto/json/timestamp_codec.hpp
+++ b/include/hpp_proto/json/timestamp_codec.hpp
@@ -167,9 +167,9 @@ public:
 
     auto buffer = std::span<char>(static_cast<char *>(std::data(b)), b.size());
     std::size_t pos = 0;
-    fixed_len_to_chars<4, '-'>(buffer, pos, (int)ymd.year());
-    fixed_len_to_chars<2, '-'>(buffer, pos, (unsigned)ymd.month());
-    fixed_len_to_chars<2, 'T'>(buffer, pos, (unsigned)ymd.day());
+    fixed_len_to_chars<4, '-'>(buffer, pos, static_cast<int>(ymd.year()));
+    fixed_len_to_chars<2, '-'>(buffer, pos, static_cast<unsigned>(ymd.month()));
+    fixed_len_to_chars<2, 'T'>(buffer, pos, static_cast<unsigned>(ymd.day()));
     fixed_len_to_chars<2, ':'>(buffer, pos, hms.hours().count());
     fixed_len_to_chars<2, ':'>(buffer, pos, hms.minutes().count());
 

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -122,7 +122,7 @@ public:
 };
 
 template <typename... T>
-struct pb_context : T::option_type... {
+struct pb_context : T::option_type... { // NOLINT(misc-multiple-inheritance)
   using is_pb_context = void;
   template <typename... U>
   constexpr explicit pb_context(U &&...ctx) : T::option_type(std::forward<U>(ctx))... {}
@@ -249,7 +249,7 @@ auto bit_cast_view(const Bytes &input_range) {
 template <concepts::dynamic_sized_view View, concepts::memory_resource MemoryResource>
 class arena_vector {
 public:
-  using value_type = typename View::value_type;
+  using value_type = View::value_type;
   using reference = value_type &;
   using const_reference = const value_type &;
   using pointer = value_type *;

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -63,7 +63,7 @@ struct message_merger {
       if constexpr (std::is_rvalue_reference_v<U &&>) {
         return std::move(src_field);
       } else {
-        return (src_field);
+        return static_cast<decltype(src_field)>(src_field);
       }
     };
     auto &&source_ref = std::forward<U>(source);

--- a/include/hpp_proto/optional_indirect.hpp
+++ b/include/hpp_proto/optional_indirect.hpp
@@ -13,12 +13,12 @@ template <typename T, typename Allocator = std::allocator<T>>
 class optional_indirect {
 public:
   using value_type = T;
-  using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
+  using allocator_type = std::allocator_traits<Allocator>::template rebind_alloc<T>;
   using allocator_arg_t = std::allocator_arg_t;
 
 private:
   using allocator_traits = std::allocator_traits<allocator_type>;
-  using pointer = typename allocator_traits::pointer;
+  using pointer = allocator_traits::pointer;
 
   [[no_unique_address]] allocator_type alloc_{};
   pointer obj_ = nullptr;

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -1098,6 +1098,7 @@ struct msg_code_generator : code_generator {
         types += (", " + type_as_template_arg(f.cpp_field_type));
       }
       format_to(target, "}};\n");
+      format_to(target, "{}// NOLINTNEXTLINE(readability-redundant-typename)\n", indent());
       format_to(target, "{}std::variant<std::monostate{}> {};\n", indent(), types, descriptor.cpp_name);
     } else {
       auto &f = fields[0];

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -344,7 +344,7 @@ struct hpp_addons {
         cpp_meta_type = "bool";
         break;
       case TYPE_STRING:
-        cpp_field_type = "typename Traits::string_t";
+        cpp_field_type = "Traits::string_t";
         qualified_cpp_field_type = cpp_field_type;
         break;
       case TYPE_GROUP:
@@ -352,7 +352,7 @@ struct hpp_addons {
       case TYPE_ENUM:
         break;
       case TYPE_BYTES:
-        cpp_field_type = "typename Traits::bytes_t";
+        cpp_field_type = "Traits::bytes_t";
         qualified_cpp_field_type = cpp_field_type;
         break;
       case TYPE_UINT32:
@@ -449,13 +449,13 @@ struct hpp_addons {
       } else if (proto.default_value == "-inf") {
         default_value = std::format("-std::numeric_limits<{}>::infinity()", cpp_field_type);
       } else if (proto.type == TYPE_FLOAT) {
-        if (proto.default_value.find('.') == std::string::npos && proto.default_value.find('e') == std::string::npos) {
+        if (!proto.default_value.contains('.') && !proto.default_value.contains('e')) {
           default_value = proto.default_value + ".0F";
         } else {
           default_value = proto.default_value + "F";
         }
       } else {
-        default_value = std::format("double({})", proto.default_value);
+        default_value = std::format("static_cast<double>({})", proto.default_value);
       }
 
       const char *wrap_type = (proto.type == TYPE_DOUBLE) ? "DOUBLE" : "FLOAT";
@@ -567,7 +567,7 @@ struct hpp_addons {
 
 hpp_proto::optional<std::string> hpp_addons::namespace_prefix;
 using hpp_gen_descriptor_pool = ::hpp_proto::descriptor_pool<hpp_addons>;
-using traits_type = typename hpp_gen_descriptor_pool::traits_type;
+using traits_type = hpp_gen_descriptor_pool::traits_type;
 using CodeGeneratorResponse = google::protobuf::compiler::CodeGeneratorResponse<traits_type>;
 
 const static hpp_proto::flat_map<std::string, std::string> well_known_codecs = {
@@ -582,7 +582,7 @@ struct code_generator {
   static std::string directory_prefix;
   static bool preserve_proto_field_names;
   std::size_t indent_num = 0;
-  typename CodeGeneratorResponse::File &file;
+  CodeGeneratorResponse::File &file;
   std::back_insert_iterator<std::string> target;
 
   using message_descriptor_t = hpp_gen_descriptor_pool::message_descriptor_t;
@@ -594,7 +594,14 @@ struct code_generator {
 
   static message_descriptor_t *parent_message_of(auto *desc) { return desc->parent_message(); }
 
-  explicit code_generator(std::vector<typename CodeGeneratorResponse::File> &files)
+  static std::string type_as_template_arg(std::string_view type) {
+    if (type.starts_with("Traits::")) {
+      return std::format("typename {}", type);
+    }
+    return std::string{type};
+  }
+
+  explicit code_generator(std::vector<CodeGeneratorResponse::File> &files)
       : file(files.emplace_back()), target(file.content) {}
 
   ~code_generator() = default;
@@ -1011,20 +1018,22 @@ struct msg_code_generator : code_generator {
       auto *type_desc = descriptor.message_field_type_descriptor();
       if (type_desc->fields()[1].is_recursive) {
         return std::format("Traits::template map_t<{}, typename Traits::template indirect_t<{}>>",
-                           type_desc->fields().front().cpp_field_type, type_desc->fields()[1].cpp_field_type);
-      } else {
-        return std::format("Traits::template map_t<{}, {}>", type_desc->fields().front().cpp_field_type,
+                           type_as_template_arg(type_desc->fields().front().cpp_field_type),
                            type_desc->fields()[1].cpp_field_type);
+      } else {
+        return std::format("Traits::template map_t<{}, {}>",
+                           type_as_template_arg(type_desc->fields().front().cpp_field_type),
+                           type_as_template_arg(type_desc->fields()[1].cpp_field_type));
       }
     }
 
     auto wrapper = field_type_wrapper(descriptor);
 
     if (wrapper == "::hpp_proto::optional" && !descriptor.default_value_template_arg.empty()) {
-      return std::format("::hpp_proto::optional<{0}, {1}>", descriptor.cpp_field_type,
+      return std::format("::hpp_proto::optional<{0}, {1}>", type_as_template_arg(descriptor.cpp_field_type),
                          descriptor.default_value_template_arg);
     } else if (!wrapper.empty()) {
-      return std::format("{}<{}>", wrapper, descriptor.cpp_field_type);
+      return std::format("{}<{}>", wrapper, type_as_template_arg(descriptor.cpp_field_type));
     }
     return descriptor.cpp_field_type;
   }
@@ -1086,7 +1095,7 @@ struct msg_code_generator : code_generator {
 
       for (auto &f : fields) {
         format_to(target, ", {}U", f.proto().number);
-        types += (", " + f.cpp_field_type);
+        types += (", " + type_as_template_arg(f.cpp_field_type));
       }
       format_to(target, "}};\n");
       format_to(target, "{}std::variant<std::monostate{}> {};\n", indent(), types, descriptor.cpp_name);
@@ -1094,7 +1103,8 @@ struct msg_code_generator : code_generator {
       auto &f = fields[0];
       std::string attribute;
 
-      format_to(target, "{}{}std::optional<{}> {};\n", indent(), attribute, f.cpp_field_type, f.cpp_name);
+      format_to(target, "{}{}std::optional<{}> {};\n", indent(), attribute, type_as_template_arg(f.cpp_field_type),
+                f.cpp_name);
     }
   }
 
@@ -1368,16 +1378,17 @@ struct hpp_meta_generator : code_generator {
       };
       auto *type_desc = descriptor.message_field_type_descriptor();
       if (type_desc->fields()[1].is_recursive) {
-        descriptor.cpp_meta_type =
-            std::format("::hpp_proto::map_entry<{}, typename Traits::template indirect_t<{}>, {}, {}>",
-                        get_meta_type(type_desc->fields()[0]), get_meta_type(type_desc->fields()[1]),
-                        join_to_string(meta_options(type_desc->fields()[0]), " | "),
-                        join_to_string(meta_options(type_desc->fields()[1]), " | "));
-      } else {
         descriptor.cpp_meta_type = std::format(
-            "::hpp_proto::map_entry<{}, {}, {}, {}>", get_meta_type(type_desc->fields()[0]),
-            get_meta_type(type_desc->fields()[1]), join_to_string(meta_options(type_desc->fields()[0]), " | "),
+            "::hpp_proto::map_entry<{}, typename Traits::template indirect_t<{}>, {}, {}>",
+            type_as_template_arg(get_meta_type(type_desc->fields()[0])), get_meta_type(type_desc->fields()[1]),
+            join_to_string(meta_options(type_desc->fields()[0]), " | "),
             join_to_string(meta_options(type_desc->fields()[1]), " | "));
+      } else {
+        descriptor.cpp_meta_type = std::format("::hpp_proto::map_entry<{}, {}, {}, {}>",
+                                               type_as_template_arg(get_meta_type(type_desc->fields()[0])),
+                                               type_as_template_arg(get_meta_type(type_desc->fields()[1])),
+                                               join_to_string(meta_options(type_desc->fields()[0]), " | "),
+                                               join_to_string(meta_options(type_desc->fields()[1]), " | "));
       }
     }
 
@@ -1427,8 +1438,9 @@ struct hpp_meta_generator : code_generator {
     auto field_value_type = descriptor.cpp_field_type;
     bool is_repeated = proto.label == LABEL_REPEATED;
 
-    auto get_result_type =
-        is_repeated ? std::format("typename Traits::template repeated_t<{}>", field_value_type) : field_value_type;
+    auto get_result_type = is_repeated
+                               ? std::format("Traits::template repeated_t<{}>", type_as_template_arg(field_value_type))
+                               : field_value_type;
 
     const char *extra_crtp_arg = "";
     if (proto.type == TYPE_MESSAGE || proto.type == TYPE_GROUP || proto.type == TYPE_STRING ||

--- a/tests/any_test.cpp
+++ b/tests/any_test.cpp
@@ -36,7 +36,7 @@ decltype(auto) expect_ok(Exp &&exp) {
 const suite test_any = [] {
   "any"_test = []<class Traits>() {
     std::pmr::monotonic_buffer_resource mr;
-    using string_t = typename Traits::string_t;
+    using string_t = Traits::string_t;
 
     ::protobuf_unittest::TestAny<Traits> message;
     ::google::protobuf::FieldMask<Traits> fm;

--- a/tests/dynamic_message_test.cpp
+++ b/tests/dynamic_message_test.cpp
@@ -1008,17 +1008,17 @@ const boost::ut::suite dynamic_message_test = [] {
 
       std::string json_buf;
       expect(::hpp_proto::write_json<opts>(msg, json_buf).ok());
-      expect(json_buf.find(R"("optionalInt32":0)") != std::string::npos);
-      expect(json_buf.find(R"("repeatedInt32":[])") != std::string::npos);
-      expect(json_buf.find(R"("optionalNestedMessage")") == std::string::npos);
+      expect(json_buf.contains(R"("optionalInt32":0)"));
+      expect(json_buf.contains(R"("repeatedInt32":[])"));
+      expect(!json_buf.contains(R"("optionalNestedMessage")"));
 
       std::string json_from_binpb;
       expect(
           ::hpp_proto::binpb_to_json<opts>(factory, "proto3_unittest.TestAllTypes", std::string_view{}, json_from_binpb)
               .ok());
-      expect(json_from_binpb.find(R"("optionalInt32":0)") != std::string::npos);
-      expect(json_from_binpb.find(R"("repeatedInt32":[])") != std::string::npos);
-      expect(json_from_binpb.find(R"("optionalNestedMessage")") == std::string::npos);
+      expect(json_from_binpb.contains(R"("optionalInt32":0)"));
+      expect(json_from_binpb.contains(R"("repeatedInt32":[])"));
+      expect(!json_from_binpb.contains(R"("optionalNestedMessage")"));
     };
 
     "json_snake_case_parsing"_test = [&factory] {
@@ -1042,8 +1042,8 @@ const boost::ut::suite dynamic_message_test = [] {
       std::string json;
       expect(hpp_proto::write_json<opts>(msg, json).ok());
       // Expect snake_case names
-      expect(json.find(R"("optional_int32":123)") != std::string::npos) << "Actual: " << json;
-      expect(json.find(R"("optional_string":"hello")") != std::string::npos) << "Actual: " << json;
+      expect(json.contains(R"("optional_int32":123)")) << "Actual: " << json;
+      expect(json.contains(R"("optional_string":"hello")")) << "Actual: " << json;
     };
 
     "repeated enum set and adopt"_test = [&factory] {

--- a/tests/grpc/grpc_test_server.cpp
+++ b/tests/grpc/grpc_test_server.cpp
@@ -39,7 +39,7 @@ std::string endpoint_from_listen_address(std::string_view address, int selected_
   if (host.empty()) {
     host = "127.0.0.1";
   }
-  if (host.find(':') != std::string::npos && host.front() != '[') {
+  if (host.contains(':') && host.front() != '[') {
     host = "[" + host + "]";
   }
 

--- a/tests/grpc/server_failure_tests.cpp
+++ b/tests/grpc/server_failure_tests.cpp
@@ -123,7 +123,7 @@ public:
   [[nodiscard]] bool finished() const { return finished_; }
   [[nodiscard]] const ::grpc::Status &finished_status() const { return finished_status_; }
 
-  void Finish(::grpc::Status status) {
+  void Finish(::grpc::Status status) { // NOLINT(bugprone-derived-method-shadowing-base-method)
     finished_ = true;
     finished_status_ = std::move(status);
   }
@@ -145,7 +145,7 @@ public:
   [[nodiscard]] bool finished() const { return finished_; }
   [[nodiscard]] const ::grpc::Status &finished_status() const { return finished_status_; }
 
-  void Finish(::grpc::Status status) {
+  void Finish(::grpc::Status status) { // NOLINT(bugprone-derived-method-shadowing-base-method)
     finished_ = true;
     finished_status_ = std::move(status);
   }

--- a/tests/grpc/server_stream_tests.cpp
+++ b/tests/grpc/server_stream_tests.cpp
@@ -78,7 +78,7 @@ void run_server_stream_case() {
   Harness harness;
   auto &stub = harness.stub();
   ::grpc::ClientContext context;
-  typename ServerStreamReactor::request_t request;
+  ServerStreamReactor::request_t request;
   request.message = "fanout";
   request.sequence = 3;
 

--- a/tests/map_test_util.hpp
+++ b/tests/map_test_util.hpp
@@ -6,9 +6,9 @@
 
 template <typename Traits>
 struct init_list {
-  using bool_t = typename Traits::template repeated_t<bool>::value_type;
-  using string_t = typename Traits::string_t;
-  using bytes_t = typename Traits::bytes_t;
+  using bool_t = Traits::template repeated_t<bool>::value_type;
+  using string_t = Traits::string_t;
+  using bytes_t = Traits::bytes_t;
   static bytes_t make_bytes(const auto &literal) { return bytes_t{literal.begin(), literal.end()}; }
 
   constexpr static auto map_int32_int32 = std::initializer_list<std::pair<std::int32_t, std::int32_t>>{{0, 0}, {1, 1}};
@@ -32,13 +32,15 @@ struct init_list {
 };
 
 template <typename Traits>
+// NOLINTNEXTLINE(readability-redundant-typename)
 const std::array<std::pair<typename Traits::string_t, typename Traits::string_t>, 2>
     init_list<Traits>::map_string_string{{
-        {typename Traits::string_t("0"), typename Traits::string_t("0")},
-        {typename Traits::string_t("1"), typename Traits::string_t("1")},
+        {init_list<Traits>::string_t("0"), init_list<Traits>::string_t("0")},
+        {init_list<Traits>::string_t("1"), init_list<Traits>::string_t("1")},
     }};
 
 template <typename Traits>
+// NOLINTNEXTLINE(readability-redundant-typename)
 const std::array<std::pair<std::int32_t, typename Traits::bytes_t>, 2> init_list<Traits>::map_int32_bytes{{
     {0, init_list<Traits>::make_bytes("0"_bytes)},
     {1, init_list<Traits>::make_bytes("1"_bytes)},

--- a/tests/test_util.hpp
+++ b/tests/test_util.hpp
@@ -47,7 +47,7 @@ constexpr auto operator""_bytes() {
   return hpp_proto::bytes_literal<str>{};
 }
 
-// NOLINTBEGIN(cert-dcl58-cpp)
+// NOLINTBEGIN(cert-dcl58-cpp, bugprone-std-namespace-modification)
 namespace std {
 template <glz::glaze_t T>
 inline std::ostream &operator<<(ostream &os, const T &v) {
@@ -105,7 +105,7 @@ std::ostream &operator<<(std::ostream &os, const equality_comparable_span<T> &sp
 }
 } // namespace hpp_proto
 
-// NOLINTEND(cert-dcl58-cpp)
+// NOLINTEND(cert-dcl58-cpp,bugprone-std-namespace-modification)
 
 #ifdef __GNUC__
 #ifdef __apple_build_version__

--- a/tests/unittest_lite_test.cpp
+++ b/tests/unittest_lite_test.cpp
@@ -15,8 +15,8 @@ struct LiteTypeMapping {
   using ImportEnum = protobuf_unittest_import::ImportEnumLite;
   using ForeignMessage_t = protobuf_unittest::ForeignMessageLite<Traits>;
   using ImportMessage_t = protobuf_unittest_import::ImportMessageLite<Traits>;
-  using NestedMessage_t = typename TestAllTypes_t::NestedMessage;
-  using RepeatedGroup_t = typename TestAllTypes_t::RepeatedGroup;
+  using NestedMessage_t = TestAllTypes_t::NestedMessage;
+  using RepeatedGroup_t = TestAllTypes_t::RepeatedGroup;
   using RepeatedGroup_extension_t = protobuf_unittest::RepeatedGroup_extension_lite<Traits>;
 
   using oneof_uint32_extension_t = protobuf_unittest::oneof_uint32_extension_lite;

--- a/tests/unittest_proto2_test.cpp
+++ b/tests/unittest_proto2_test.cpp
@@ -14,8 +14,8 @@ struct Proto2TypeMapping {
   using ImportEnum = protobuf_unittest_import::ImportEnum;
   using ForeignMessage_t = protobuf_unittest::ForeignMessage<Traits>;
   using ImportMessage_t = protobuf_unittest_import::ImportMessage<Traits>;
-  using NestedMessage_t = typename TestAllTypes_t::NestedMessage;
-  using RepeatedGroup_t = typename TestAllTypes_t::RepeatedGroup;
+  using NestedMessage_t = TestAllTypes_t::NestedMessage;
+  using RepeatedGroup_t = TestAllTypes_t::RepeatedGroup;
   using RepeatedGroup_extension_t = protobuf_unittest::RepeatedGroup_extension<Traits>;
   using TestMutualRecursionA_t = protobuf_unittest::TestMutualRecursionA<Traits>;
 

--- a/tests/unittest_proto3_test.cpp
+++ b/tests/unittest_proto3_test.cpp
@@ -30,9 +30,9 @@ struct Proto3Tests {
   using ForeignMessage = proto3_unittest::ForeignMessage<Traits>;
   using TestUnpackedTypes = proto3_unittest::TestUnpackedTypes<Traits>;
 
-  using bool_t = typename Traits::template repeated_t<bool>::value_type;
-  using string_t = typename Traits::string_t;
-  using bytes_t = typename Traits::bytes_t;
+  using bool_t = Traits::template repeated_t<bool>::value_type;
+  using string_t = Traits::string_t;
+  using bytes_t = Traits::bytes_t;
 
   // We selectively set/check a few representative fields rather than all fields
   // as this test is only expected to cover the basics of lite support.

--- a/tests/unittest_testsuite.hpp
+++ b/tests/unittest_testsuite.hpp
@@ -27,124 +27,124 @@ std::ostream &operator<<(std::ostream &os, const T &v) {
 template <typename Traits, template <typename> typename TypeMapping>
 struct TestSuite {
   using mapping_t = TypeMapping<Traits>;
-  using TestAllTypes_t = typename mapping_t::TestAllTypes_t;
-  using TestAllExtensions_t = typename mapping_t::TestAllExtensions_t;
-  using TestPackedTypes_t = typename mapping_t::TestPackedTypes_t;
-  using TestPackedExtensions_t = typename mapping_t::TestPackedExtensions_t;
+  using TestAllTypes_t = mapping_t::TestAllTypes_t;
+  using TestAllExtensions_t = mapping_t::TestAllExtensions_t;
+  using TestPackedTypes_t = mapping_t::TestPackedTypes_t;
+  using TestPackedExtensions_t = mapping_t::TestPackedExtensions_t;
 
-  using NestedEnum = typename mapping_t::NestedEnum;
-  using ForeignEnum = typename mapping_t::ForeignEnum;
-  using ImportEnum = typename mapping_t::ImportEnum;
-  using ForeignMessage_t = typename mapping_t::ForeignMessage_t;
-  using ImportMessage_t = typename mapping_t::ImportMessage_t;
-  using NestedMessage_t = typename mapping_t::NestedMessage_t;
-  using RepeatedGroup_t = typename mapping_t::RepeatedGroup_t;
-  using RepeatedGroup_extension_t = typename mapping_t::RepeatedGroup_extension_t;
+  using NestedEnum = mapping_t::NestedEnum;
+  using ForeignEnum = mapping_t::ForeignEnum;
+  using ImportEnum = mapping_t::ImportEnum;
+  using ForeignMessage_t = mapping_t::ForeignMessage_t;
+  using ImportMessage_t = mapping_t::ImportMessage_t;
+  using NestedMessage_t = mapping_t::NestedMessage_t;
+  using RepeatedGroup_t = mapping_t::RepeatedGroup_t;
+  using RepeatedGroup_extension_t = mapping_t::RepeatedGroup_extension_t;
 
-  using oneof_uint32_extension_t = typename mapping_t::oneof_uint32_extension_t;
-  using oneof_nested_message_extension_t = typename mapping_t::oneof_nested_message_extension_t;
-  using oneof_string_extension_t = typename mapping_t::oneof_string_extension_t;
-  using oneof_bytes_extension_t = typename mapping_t::oneof_bytes_extension_t;
+  using oneof_uint32_extension_t = mapping_t::oneof_uint32_extension_t;
+  using oneof_nested_message_extension_t = mapping_t::oneof_nested_message_extension_t;
+  using oneof_string_extension_t = mapping_t::oneof_string_extension_t;
+  using oneof_bytes_extension_t = mapping_t::oneof_bytes_extension_t;
 
-  using optional_int32_extension_t = typename mapping_t::optional_int32_extension_t;
-  using optional_int64_extension_t = typename mapping_t::optional_int64_extension_t;
-  using optional_uint32_extension_t = typename mapping_t::optional_uint32_extension_t;
-  using optional_uint64_extension_t = typename mapping_t::optional_uint64_extension_t;
-  using optional_sint32_extension_t = typename mapping_t::optional_sint32_extension_t;
-  using optional_sint64_extension_t = typename mapping_t::optional_sint64_extension_t;
-  using optional_fixed32_extension_t = typename mapping_t::optional_fixed32_extension_t;
-  using optional_fixed64_extension_t = typename mapping_t::optional_fixed64_extension_t;
-  using optional_sfixed32_extension_t = typename mapping_t::optional_sfixed32_extension_t;
-  using optional_sfixed64_extension_t = typename mapping_t::optional_sfixed64_extension_t;
-  using optional_float_extension_t = typename mapping_t::optional_float_extension_t;
-  using optional_double_extension_t = typename mapping_t::optional_double_extension_t;
-  using optional_bool_extension_t = typename mapping_t::optional_bool_extension_t;
-  using optional_string_extension_t = typename mapping_t::optional_string_extension_t;
-  using optional_bytes_extension_t = typename mapping_t::optional_bytes_extension_t;
+  using optional_int32_extension_t = mapping_t::optional_int32_extension_t;
+  using optional_int64_extension_t = mapping_t::optional_int64_extension_t;
+  using optional_uint32_extension_t = mapping_t::optional_uint32_extension_t;
+  using optional_uint64_extension_t = mapping_t::optional_uint64_extension_t;
+  using optional_sint32_extension_t = mapping_t::optional_sint32_extension_t;
+  using optional_sint64_extension_t = mapping_t::optional_sint64_extension_t;
+  using optional_fixed32_extension_t = mapping_t::optional_fixed32_extension_t;
+  using optional_fixed64_extension_t = mapping_t::optional_fixed64_extension_t;
+  using optional_sfixed32_extension_t = mapping_t::optional_sfixed32_extension_t;
+  using optional_sfixed64_extension_t = mapping_t::optional_sfixed64_extension_t;
+  using optional_float_extension_t = mapping_t::optional_float_extension_t;
+  using optional_double_extension_t = mapping_t::optional_double_extension_t;
+  using optional_bool_extension_t = mapping_t::optional_bool_extension_t;
+  using optional_string_extension_t = mapping_t::optional_string_extension_t;
+  using optional_bytes_extension_t = mapping_t::optional_bytes_extension_t;
 
-  using optionalgroup_extension_t = typename mapping_t::optionalgroup_extension_t;
-  using optional_nested_message_extension_t = typename mapping_t::optional_nested_message_extension_t;
-  using optional_foreign_message_extension_t = typename mapping_t::optional_foreign_message_extension_t;
-  using optional_import_message_extension_t = typename mapping_t::optional_import_message_extension_t;
-  using optional_public_import_message_extension_t = typename mapping_t::optional_public_import_message_extension_t;
-  using optional_lazy_message_extension_t = typename mapping_t::optional_lazy_message_extension_t;
+  using optionalgroup_extension_t = mapping_t::optionalgroup_extension_t;
+  using optional_nested_message_extension_t = mapping_t::optional_nested_message_extension_t;
+  using optional_foreign_message_extension_t = mapping_t::optional_foreign_message_extension_t;
+  using optional_import_message_extension_t = mapping_t::optional_import_message_extension_t;
+  using optional_public_import_message_extension_t = mapping_t::optional_public_import_message_extension_t;
+  using optional_lazy_message_extension_t = mapping_t::optional_lazy_message_extension_t;
 
-  using optional_nested_enum_extension_t = typename mapping_t::optional_nested_enum_extension_t;
-  using optional_foreign_enum_extension_t = typename mapping_t::optional_foreign_enum_extension_t;
-  using optional_import_enum_extension_t = typename mapping_t::optional_import_enum_extension_t;
+  using optional_nested_enum_extension_t = mapping_t::optional_nested_enum_extension_t;
+  using optional_foreign_enum_extension_t = mapping_t::optional_foreign_enum_extension_t;
+  using optional_import_enum_extension_t = mapping_t::optional_import_enum_extension_t;
 
-  using optional_string_piece_extension_t = typename mapping_t::optional_string_piece_extension_t;
-  using optional_cord_extension_t = typename mapping_t::optional_cord_extension_t;
+  using optional_string_piece_extension_t = mapping_t::optional_string_piece_extension_t;
+  using optional_cord_extension_t = mapping_t::optional_cord_extension_t;
 
-  using default_int32_extension_t = typename mapping_t::default_int32_extension_t;
-  using default_int64_extension_t = typename mapping_t::default_int64_extension_t;
-  using default_uint32_extension_t = typename mapping_t::default_uint32_extension_t;
-  using default_uint64_extension_t = typename mapping_t::default_uint64_extension_t;
-  using default_sint32_extension_t = typename mapping_t::default_sint32_extension_t;
-  using default_sint64_extension_t = typename mapping_t::default_sint64_extension_t;
-  using default_fixed32_extension_t = typename mapping_t::default_fixed32_extension_t;
-  using default_fixed64_extension_t = typename mapping_t::default_fixed64_extension_t;
-  using default_sfixed32_extension_t = typename mapping_t::default_sfixed32_extension_t;
-  using default_sfixed64_extension_t = typename mapping_t::default_sfixed64_extension_t;
-  using default_float_extension_t = typename mapping_t::default_float_extension_t;
-  using default_double_extension_t = typename mapping_t::default_double_extension_t;
-  using default_bool_extension_t = typename mapping_t::default_bool_extension_t;
-  using default_string_extension_t = typename mapping_t::default_string_extension_t;
-  using default_bytes_extension_t = typename mapping_t::default_bytes_extension_t;
+  using default_int32_extension_t = mapping_t::default_int32_extension_t;
+  using default_int64_extension_t = mapping_t::default_int64_extension_t;
+  using default_uint32_extension_t = mapping_t::default_uint32_extension_t;
+  using default_uint64_extension_t = mapping_t::default_uint64_extension_t;
+  using default_sint32_extension_t = mapping_t::default_sint32_extension_t;
+  using default_sint64_extension_t = mapping_t::default_sint64_extension_t;
+  using default_fixed32_extension_t = mapping_t::default_fixed32_extension_t;
+  using default_fixed64_extension_t = mapping_t::default_fixed64_extension_t;
+  using default_sfixed32_extension_t = mapping_t::default_sfixed32_extension_t;
+  using default_sfixed64_extension_t = mapping_t::default_sfixed64_extension_t;
+  using default_float_extension_t = mapping_t::default_float_extension_t;
+  using default_double_extension_t = mapping_t::default_double_extension_t;
+  using default_bool_extension_t = mapping_t::default_bool_extension_t;
+  using default_string_extension_t = mapping_t::default_string_extension_t;
+  using default_bytes_extension_t = mapping_t::default_bytes_extension_t;
 
-  using default_nested_enum_extension_t = typename mapping_t::default_nested_enum_extension_t;
-  using default_foreign_enum_extension_t = typename mapping_t::default_foreign_enum_extension_t;
-  using default_import_enum_extension_t = typename mapping_t::default_import_enum_extension_t;
+  using default_nested_enum_extension_t = mapping_t::default_nested_enum_extension_t;
+  using default_foreign_enum_extension_t = mapping_t::default_foreign_enum_extension_t;
+  using default_import_enum_extension_t = mapping_t::default_import_enum_extension_t;
 
-  using default_string_piece_extension_t = typename mapping_t::default_string_piece_extension_t;
-  using default_cord_extension_t = typename mapping_t::default_cord_extension_t;
+  using default_string_piece_extension_t = mapping_t::default_string_piece_extension_t;
+  using default_cord_extension_t = mapping_t::default_cord_extension_t;
 
-  using repeated_int32_extension_t = typename mapping_t::repeated_int32_extension_t;
-  using repeated_int64_extension_t = typename mapping_t::repeated_int64_extension_t;
-  using repeated_uint32_extension_t = typename mapping_t::repeated_uint32_extension_t;
-  using repeated_uint64_extension_t = typename mapping_t::repeated_uint64_extension_t;
-  using repeated_sint32_extension_t = typename mapping_t::repeated_sint32_extension_t;
-  using repeated_sint64_extension_t = typename mapping_t::repeated_sint64_extension_t;
-  using repeated_fixed32_extension_t = typename mapping_t::repeated_fixed32_extension_t;
-  using repeated_fixed64_extension_t = typename mapping_t::repeated_fixed64_extension_t;
-  using repeated_sfixed32_extension_t = typename mapping_t::repeated_sfixed32_extension_t;
-  using repeated_sfixed64_extension_t = typename mapping_t::repeated_sfixed64_extension_t;
-  using repeated_float_extension_t = typename mapping_t::repeated_float_extension_t;
-  using repeated_double_extension_t = typename mapping_t::repeated_double_extension_t;
-  using repeated_bool_extension_t = typename mapping_t::repeated_bool_extension_t;
-  using repeated_string_extension_t = typename mapping_t::repeated_string_extension_t;
-  using repeated_bytes_extension_t = typename mapping_t::repeated_bytes_extension_t;
+  using repeated_int32_extension_t = mapping_t::repeated_int32_extension_t;
+  using repeated_int64_extension_t = mapping_t::repeated_int64_extension_t;
+  using repeated_uint32_extension_t = mapping_t::repeated_uint32_extension_t;
+  using repeated_uint64_extension_t = mapping_t::repeated_uint64_extension_t;
+  using repeated_sint32_extension_t = mapping_t::repeated_sint32_extension_t;
+  using repeated_sint64_extension_t = mapping_t::repeated_sint64_extension_t;
+  using repeated_fixed32_extension_t = mapping_t::repeated_fixed32_extension_t;
+  using repeated_fixed64_extension_t = mapping_t::repeated_fixed64_extension_t;
+  using repeated_sfixed32_extension_t = mapping_t::repeated_sfixed32_extension_t;
+  using repeated_sfixed64_extension_t = mapping_t::repeated_sfixed64_extension_t;
+  using repeated_float_extension_t = mapping_t::repeated_float_extension_t;
+  using repeated_double_extension_t = mapping_t::repeated_double_extension_t;
+  using repeated_bool_extension_t = mapping_t::repeated_bool_extension_t;
+  using repeated_string_extension_t = mapping_t::repeated_string_extension_t;
+  using repeated_bytes_extension_t = mapping_t::repeated_bytes_extension_t;
 
-  using repeatedgroup_extension_t = typename mapping_t::repeatedgroup_extension_t;
-  using repeated_nested_message_extension_t = typename mapping_t::repeated_nested_message_extension_t;
-  using repeated_foreign_message_extension_t = typename mapping_t::repeated_foreign_message_extension_t;
-  using repeated_import_message_extension_t = typename mapping_t::repeated_import_message_extension_t;
-  using repeated_lazy_message_extension_t = typename mapping_t::repeated_lazy_message_extension_t;
-  using repeated_nested_enum_extension_t = typename mapping_t::repeated_nested_enum_extension_t;
-  using repeated_foreign_enum_extension_t = typename mapping_t::repeated_foreign_enum_extension_t;
-  using repeated_import_enum_extension_t = typename mapping_t::repeated_import_enum_extension_t;
+  using repeatedgroup_extension_t = mapping_t::repeatedgroup_extension_t;
+  using repeated_nested_message_extension_t = mapping_t::repeated_nested_message_extension_t;
+  using repeated_foreign_message_extension_t = mapping_t::repeated_foreign_message_extension_t;
+  using repeated_import_message_extension_t = mapping_t::repeated_import_message_extension_t;
+  using repeated_lazy_message_extension_t = mapping_t::repeated_lazy_message_extension_t;
+  using repeated_nested_enum_extension_t = mapping_t::repeated_nested_enum_extension_t;
+  using repeated_foreign_enum_extension_t = mapping_t::repeated_foreign_enum_extension_t;
+  using repeated_import_enum_extension_t = mapping_t::repeated_import_enum_extension_t;
 
-  using repeated_string_piece_extension_t = typename mapping_t::repeated_string_piece_extension_t;
-  using repeated_cord_extension_t = typename mapping_t::repeated_cord_extension_t;
+  using repeated_string_piece_extension_t = mapping_t::repeated_string_piece_extension_t;
+  using repeated_cord_extension_t = mapping_t::repeated_cord_extension_t;
 
-  using packed_int32_extension_t = typename mapping_t::packed_int32_extension_t;
-  using packed_int64_extension_t = typename mapping_t::packed_int64_extension_t;
-  using packed_uint32_extension_t = typename mapping_t::packed_uint32_extension_t;
-  using packed_uint64_extension_t = typename mapping_t::packed_uint64_extension_t;
-  using packed_sint32_extension_t = typename mapping_t::packed_sint32_extension_t;
-  using packed_sint64_extension_t = typename mapping_t::packed_sint64_extension_t;
-  using packed_fixed32_extension_t = typename mapping_t::packed_fixed32_extension_t;
-  using packed_fixed64_extension_t = typename mapping_t::packed_fixed64_extension_t;
-  using packed_sfixed32_extension_t = typename mapping_t::packed_sfixed32_extension_t;
-  using packed_sfixed64_extension_t = typename mapping_t::packed_sfixed64_extension_t;
-  using packed_float_extension_t = typename mapping_t::packed_float_extension_t;
-  using packed_double_extension_t = typename mapping_t::packed_double_extension_t;
-  using packed_bool_extension_t = typename mapping_t::packed_bool_extension_t;
-  using packed_enum_extension_t = typename mapping_t::packed_enum_extension_t;
+  using packed_int32_extension_t = mapping_t::packed_int32_extension_t;
+  using packed_int64_extension_t = mapping_t::packed_int64_extension_t;
+  using packed_uint32_extension_t = mapping_t::packed_uint32_extension_t;
+  using packed_uint64_extension_t = mapping_t::packed_uint64_extension_t;
+  using packed_sint32_extension_t = mapping_t::packed_sint32_extension_t;
+  using packed_sint64_extension_t = mapping_t::packed_sint64_extension_t;
+  using packed_fixed32_extension_t = mapping_t::packed_fixed32_extension_t;
+  using packed_fixed64_extension_t = mapping_t::packed_fixed64_extension_t;
+  using packed_sfixed32_extension_t = mapping_t::packed_sfixed32_extension_t;
+  using packed_sfixed64_extension_t = mapping_t::packed_sfixed64_extension_t;
+  using packed_float_extension_t = mapping_t::packed_float_extension_t;
+  using packed_double_extension_t = mapping_t::packed_double_extension_t;
+  using packed_bool_extension_t = mapping_t::packed_bool_extension_t;
+  using packed_enum_extension_t = mapping_t::packed_enum_extension_t;
 
-  using bool_t = typename Traits::template repeated_t<bool>::value_type;
-  using string_t = typename Traits::string_t;
-  using bytes_t = typename Traits::bytes_t;
+  using bool_t = Traits::template repeated_t<bool>::value_type;
+  using string_t = Traits::string_t;
+  using bytes_t = Traits::bytes_t;
 
   static bytes_t make_bytes(const auto &literal) { return bytes_t{literal.begin(), literal.end()}; }
 
@@ -595,7 +595,7 @@ struct TestSuite {
     message->packed_enum = packed_enum;
   }
 
-  static void SetAll(typename mapping_t::TestUnpackedTypes_t *message, auto && /*unused*/) {
+  static void SetAll(mapping_t::TestUnpackedTypes_t *message, auto && /*unused*/) {
     // The values applied here must match those of SetPackedFields.
 
     const static auto unpacked_int32 = std::initializer_list<int32_t>{601, 701};
@@ -690,7 +690,7 @@ struct TestSuite {
     expect(mapping_t::FOREIGN_BAZ == message.packed_enum[1]);
   }
 
-  static void ExpectAllSet(const typename mapping_t::TestUnpackedTypes_t &message) {
+  static void ExpectAllSet(const mapping_t::TestUnpackedTypes_t &message) {
     // The values expected here must match those of ExpectPackedFieldsSet.
     expect(fatal(eq(2, message.unpacked_int32.size())));
     expect(fatal(eq(2, message.unpacked_int64.size())));
@@ -825,11 +825,11 @@ struct TestSuite {
     expect_set_extension_ok(repeated_import_message_extension_t{.value = repeated_import_message});
     expect_set_extension_ok(repeated_lazy_message_extension_t{.value = repeated_lazy_message});
     expect_set_extension_ok(repeated_nested_enum_extension_t{.value = repeated_nested_enum});
-    using foreign_enum_t = typename repeated_foreign_enum_extension_t::value_type::value_type;
+    using foreign_enum_t = repeated_foreign_enum_extension_t::value_type::value_type;
     const static auto repeated_foreign_enum =
         std::initializer_list<foreign_enum_t>{mapping_t::FOREIGN_BAR, mapping_t::FOREIGN_BAZ};
     expect_set_extension_ok(repeated_foreign_enum_extension_t{.value = repeated_foreign_enum});
-    using import_enum_t = typename repeated_import_enum_extension_t::value_type::value_type;
+    using import_enum_t = repeated_import_enum_extension_t::value_type::value_type;
     const static auto repeated_import_enum =
         std::initializer_list<import_enum_t>{mapping_t::IMPORT_BAR, mapping_t::IMPORT_BAZ};
     const static auto repeated_string_piece = std::initializer_list<string_t>{"224", "324"};

--- a/tests/unittest_well_known_types_test.cpp
+++ b/tests/unittest_well_known_types_test.cpp
@@ -16,15 +16,15 @@ decltype(auto) expect_ok(Exp &&exp) {
 
 template <typename Traits>
 struct WellKnownTypesTests {
-  using string_t = typename Traits::string_t;
-  using bytes_t = typename Traits::bytes_t;
-  using value_t = typename google::protobuf::Value<Traits>;
-  using struct_t = typename google::protobuf::Struct<Traits>;
+  using string_t = Traits::string_t;
+  using bytes_t = Traits::bytes_t;
+  using value_t = google::protobuf::Value<Traits>;
+  using struct_t = google::protobuf::Struct<Traits>;
   using struct_fields_t = decltype(std::declval<struct_t>().fields);
-  using any_t = typename google::protobuf::Any<Traits>;
-  using field_mask_t = typename google::protobuf::FieldMask<Traits>;
-  using duration_t = typename google::protobuf::Duration<Traits>;
-  using timestamp_t = typename google::protobuf::Timestamp<Traits>;
+  using any_t = google::protobuf::Any<Traits>;
+  using field_mask_t = google::protobuf::FieldMask<Traits>;
+  using duration_t = google::protobuf::Duration<Traits>;
+  using timestamp_t = google::protobuf::Timestamp<Traits>;
   using TestWellKnownTypes = proto2_unittest::TestWellKnownTypes<Traits>;
 
   std::pmr::monotonic_buffer_resource pool;
@@ -181,8 +181,9 @@ struct WellKnownTypesTests {
 };
 
 template <typename Traits>
+// NOLINTNEXTLINE(readability-redundant-typename)
 std::initializer_list<typename Traits::string_t> WellKnownTypesTests<Traits>::field_mask_paths_init_list{
-    string_t{"/usr/share"}, string_t{"/usr/local/share"}};
+    WellKnownTypesTests<Traits>::string_t{"/usr/share"}, WellKnownTypesTests<Traits>::string_t{"/usr/local/share"}};
 
 const boost::ut::suite well_known_types_test = [] {
   "TestWellKnownTypes"_test = []<class Traits> {

--- a/tests/well_known_types_tests.cpp
+++ b/tests/well_known_types_tests.cpp
@@ -306,7 +306,7 @@ const ut::suite test_value = [] {
     using NullValue = google::protobuf::NullValue;
     using ListValue = google::protobuf::ListValue<Traits>;
     using Struct = google::protobuf::Struct<Traits>;
-    using Struct_value_t = typename decltype(std::declval<Struct>().fields)::value_type;
+    using Struct_value_t = decltype(std::declval<Struct>().fields)::value_type;
     "verify Value null"_test = [&factory] { verify<Value>(factory, Value{.kind = NullValue{}}, "null"); };
 
     "verify Value true"_test = [&factory] { verify<Value>(factory, Value{.kind = true}, "true"); };
@@ -402,7 +402,7 @@ const ut::suite test_value = [] {
   "struct prettify separator"_test = [&factory] {
     using Value = google::protobuf::Value<hpp_proto::stable_traits>;
     using Struct = google::protobuf::Struct<hpp_proto::stable_traits>;
-    using Struct_value_t = typename decltype(std::declval<Struct>().fields)::value_type;
+    using Struct_value_t = decltype(std::declval<Struct>().fields)::value_type;
     auto make_indirect = [](Value &v) { return hpp_proto::indirect<Value>(v); };
     Value a_value{.kind = std::string{"x"}};
     Value b_value{.kind = true};

--- a/unittests/json_serializer_tests.cpp
+++ b/unittests/json_serializer_tests.cpp
@@ -402,10 +402,10 @@ void verify(const T &msg, std::string_view json, const source_location &from_loc
 
 template <typename Traits>
 struct bytes_example {
-  typename Traits::bytes_t field0;
+  Traits::bytes_t field0;
   hpp_proto::optional<typename Traits::bytes_t> field1;
   hpp_proto::optional<typename Traits::bytes_t, hpp_proto::bytes_literal<"test">{}> field2;
-  typename Traits::bytes_t field3;
+  Traits::bytes_t field3;
   bool operator==(const bytes_example &) const = default;
 };
 
@@ -437,7 +437,7 @@ const ut::suite test_bytes = [] {
 
   "bytes"_test = []<class Traits> {
     auto make_bytes = [](const auto &literal) {
-      using bytes_t = typename Traits::bytes_t;
+      using bytes_t = Traits::bytes_t;
       if constexpr (std::same_as<Traits, hpp_proto::non_owning_traits>) {
         return bytes_t{std::span<const std::byte>{literal.begin(), literal.end()}};
       } else {

--- a/unittests/merge_message_tests.cpp
+++ b/unittests/merge_message_tests.cpp
@@ -7,7 +7,7 @@ template <typename Traits = hpp_proto::default_traits>
 struct ForeignMessage {
   std::int32_t c = {};
   std::int32_t d = {};
-  typename Traits::bytes_t e;
+  Traits::bytes_t e;
   bool operator==(const ForeignMessage &) const = default;
 };
 
@@ -108,7 +108,7 @@ auto pb_meta(const TestMessage<Traits> &)
 
 template <typename Traits = hpp_proto::default_traits>
 struct MoveRepeatedMessage {
-  typename Traits::template repeated_t<typename Traits::string_t> values;
+  Traits::template repeated_t<typename Traits::string_t> values;
   bool operator==(const MoveRepeatedMessage &) const = default;
 };
 
@@ -168,8 +168,8 @@ const boost::ut::suite merge_test_suite = [] {
           expect(dest.repeated_uint64.empty());
         };
 
-        using DestTraits = typename TraitsPair::first_type;
-        using SourceTraits = typename TraitsPair::second_type;
+        using DestTraits = TraitsPair::first_type;
+        using SourceTraits = TraitsPair::second_type;
 
         TestMessage<DestTraits> dest;
         TestMessage<SourceTraits> source;
@@ -229,8 +229,8 @@ const boost::ut::suite merge_test_suite = [] {
 
   "map_merge"_test =
       []<class TraitsPair> {
-        using DestTraits = typename TraitsPair::first_type;
-        using SourceTraits = typename TraitsPair::second_type;
+        using DestTraits = TraitsPair::first_type;
+        using SourceTraits = TraitsPair::second_type;
         using namespace boost::ut::bdd;
 
         given("dest and source") = [] {
@@ -313,8 +313,8 @@ const boost::ut::suite merge_test_suite = [] {
 
   "oneof_merge"_test =
       []<class TraitsPair> {
-        using DestTraits = typename TraitsPair::first_type;
-        using SourceTraits = typename TraitsPair::second_type;
+        using DestTraits = TraitsPair::first_type;
+        using SourceTraits = TraitsPair::second_type;
         using namespace std::string_literals;
         using namespace boost::ut::bdd;
 
@@ -404,8 +404,8 @@ const boost::ut::suite merge_test_suite = [] {
 
   "merge_optional_bool"_test =
       []<class TraitsPair> {
-        using DestTraits = typename TraitsPair::first_type;
-        using SourceTraits = typename TraitsPair::second_type;
+        using DestTraits = TraitsPair::first_type;
+        using SourceTraits = TraitsPair::second_type;
 
         should("merge const reference should overwrite optional<bool>") = [] {
           BoolOptionalMessage<DestTraits> dest;

--- a/unittests/optional_indirect_tests.cpp
+++ b/unittests/optional_indirect_tests.cpp
@@ -36,8 +36,8 @@ const boost::ut::suite optional_indirect_tests = [] {
 
   "optional_indirect"_test = []<class Traits> {
     using Message = TestRecursiveMessage<Traits>;
-    using Optional = typename Traits::template optional_indirect_t<Message>;
-    using Alloc = typename Optional::allocator_type;
+    using Optional = Traits::template optional_indirect_t<Message>;
+    using Alloc = Optional::allocator_type;
 
     auto expect_allocator_eq = [](const Alloc &lhs, const Alloc &rhs) {
       if constexpr (requires { lhs.resource(); }) {

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -328,7 +328,7 @@ const ut::suite test_repeated_vint = [] {
 
   "normal_cases"_test = []<class Traits> {
     auto make_repeated = []<typename Elem, std::size_t N>(const std::array<Elem, N> &values) {
-      using repeated_t = typename Traits::template repeated_t<Elem>;
+      using repeated_t = Traits::template repeated_t<Elem>;
       if constexpr (std::same_as<Traits, hpp_proto::non_owning_traits>) {
         return repeated_t{values};
       } else {
@@ -533,9 +533,9 @@ enum class ForeignEnumEx : int8_t { ZERO = 0, FOO = 1, BAR = 2, BAZ = 3, EXTRA =
 
 template <typename Traits = hpp_proto::default_traits>
 struct open_enum_message {
-  typename Traits::template repeated_t<ForeignEnumEx> expanded_repeated_field;
+  Traits::template repeated_t<ForeignEnumEx> expanded_repeated_field;
   ForeignEnumEx foreign_enum_field = ForeignEnumEx::ZERO;
-  typename Traits::template repeated_t<ForeignEnumEx> packed_repeated_field;
+  Traits::template repeated_t<ForeignEnumEx> packed_repeated_field;
   std::optional<example> optional_indirect_field;
   [[no_unique_address]] hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
   bool operator==(const open_enum_message &) const = default;
@@ -551,9 +551,9 @@ auto pb_meta(const open_enum_message<Traits> &)
 
 template <typename Traits = hpp_proto::default_traits>
 struct closed_enum_message {
-  typename Traits::template repeated_t<ForeignEnum> expanded_repeated_field;
+  Traits::template repeated_t<ForeignEnum> expanded_repeated_field;
   std::optional<ForeignEnum> foreign_enum_field;
-  typename Traits::template repeated_t<ForeignEnum> packed_repeated_field;
+  Traits::template repeated_t<ForeignEnum> packed_repeated_field;
   [[no_unique_address]] hpp_proto::pb_unknown_fields<Traits> unknown_fields_;
   bool operator==(const closed_enum_message &) const = default;
 };
@@ -584,7 +584,7 @@ const ut::suite test_enums = [] {
 
   "repeated_open_enum"_test = []<class Traits> {
     auto make_repeated = []<typename Elem, std::size_t N>(const std::array<Elem, N> &values) {
-      using repeated_t = typename Traits::template repeated_t<Elem>;
+      using repeated_t = Traits::template repeated_t<Elem>;
       if constexpr (std::same_as<Traits, hpp_proto::non_owning_traits>) {
         return repeated_t{values};
       } else {
@@ -896,7 +896,7 @@ const ut::suite test_map_example = [] {
 
 template <typename Traits = hpp_proto::default_traits>
 struct string_example {
-  typename Traits::string_t field;
+  Traits::string_t field;
   hpp_proto::optional<typename Traits::string_t, hpp_proto::string_literal<"test">{}> optional_field;
   bool operator==(const string_example &) const = default;
 };
@@ -970,7 +970,7 @@ const ut::suite test_string_example = [] {
 
 template <typename Traits = hpp_proto::default_traits>
 struct bytes_example {
-  typename Traits::bytes_t field;
+  Traits::bytes_t field;
   hpp_proto::optional<typename Traits::bytes_t, hpp_proto::bytes_literal<"test">{}> optional_field;
   bool operator==(const bytes_example &) const = default;
 };
@@ -1257,9 +1257,9 @@ const ut::suite test_repeated_strings = [] {
   };
 
   "repeated_strings_case"_test = []<class Traits> {
-    using element_type = typename Traits::string_t;
+    using element_type = Traits::string_t;
     auto make_repeated = []<typename Elem, std::size_t N>(const std::array<Elem, N> &values) {
-      using repeated_t = typename Traits::template repeated_t<Elem>;
+      using repeated_t = Traits::template repeated_t<Elem>;
       if constexpr (std::same_as<Traits, hpp_proto::non_owning_traits>) {
         return repeated_t{values};
       } else {
@@ -1388,7 +1388,7 @@ struct i32_ext : hpp_proto::extension_base<i32_ext<Traits>, extension_example> {
 
 template <typename Traits = ::hpp_proto::default_traits>
 struct string_ext : ::hpp_proto::extension_base<string_ext<Traits>, extension_example> {
-  using value_type = typename Traits::string_t;
+  using value_type = Traits::string_t;
   value_type value = {};
   using pb_meta =
       std::tuple<::hpp_proto::field_meta<11, &string_ext<Traits>::value,
@@ -1421,7 +1421,7 @@ struct example_ext : ::hpp_proto::extension_base<example_ext<Traits>, extension_
 
 template <typename Traits = ::hpp_proto::default_traits>
 struct repeated_i32_ext : ::hpp_proto::extension_base<repeated_i32_ext<Traits>, extension_example> {
-  using value_type = typename Traits::template repeated_t<std::int32_t>;
+  using value_type = Traits::template repeated_t<std::int32_t>;
   value_type value;
   using pb_meta = std::tuple<
       ::hpp_proto::field_meta<20, &repeated_i32_ext<Traits>::value, field_option::none, hpp_proto::vint64_t>>;
@@ -1429,14 +1429,14 @@ struct repeated_i32_ext : ::hpp_proto::extension_base<repeated_i32_ext<Traits>, 
 
 template <typename Traits = ::hpp_proto::default_traits>
 struct repeated_string_ext : ::hpp_proto::extension_base<repeated_string_ext<Traits>, extension_example> {
-  using value_type = typename Traits::template repeated_t<typename Traits::string_t>;
+  using value_type = Traits::template repeated_t<typename Traits::string_t>;
   value_type value;
   using pb_meta = std::tuple<::hpp_proto::field_meta<21, &repeated_string_ext<Traits>::value, field_option::none>>;
 };
 
 template <typename Traits = ::hpp_proto::default_traits>
 struct repeated_packed_i32_ext : ::hpp_proto::extension_base<repeated_packed_i32_ext<Traits>, extension_example> {
-  using value_type = typename Traits::template repeated_t<std::int32_t>;
+  using value_type = Traits::template repeated_t<std::int32_t>;
   value_type value;
   using pb_meta = std::tuple<::hpp_proto::field_meta<22, &repeated_packed_i32_ext<Traits>::value,
                                                      field_option::is_packed, hpp_proto::vint64_t>>;


### PR DESCRIPTION
## Summary

Fixes clang-tidy failures reported by newer LLVM/clang-tidy checks while preserving existing runtime behavior.

## What changed

- Removed redundant `typename` usage across library headers, tests, and checked-in generated protobuf headers.
- Updated the protoc plugin to emit clang-tidy-clean generated code, including targeted suppression for oneof `std::variant` cases where dependent `typename` is required by compilers.
- Added narrow `NOLINT` annotations for intentional patterns, such as range view-interface method shadowing, multiple inheritance adapters, and `decltype(auto)` reference preservation.

## Why

LLVM 22 enables/reports additional diagnostics under the project’s broad clang-tidy configuration, causing CI failures. The changes prefer source cleanup where possible and use local suppressions only where the warning conflicts with required C++ syntax or intentional API design.
