### PR TITLE
Remove floating-point NTTP workaround

### DIFF
--- a/include/hpp_proto/binpb/meta.hpp
+++ b/include/hpp_proto/binpb/meta.hpp
@@ -49,7 +49,7 @@ struct accessor_type {
 template <uint32_t Number, uint8_t FieldOptions, typename Type, auto DefaultValue>
 struct field_meta_base {
   constexpr static uint32_t number = Number;
-  constexpr static auto default_value = unwrap(DefaultValue);
+  constexpr static auto default_value = DefaultValue;
 
   using type = Type;
 

--- a/include/hpp_proto/field_types.hpp
+++ b/include/hpp_proto/field_types.hpp
@@ -70,44 +70,6 @@ using stdext::sorted_unique;
 
 namespace hpp_proto {
 
-// workaround for clang not supporting floating-point types in non-type template
-// parameters as of clang-15
-template <int64_t x>
-struct double_wrapper {
-  constexpr bool operator==(double v) const { return v == std::bit_cast<double>(x); }
-};
-template <int32_t x>
-struct float_wrapper {
-  constexpr bool operator==(float v) const { return v == std::bit_cast<float>(x); }
-};
-
-// NOLINTBEGIN(cppcoreguidelines-macro-usage)
-#ifdef __clang__
-#define HPP_PROTO_WRAP_FLOAT(v)                                                                                        \
-  hpp_proto::float_wrapper<std::bit_cast<int32_t>(v)> {}
-#define HPP_PROTO_WRAP_DOUBLE(v)                                                                                       \
-  hpp_proto::double_wrapper<std::bit_cast<int64_t>(v)> {}
-#else
-#define HPP_PROTO_WRAP_FLOAT(v) v
-#define HPP_PROTO_WRAP_DOUBLE(v) v
-#endif
-// NOLINTEND(cppcoreguidelines-macro-usage)
-
-template <int64_t x>
-static constexpr auto unwrap(double_wrapper<x> /* unused */) {
-  return std::bit_cast<double>(x);
-}
-
-template <int32_t x>
-static constexpr auto unwrap(float_wrapper<x> /* unused */) {
-  return std::bit_cast<float>(x);
-}
-
-template <typename T>
-static constexpr auto unwrap(T v) {
-  return v;
-}
-
 namespace concepts {
 template <typename T>
 concept optional = requires(T optional) {
@@ -129,7 +91,7 @@ public:
     if constexpr (std::same_as<std::remove_cvref_t<decltype(Default)>, std::monostate>) {
       return T{};
     } else if constexpr (std::is_fundamental_v<T> || std::is_enum_v<T>) {
-      return unwrap(Default);
+      return Default;
     } else {
       static_assert(sizeof(typename T::value_type) == 1);
       auto data = static_cast<const T::value_type *>(Default.data());

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -458,9 +458,7 @@ struct hpp_addons {
         default_value = std::format("static_cast<double>({})", proto.default_value);
       }
 
-      const char *wrap_type = (proto.type == TYPE_DOUBLE) ? "DOUBLE" : "FLOAT";
-
-      default_value_template_arg = std::format("HPP_PROTO_WRAP_{}({})", wrap_type, default_value);
+      default_value_template_arg = default_value;
     }
 
     [[nodiscard]] std::string_view qualified_parent_name() const {


### PR DESCRIPTION
## Summary

Removes the old floating-point non-type template parameter workaround now that supported compilers can use floating-point values directly as NTTPs.

## What changed

- Removed `float_wrapper`, `double_wrapper`, `unwrap`, and the `HPP_PROTO_WRAP_FLOAT` / `HPP_PROTO_WRAP_DOUBLE` macros.
- Updated default-value handling to use `DefaultValue` directly in `field_meta_base`.
- Updated the protoc plugin to emit floating-point defaults directly instead of wrapping them.

## Why

The workaround existed for older Clang versions that did not support floating-point NTTPs. It adds complexity to generated code and field metadata that is no longer needed for the current toolchain baseline.


## Notes

- This changes generated code shape for floating-point defaults, but not the intended serialized/deserialized values.
- Requires compiler support for floating-point non-type template parameters.