### PR TITLE
fix codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![linux](https://github.com/huangminghuang/hpp-proto/actions/workflows/linux.yml/badge.svg)
 ![macos](https://github.com/huangminghuang/hpp-proto/actions/workflows/macos.yml/badge.svg)
 ![windows](https://github.com/huangminghuang/hpp-proto/actions/workflows/windows.yml/badge.svg)
-[![codecov](https://codecov.io/github/huangminghuang/hpp-proto/graph/badge.svg?token=C2DD0WLCRC&flag=ci)](https://codecov.io/github/huangminghuang/hpp-proto)
+[![codecov](https://codecov.io/github/huangminghuang/hpp-proto/graph/badge.svg?token=C2DD0WLCRC)](https://codecov.io/github/huangminghuang/hpp-proto)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/c629f1cf7a7c45b3b3640362da4ac95a)](https://app.codacy.com/gh/huangminghuang/hpp-proto/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 Hpp-proto is a modern, high-performance C++23 implementation of Google's Protocol Buffers. It is designed from the ground up for extreme performance and minimal code size, making it an ideal choice for resource-constrained environments, real-time systems, and performance-critical applications.

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,4 +13,5 @@ coverage:
     project:
       default:
         flags:
-          - ci
+          - linux
+          - macos


### PR DESCRIPTION
## Summary
- update the Codecov badge reference in README.md
- adjust Codecov configuration for project coverage reporting

## Validation
- not run; documentation/config-only change