### PR TITLE
Add clang-format 22 format target

### DIFF
--- a/.github/workflows/auto-clang-format.yml
+++ b/.github/workflows/auto-clang-format.yml
@@ -6,13 +6,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: DoozyX/clang-format-lint-action@v0.18.2
-      with:
-        source: '.'
-        exclude: './third_party ./external'
-        extensions: 'h,cpp,hpp'
-        clangFormatVersion: 18
-        inplace: True
+    - name: Check clang-format version
+      run: docker run --rm xianpengshen/clang-tools:22 clang-format --version
+    - name: Run clang-format
+      run: |
+        find . \
+          -path './.git' -prune -o \
+          -path './third_party' -prune -o \
+          -path './external' -prune -o \
+          \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \) \
+          -print0 |
+          xargs -0 docker run --rm -i -v "$PWD:/src" -w /src xianpengshen/clang-tools:22 clang-format -i
     - uses: EndBug/add-and-commit@v9
       with:
         author_name: Clang Robot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,35 @@ project(hpp_proto
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(PROJECT_IS_TOP_LEVEL)
+  find_program(HPP_PROTO_CLANG_FORMAT NAMES clang-format)
+  file(GLOB_RECURSE HPP_PROTO_FORMAT_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/fuzz/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/fuzz/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tutorial/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tutorial/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/unittests/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/unittests/*.hpp")
+
+  if(HPP_PROTO_CLANG_FORMAT)
+    add_custom_target(format
+      COMMAND "${HPP_PROTO_CLANG_FORMAT}" -i ${HPP_PROTO_FORMAT_SOURCES}
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      COMMENT "Running clang-format"
+      VERBATIM)
+  else()
+    message(STATUS "clang-format not found; the format target will not be available")
+  endif()
+endif()
+
 set(HPP_PROTO_PROTOC "find" CACHE STRING "'find' for locating using find_program, or 'compile' for compiling from source")
 set_property(CACHE HPP_PROTO_PROTOC PROPERTY STRINGS "find" "compile")
 set(HPP_PROTO_PROTOC_GEN_HPP "" CACHE FILEPATH

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1418,8 +1418,8 @@ struct contiguous_input_archive<Context, Byte> : padded_input_archive_base<Byte>
 };
 
 template <concepts::contiguous_byte_range Buffer, concepts::is_pb_context Context>
-contiguous_input_archive(const Buffer &,
-                         Context &) -> contiguous_input_archive<Context, std::ranges::range_value_t<Buffer>>;
+contiguous_input_archive(const Buffer &, Context &)
+    -> contiguous_input_archive<Context, std::ranges::range_value_t<Buffer>>;
 
 constexpr status deserialize(auto &item, std::span<const std::byte> buffer, concepts::is_pb_context auto &context) {
   contiguous_input_archive archive{buffer, context};

--- a/include/hpp_proto/binpb/varint.hpp
+++ b/include/hpp_proto/binpb/varint.hpp
@@ -116,8 +116,8 @@ template <concepts::varint VarintType, concepts::byte_type Byte>
 // pointer passed the consumed input data.
 // NOLINTBEGIN
 template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
-[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input,
-                                                    int64_t &res1) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto shift_mix_parse_varint(concepts::contiguous_byte_range auto const &input, int64_t &res1)
+    -> decltype(std::ranges::cdata(input)) {
   // The algorithm relies on sign extension for each byte to set all high bits
   // when the varint continues. It also relies on asserting all of the lower
   // bits for each successive byte read. This allows the result to be aggregated
@@ -250,8 +250,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
   return done2();
 }
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                                  bool &value) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, bool &value)
+    -> decltype(std::ranges::cdata(input)) {
   // This function is adapted from
   // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_tctable_lite.cc
   auto p = std::ranges::cdata(input);
@@ -308,8 +308,8 @@ template <typename Type, int MAX_BYTES = ((sizeof(Type) * 8 + 6) / 7)>
 }
 // NOLINTEND
 
-[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input,
-                                                  boolean &value) -> decltype(std::ranges::cdata(input)) {
+[[nodiscard]] constexpr auto unchecked_parse_bool(concepts::contiguous_byte_range auto const &input, boolean &value)
+    -> decltype(std::ranges::cdata(input)) {
   return unchecked_parse_bool(input, value.value);
 }
 

--- a/include/hpp_proto/flat_map.hpp
+++ b/include/hpp_proto/flat_map.hpp
@@ -1140,9 +1140,9 @@ flat_map(Container) -> flat_map<flatmap_detail::cont_key_type<Container>, flatma
 template <class KeyContainer, class MappedContainer,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<KeyContainer>::value &&
                                    !flatmap_detail::qualifies_as_allocator<MappedContainer>::value>>
-flat_map(KeyContainer,
-         MappedContainer) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                      std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(KeyContainer, MappedContainer)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value &&
@@ -1157,20 +1157,20 @@ template <class KeyContainer, class MappedContainer, class Allocator,
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value &&
                                    std::uses_allocator<KeyContainer, Allocator>::value &&
                                    std::uses_allocator<MappedContainer, Allocator>::value>>
-flat_map(KeyContainer, MappedContainer,
-         Allocator) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(KeyContainer, MappedContainer, Allocator)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value>>
-flat_map(sorted_unique_t,
-         Container) -> flat_map<flatmap_detail::cont_key_type<Container>, flatmap_detail::cont_mapped_type<Container>>;
+flat_map(sorted_unique_t, Container)
+    -> flat_map<flatmap_detail::cont_key_type<Container>, flatmap_detail::cont_mapped_type<Container>>;
 
 template <class KeyContainer, class MappedContainer,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<KeyContainer>::value &&
                                    !flatmap_detail::qualifies_as_allocator<MappedContainer>::value>>
-flat_map(sorted_unique_t, KeyContainer,
-         MappedContainer) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                      std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(sorted_unique_t, KeyContainer, MappedContainer)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class Container, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Container>::value &&
@@ -1185,9 +1185,9 @@ template <class KeyContainer, class MappedContainer, class Allocator,
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value &&
                                    std::uses_allocator<KeyContainer, Allocator>::value &&
                                    std::uses_allocator<MappedContainer, Allocator>::value>>
-flat_map(sorted_unique_t, KeyContainer, MappedContainer,
-         Allocator) -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
-                                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
+flat_map(sorted_unique_t, KeyContainer, MappedContainer, Allocator)
+    -> flat_map<typename KeyContainer::value_type, typename MappedContainer::value_type,
+                std::less<typename KeyContainer::value_type>, KeyContainer, MappedContainer>;
 
 template <class InputIterator, class Compare = std::less<flatmap_detail::iter_key_type<InputIterator>>,
           class = std::enable_if_t<flatmap_detail::qualifies_as_input_iterator<InputIterator>::value &&
@@ -1242,19 +1242,19 @@ flat_map(std::initializer_list<std::pair<const Key, T>>, Allocator, int = 0 /*to
 
 template <class Key, class T, class Compare = std::less<Key>,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Compare>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>,
-         Compare = Compare()) -> flat_map<Key, T, Compare>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare = Compare())
+    -> flat_map<Key, T, Compare>;
 
 template <class Key, class T, class Compare, class Allocator,
           class = std::enable_if_t<!flatmap_detail::qualifies_as_allocator<Compare>::value &&
                                    flatmap_detail::qualifies_as_allocator<Allocator>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare,
-         Allocator) -> flat_map<Key, T, Compare>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Compare, Allocator)
+    -> flat_map<Key, T, Compare>;
 
 template <class Key, class T, class Allocator,
           class = std::enable_if_t<flatmap_detail::qualifies_as_allocator<Allocator>::value>>
-flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Allocator,
-         int = 0 /*to please MSVC*/) -> flat_map<Key, T>;
+flat_map(sorted_unique_t, std::initializer_list<std::pair<const Key, T>>, Allocator, int = 0 /*to please MSVC*/)
+    -> flat_map<Key, T>;
 
 #endif
 

--- a/include/hpp_proto/json.hpp
+++ b/include/hpp_proto/json.hpp
@@ -603,8 +603,8 @@ inline json_status write_json(concepts::write_json_supported auto const &value,
 /// @param option Optional configuration parameters.
 /// @return A std::expected containing the buffer on success, or a json_status on failure.
 template <auto Opts = json_write_opts{}, concepts::contiguous_byte_range Buffer = std::string>
-inline auto write_json(concepts::write_json_supported auto const &value,
-                       concepts::is_option_type auto &&...option) -> std::expected<Buffer, json_status> {
+inline auto write_json(concepts::write_json_supported auto const &value, concepts::is_option_type auto &&...option)
+    -> std::expected<Buffer, json_status> {
   std::expected<Buffer, json_status> result;
   detail::always_print_guard guard{Opts.always_print_fields_with_no_presence};
   auto ec = write_json<Opts>(value, *result, std::forward<decltype(option)>(option)...);

--- a/unittests/merge_message_tests.cpp
+++ b/unittests/merge_message_tests.cpp
@@ -12,11 +12,10 @@ struct ForeignMessage {
 };
 
 template <typename Traits>
-auto pb_meta(const ForeignMessage<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &ForeignMessage<Traits>::c, hpp_proto::field_option::none, hpp_proto::vint64_t>,
-        hpp_proto::field_meta<2, &ForeignMessage<Traits>::d, hpp_proto::field_option::none, hpp_proto::vint64_t>,
-        hpp_proto::field_meta<15, &ForeignMessage<Traits>::e, hpp_proto::field_option::none>>;
+auto pb_meta(const ForeignMessage<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &ForeignMessage<Traits>::c, hpp_proto::field_option::none, hpp_proto::vint64_t>,
+    hpp_proto::field_meta<2, &ForeignMessage<Traits>::d, hpp_proto::field_option::none, hpp_proto::vint64_t>,
+    hpp_proto::field_meta<15, &ForeignMessage<Traits>::e, hpp_proto::field_option::none>>;
 
 #if defined(__GNUC__) && (__GNUC__ < 14) && !defined(__clang__)
 namespace std {
@@ -66,45 +65,42 @@ struct TestMessage {
 };
 
 template <typename Traits>
-auto pb_meta(const TestMessage<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &TestMessage<Traits>::optional_int32, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vint64_t>,
-        hpp_proto::field_meta<2, &TestMessage<Traits>::optional_int64, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vint64_t>,
-        hpp_proto::field_meta<3, &TestMessage<Traits>::optional_uint32, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vuint32_t>,
-        hpp_proto::field_meta<4, &TestMessage<Traits>::optional_uint64, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vuint64_t>,
-        hpp_proto::field_meta<14, &TestMessage<Traits>::optional_string, hpp_proto::field_option::explicit_presence>,
-        hpp_proto::field_meta<15, &TestMessage<Traits>::optional_bytes, hpp_proto::field_option::explicit_presence>,
-        hpp_proto::field_meta<19, &TestMessage<Traits>::optional_foreign_message,
-                              hpp_proto::field_option::explicit_presence>,
-        hpp_proto::field_meta<31, &TestMessage<Traits>::repeated_int32, hpp_proto::field_option::none,
-                              hpp_proto::vint64_t>,
-        hpp_proto::field_meta<32, &TestMessage<Traits>::repeated_int64, hpp_proto::field_option::none,
-                              hpp_proto::vint64_t>,
-        hpp_proto::field_meta<33, &TestMessage<Traits>::repeated_uint32, hpp_proto::field_option::none,
-                              hpp_proto::vuint32_t>,
-        hpp_proto::field_meta<34, &TestMessage<Traits>::repeated_uint64, hpp_proto::field_option::none,
-                              hpp_proto::vuint64_t>,
-        hpp_proto::field_meta<61, &TestMessage<Traits>::default_int32, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vint64_t>,
-        hpp_proto::field_meta<62, &TestMessage<Traits>::default_int64, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vint64_t>,
-        hpp_proto::field_meta<63, &TestMessage<Traits>::default_uint32, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vuint32_t>,
-        hpp_proto::field_meta<64, &TestMessage<Traits>::default_uint64, hpp_proto::field_option::explicit_presence,
-                              hpp_proto::vuint64_t>,
-        hpp_proto::field_meta<71, &TestMessage<Traits>::map_int32_int32, hpp_proto::field_option::none,
-                              hpp_proto::map_entry<hpp_proto::vint64_t, hpp_proto::vint64_t,
-                                                   hpp_proto::field_option::none, hpp_proto::field_option::none>>,
-        hpp_proto::oneof_field_meta<
-            &TestMessage<Traits>::oneof_field,
-            hpp_proto::field_meta<111, 1, hpp_proto::field_option::explicit_presence, hpp_proto::vuint32_t>,
-            hpp_proto::field_meta<112, 2, hpp_proto::field_option::explicit_presence>,
-            hpp_proto::field_meta<113, 3, hpp_proto::field_option::explicit_presence>,
-            hpp_proto::field_meta<114, 4, hpp_proto::field_option::explicit_presence>>>;
+auto pb_meta(const TestMessage<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &TestMessage<Traits>::optional_int32, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vint64_t>,
+    hpp_proto::field_meta<2, &TestMessage<Traits>::optional_int64, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vint64_t>,
+    hpp_proto::field_meta<3, &TestMessage<Traits>::optional_uint32, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vuint32_t>,
+    hpp_proto::field_meta<4, &TestMessage<Traits>::optional_uint64, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vuint64_t>,
+    hpp_proto::field_meta<14, &TestMessage<Traits>::optional_string, hpp_proto::field_option::explicit_presence>,
+    hpp_proto::field_meta<15, &TestMessage<Traits>::optional_bytes, hpp_proto::field_option::explicit_presence>,
+    hpp_proto::field_meta<19, &TestMessage<Traits>::optional_foreign_message,
+                          hpp_proto::field_option::explicit_presence>,
+    hpp_proto::field_meta<31, &TestMessage<Traits>::repeated_int32, hpp_proto::field_option::none, hpp_proto::vint64_t>,
+    hpp_proto::field_meta<32, &TestMessage<Traits>::repeated_int64, hpp_proto::field_option::none, hpp_proto::vint64_t>,
+    hpp_proto::field_meta<33, &TestMessage<Traits>::repeated_uint32, hpp_proto::field_option::none,
+                          hpp_proto::vuint32_t>,
+    hpp_proto::field_meta<34, &TestMessage<Traits>::repeated_uint64, hpp_proto::field_option::none,
+                          hpp_proto::vuint64_t>,
+    hpp_proto::field_meta<61, &TestMessage<Traits>::default_int32, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vint64_t>,
+    hpp_proto::field_meta<62, &TestMessage<Traits>::default_int64, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vint64_t>,
+    hpp_proto::field_meta<63, &TestMessage<Traits>::default_uint32, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vuint32_t>,
+    hpp_proto::field_meta<64, &TestMessage<Traits>::default_uint64, hpp_proto::field_option::explicit_presence,
+                          hpp_proto::vuint64_t>,
+    hpp_proto::field_meta<71, &TestMessage<Traits>::map_int32_int32, hpp_proto::field_option::none,
+                          hpp_proto::map_entry<hpp_proto::vint64_t, hpp_proto::vint64_t, hpp_proto::field_option::none,
+                                               hpp_proto::field_option::none>>,
+    hpp_proto::oneof_field_meta<
+        &TestMessage<Traits>::oneof_field,
+        hpp_proto::field_meta<111, 1, hpp_proto::field_option::explicit_presence, hpp_proto::vuint32_t>,
+        hpp_proto::field_meta<112, 2, hpp_proto::field_option::explicit_presence>,
+        hpp_proto::field_meta<113, 3, hpp_proto::field_option::explicit_presence>,
+        hpp_proto::field_meta<114, 4, hpp_proto::field_option::explicit_presence>>>;
 
 template <typename Traits = hpp_proto::default_traits>
 struct MoveRepeatedMessage {
@@ -123,9 +119,8 @@ struct BoolOptionalMessage {
 };
 
 template <typename Traits>
-auto pb_meta(const BoolOptionalMessage<Traits> &)
-    -> std::tuple<hpp_proto::field_meta<1, &BoolOptionalMessage<Traits>::optional_bool,
-                                        hpp_proto::field_option::explicit_presence>>;
+auto pb_meta(const BoolOptionalMessage<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &BoolOptionalMessage<Traits>::optional_bool, hpp_proto::field_option::explicit_presence>>;
 
 const boost::ut::suite merge_test_suite = [] {
   using namespace boost::ut;

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -150,9 +150,8 @@ struct example_explicit_presence {
   constexpr bool operator==(const example_explicit_presence &) const = default;
 };
 
-auto pb_meta(const example_explicit_presence &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &example_explicit_presence::i, field_option::explicit_presence, hpp_proto::vint64_t>>;
+auto pb_meta(const example_explicit_presence &) -> std::tuple<
+    hpp_proto::field_meta<1, &example_explicit_presence::i, field_option::explicit_presence, hpp_proto::vint64_t>>;
 
 struct example_default_type {
   int32_t i = 1; // field number == 1
@@ -248,9 +247,8 @@ struct repeated_sint32 {
 };
 
 template <typename Traits>
-auto pb_meta(const repeated_sint32<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &repeated_sint32<Traits>::integers, field_option::is_packed, hpp_proto::vsint32_t>>;
+auto pb_meta(const repeated_sint32<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &repeated_sint32<Traits>::integers, field_option::is_packed, hpp_proto::vsint32_t>>;
 
 template <typename Traits = hpp_proto::default_traits>
 
@@ -282,9 +280,8 @@ struct repeated_uint64 {
 };
 
 template <typename Traits>
-auto pb_meta(const repeated_uint64<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &repeated_uint64<Traits>::integers, field_option::is_packed, hpp_proto::vuint64_t>>;
+auto pb_meta(const repeated_uint64<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &repeated_uint64<Traits>::integers, field_option::is_packed, hpp_proto::vuint64_t>>;
 
 const ut::suite test_repeated_vint = [] {
   using namespace boost::ut::operators;
@@ -389,9 +386,8 @@ struct repeated_fixed_explicit_type {
 };
 
 template <typename Traits>
-auto pb_meta(const repeated_fixed_explicit_type<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &repeated_fixed_explicit_type<Traits>::integers, field_option::is_packed, uint64_t>>;
+auto pb_meta(const repeated_fixed_explicit_type<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &repeated_fixed_explicit_type<Traits>::integers, field_option::is_packed, uint64_t>>;
 
 template <typename Traits = hpp_proto::default_traits>
 struct repeated_fixed_unpacked {
@@ -410,9 +406,8 @@ struct repeated_fixed_unpacked_explicit_type {
 };
 
 template <typename Traits>
-auto pb_meta(const repeated_fixed_unpacked_explicit_type<Traits> &)
-    -> std::tuple<hpp_proto::field_meta<1, &repeated_fixed_unpacked_explicit_type<Traits>::integers, field_option::none,
-                                        uint64_t>>;
+auto pb_meta(const repeated_fixed_unpacked_explicit_type<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &repeated_fixed_unpacked_explicit_type<Traits>::integers, field_option::none, uint64_t>>;
 
 const ut::suite test_repeated_fixed = [] {
   using namespace boost::ut::operators;
@@ -473,9 +468,8 @@ struct repeated_bool {
 };
 
 template <typename Traits>
-auto pb_meta(const repeated_bool<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &repeated_bool<Traits>::booleans, field_option::is_packed, hpp_proto::boolean>>;
+auto pb_meta(const repeated_bool<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &repeated_bool<Traits>::booleans, field_option::is_packed, hpp_proto::boolean>>;
 
 template <typename Traits = hpp_proto::default_traits>
 struct repeated_bool_unpacked {
@@ -484,9 +478,8 @@ struct repeated_bool_unpacked {
 };
 
 template <typename Traits>
-auto pb_meta(const repeated_bool_unpacked<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &repeated_bool_unpacked<Traits>::booleans, field_option::none, hpp_proto::boolean>>;
+auto pb_meta(const repeated_bool_unpacked<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &repeated_bool_unpacked<Traits>::booleans, field_option::none, hpp_proto::boolean>>;
 
 const ut::suite test_repeated_bool = [] {
   using namespace boost::ut::operators;
@@ -559,14 +552,13 @@ struct closed_enum_message {
 };
 
 template <typename Traits>
-auto pb_meta(const closed_enum_message<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &closed_enum_message<Traits>::expanded_repeated_field, field_option::closed_enum>,
-        hpp_proto::field_meta<2, &closed_enum_message<Traits>::foreign_enum_field,
-                              field_option::explicit_presence | field_option::closed_enum>,
-        hpp_proto::field_meta<3, &closed_enum_message<Traits>::packed_repeated_field,
-                              field_option::is_packed | field_option::closed_enum>,
-        hpp_proto::field_meta<UINT32_MAX, &closed_enum_message<Traits>::unknown_fields_>>;
+auto pb_meta(const closed_enum_message<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &closed_enum_message<Traits>::expanded_repeated_field, field_option::closed_enum>,
+    hpp_proto::field_meta<2, &closed_enum_message<Traits>::foreign_enum_field,
+                          field_option::explicit_presence | field_option::closed_enum>,
+    hpp_proto::field_meta<3, &closed_enum_message<Traits>::packed_repeated_field,
+                          field_option::is_packed | field_option::closed_enum>,
+    hpp_proto::field_meta<UINT32_MAX, &closed_enum_message<Traits>::unknown_fields_>>;
 
 const ut::suite test_enums = [] {
   using namespace boost::ut::operators;
@@ -783,33 +775,30 @@ struct string_key_map_example {
   bool operator==(const string_key_map_example &) const = default;
 };
 
-auto pb_meta(const string_key_map_example &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &string_key_map_example::dict, field_option::none,
-                              hpp_proto::map_entry<std::string, color_t, hpp_proto::field_option::utf8_validation,
-                                                   hpp_proto::field_option::none>>>;
+auto pb_meta(const string_key_map_example &) -> std::tuple<
+    hpp_proto::field_meta<1, &string_key_map_example::dict, field_option::none,
+                          hpp_proto::map_entry<std::string, color_t, hpp_proto::field_option::utf8_validation,
+                                               hpp_proto::field_option::none>>>;
 
 struct unordered_map_example {
   std::unordered_map<std::string, color_t> dict;
   bool operator==(const unordered_map_example &) const = default;
 };
 
-auto pb_meta(const unordered_map_example &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &unordered_map_example::dict, field_option::none,
-                              hpp_proto::map_entry<std::string, color_t, hpp_proto::field_option::utf8_validation,
-                                                   hpp_proto::field_option::none>>>;
+auto pb_meta(const unordered_map_example &) -> std::tuple<
+    hpp_proto::field_meta<1, &unordered_map_example::dict, field_option::none,
+                          hpp_proto::map_entry<std::string, color_t, hpp_proto::field_option::utf8_validation,
+                                               hpp_proto::field_option::none>>>;
 
 struct indirect_map_example {
   hpp_proto::flat_map<std::string, hpp_proto::indirect<example>> fields;
   bool operator==(const indirect_map_example &) const = default;
 };
 
-auto pb_meta(const indirect_map_example &)
-    -> std::tuple<hpp_proto::field_meta<
-        1, &indirect_map_example::fields, field_option::none,
-        hpp_proto::map_entry<std::string, hpp_proto::indirect<example>, hpp_proto::field_option::utf8_validation,
-                             hpp_proto::field_option::none>>>;
+auto pb_meta(const indirect_map_example &) -> std::tuple<hpp_proto::field_meta<
+    1, &indirect_map_example::fields, field_option::none,
+    hpp_proto::map_entry<std::string, hpp_proto::indirect<example>, hpp_proto::field_option::utf8_validation,
+                         hpp_proto::field_option::none>>>;
 
 const ut::suite test_map_example = [] {
   auto encoded = "\x0a\x04\x08\x01\x10\x00\x0a\x04\x08\x02\x10\x01\x0a\x04\x08\x03\x10\x02"sv;
@@ -1279,10 +1268,9 @@ struct optional_bools {
   bool operator==(const optional_bools &) const = default;
 };
 
-auto pb_meta(const optional_bools &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &optional_bools::false_defaulted, field_option::explicit_presence>,
-        hpp_proto::field_meta<2, &optional_bools::true_defaulted, field_option::explicit_presence, bool, true>>;
+auto pb_meta(const optional_bools &) -> std::tuple<
+    hpp_proto::field_meta<1, &optional_bools::false_defaulted, field_option::explicit_presence>,
+    hpp_proto::field_meta<2, &optional_bools::true_defaulted, field_option::explicit_presence, bool, true>>;
 
 const ut::suite test_optional_bools = [] {
   "empty_optional_bools"_test = [] {
@@ -1304,12 +1292,11 @@ struct oneof_example {
   bool operator==(const oneof_example &) const = default;
 };
 
-auto pb_meta(const oneof_example &)
-    -> std::tuple<
-        hpp_proto::oneof_field_meta<&oneof_example::value, hpp_proto::field_meta<1, 1, field_option::explicit_presence>,
-                                    hpp_proto::field_meta<2, 2, field_option::explicit_presence, hpp_proto::vint64_t>,
-                                    hpp_proto::field_meta<3, 3, field_option::explicit_presence>,
-                                    hpp_proto::field_meta<4, 4, field_option::explicit_presence>>>;
+auto pb_meta(const oneof_example &) -> std::tuple<
+    hpp_proto::oneof_field_meta<&oneof_example::value, hpp_proto::field_meta<1, 1, field_option::explicit_presence>,
+                                hpp_proto::field_meta<2, 2, field_option::explicit_presence, hpp_proto::vint64_t>,
+                                hpp_proto::field_meta<3, 3, field_option::explicit_presence>,
+                                hpp_proto::field_meta<4, 4, field_option::explicit_presence>>>;
 
 const ut::suite test_oneof = [] {
   "empty_oneof_example"_test = [] { expect_roundtrip_ok(""sv, oneof_example{}); };
@@ -1373,10 +1360,9 @@ struct extension_example {
 };
 
 template <typename Traits>
-auto pb_meta(const extension_example<Traits> &)
-    -> std::tuple<
-        hpp_proto::field_meta<1, &extension_example<Traits>::int_value, field_option::none, hpp_proto::vint64_t>,
-        hpp_proto::field_meta<UINT32_MAX, &extension_example<Traits>::unknown_fields_>>;
+auto pb_meta(const extension_example<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &extension_example<Traits>::int_value, field_option::none, hpp_proto::vint64_t>,
+    hpp_proto::field_meta<UINT32_MAX, &extension_example<Traits>::unknown_fields_>>;
 
 template <typename Traits = ::hpp_proto::default_traits>
 struct i32_ext : hpp_proto::extension_base<i32_ext<Traits>, extension_example> {


### PR DESCRIPTION
## Summary

Update clang-format handling for the project and add a manual CMake `format` target so contributors can format sources locally through the build system.

## What changed

- Update clang-format automation for clang-format 22.
- Apply clang-format changes to affected headers and unit tests.
- Add a top-level CMake `format` target that runs `clang-format -i` over project C/C++ sources.

## Why

This keeps local formatting aligned with the project automation and gives contributors a simple manual command for formatting without needing to remember the exact file set.

## Testing

- `cmake -S . -B /tmp/hpp-proto-format-check -DHPP_PROTO_TESTS=OFF -DHPP_PROTO_BENCHMARKS=OFF`
- `cmake --build /tmp/hpp-proto-format-check --target help | rg '^\.\.\. format$|format'`

## Notes

- The generated `format` target is only added for top-level project builds.
