### PR TITLE
Make clang-tidy CI generate inputs before linting

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -96,19 +96,38 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
 
-      - name: Configure (clang-tidy via ctcache)
+      - name: Configure
         run: |
           cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release \
                 -DHPP_PROTO_PROTOC=find \
                 -DCMAKE_C_COMPILER=clang \
                 -DCMAKE_CXX_COMPILER=clang++ \
                 -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_C_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
-                -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
-      - name: Build (clang-tidy via ctcache)
-        run: cmake --build build -j"$(nproc)"
+      - name: Generate clang-tidy inputs
+        run: cmake --build build --target hpp_proto_clang_tidy_inputs -j"$(nproc)"
+
+      - name: Run clang-tidy via ctcache
+        shell: bash
+        run: |
+          jq -r '.[].file' build/compile_commands.json \
+            | sort -u \
+            | grep "^${GITHUB_WORKSPACE}/" \
+            | grep -Ev "/(build|_deps|cpm_modules)/" \
+            > build/clang-tidy-files.txt
+
+          mapfile -t TIDY_FILES < build/clang-tidy-files.txt
+          if [ "${#TIDY_FILES[@]}" -eq 0 ]; then
+            echo "No repo source files found in compile_commands.json" >&2
+            exit 1
+          fi
+
+          run-clang-tidy -p build \
+            -clang-tidy-binary clang-tidy \
+            -warnings-as-errors='*' \
+            -j "$(nproc)" \
+            "${TIDY_FILES[@]}"
 
       - name: ctcache stats
         if: always()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ endif()
 
 include(third-parties.cmake)
 include(cmake/coverage.cmake)
+include(cmake/hpp_proto_clang_tidy_helpers.cmake)
 
 add_library(hpp_proto_core INTERFACE)
 
@@ -167,6 +168,20 @@ endif()
 
 if(HPP_PROTO_BENCHMARKS)
   add_subdirectory(benchmarks)
+endif()
+
+if(PROJECT_IS_TOP_LEVEL)
+  get_property(HPP_PROTO_CLANG_TIDY_INPUT_TARGETS GLOBAL PROPERTY HPP_PROTO_CLANG_TIDY_INPUT_TARGETS)
+  list(REMOVE_DUPLICATES HPP_PROTO_CLANG_TIDY_INPUT_TARGETS)
+
+  add_custom_target(hpp_proto_clang_tidy_inputs
+    COMMENT "Generating inputs required by clang-tidy")
+
+  foreach(_hpp_proto_clang_tidy_input IN LISTS HPP_PROTO_CLANG_TIDY_INPUT_TARGETS)
+    if(TARGET ${_hpp_proto_clang_tidy_input})
+      add_dependencies(hpp_proto_clang_tidy_inputs ${_hpp_proto_clang_tidy_input})
+    endif()
+  endforeach()
 endif()
 
 include(cmake/hpp_proto_install_package.cmake)

--- a/cmake/hpp_proto_clang_tidy_helpers.cmake
+++ b/cmake/hpp_proto_clang_tidy_helpers.cmake
@@ -1,0 +1,9 @@
+function(hpp_proto_register_clang_tidy_input_targets)
+    foreach(_hpp_proto_clang_tidy_input IN LISTS ARGN)
+        if(TARGET ${_hpp_proto_clang_tidy_input})
+            set_property(GLOBAL APPEND PROPERTY
+                HPP_PROTO_CLANG_TIDY_INPUT_TARGETS
+                ${_hpp_proto_clang_tidy_input})
+        endif()
+    endforeach()
+endfunction()

--- a/cmake/hpp_proto_test_helpers.cmake
+++ b/cmake/hpp_proto_test_helpers.cmake
@@ -69,4 +69,6 @@ function(add_hpp_proto_generated_test_lib)
         PLUGIN_OPTIONS ${add_hpp_proto_generated_test_lib_PLUGIN_OPTIONS}
         PROTOC_OPTIONS ${add_hpp_proto_generated_test_lib_PROTOC_OPTIONS}
         PROTOC_OUT_DIR ${add_hpp_proto_generated_test_lib_PROTOC_OUT_DIR})
+
+    hpp_proto_register_clang_tidy_input_targets(${add_hpp_proto_generated_test_lib_NAME})
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ protobuf_generate_hpp(
     TARGET well_known_types
     IMPORT_DIRS "${Protobuf_INCLUDE_DIRS}"
     PROTOC_OUT_DIR ${PROJECT_BINARY_DIR}/include)
+hpp_proto_register_clang_tidy_input_targets(well_known_types)
 install(TARGETS well_known_types EXPORT hpp_proto-targets
     FILE_SET HEADERS DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR})

--- a/tests/grpc/CMakeLists.txt
+++ b/tests/grpc/CMakeLists.txt
@@ -65,7 +65,8 @@ if(TARGET protobuf::libprotobuf AND TARGET protobuf::protoc
         LANGUAGE cpp
         IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
         PROTOC_OUT_DIR "${GRPC_OFFICIAL_GENERATED_DIR}"
-        PROTOS "${GRPC_OFFICIAL_PROTO}")
+        PROTOS "${GRPC_OFFICIAL_PROTO}"
+        OUT_VAR grpc_official_cpp_outputs)
 
     protobuf_generate(
         TARGET grpc_official_proto
@@ -75,7 +76,12 @@ if(TARGET protobuf::libprotobuf AND TARGET protobuf::protoc
         PROTOS "${GRPC_OFFICIAL_PROTO}"
         PLUGIN protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
         DEPENDENCIES gRPC::grpc_cpp_plugin
-        GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc)
+        GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
+        OUT_VAR grpc_official_grpc_outputs)
+
+    add_custom_target(grpc_official_proto_generated
+        DEPENDS ${grpc_official_cpp_outputs} ${grpc_official_grpc_outputs})
+    hpp_proto_register_clang_tidy_input_targets(grpc_official_proto_generated)
 
     target_include_directories(grpc_official_proto PUBLIC "${GRPC_OFFICIAL_GENERATED_DIR}")
     target_link_libraries(grpc_official_proto PUBLIC protobuf::libprotobuf gRPC::grpc++)

--- a/tests/test_descriptors.cmake
+++ b/tests/test_descriptors.cmake
@@ -41,18 +41,21 @@ protobuf_generate_hpp(
     IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
     PROTOC_OPTIONS ${PROTOC3_OPTIONAL_OPTION}
 )
+hpp_proto_register_clang_tidy_input_targets(unittest_proto3_proto_lib)
 
 add_library(unittest_proto_lib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/unittest.proto")
 protobuf_generate_hpp(
     TARGET unittest_proto_lib
     IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
 )
+hpp_proto_register_clang_tidy_input_targets(unittest_proto_lib)
 
 add_library(map_unittest_proto_lib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/map_unittest.proto")
 protobuf_generate_hpp(
     TARGET map_unittest_proto_lib
     IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
 )
+hpp_proto_register_clang_tidy_input_targets(map_unittest_proto_lib)
 target_link_libraries(map_unittest_proto_lib INTERFACE unittest_proto_lib)
 
 add_library(unittest_well_known_types_proto_lib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/unittest_well_known_types.proto")
@@ -61,3 +64,4 @@ protobuf_generate_hpp(
     TARGET unittest_well_known_types_proto_lib
     IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
 )
+hpp_proto_register_clang_tidy_input_targets(unittest_well_known_types_proto_lib)

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -22,6 +22,10 @@ if(PROJECT_IS_TOP_LEVEL)
   else()
     find_package(hpp_proto CONFIG REQUIRED)
   endif()
+  
+  function(hpp_proto_register_clang_tidy_input_targets)
+  endfunction()
+
 elseif(NOT HPP_PROTO_TESTS)
   return()
 endif()

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -32,6 +32,7 @@ protobuf_generate_hpp(
     TARGET addressbook_proto3
     IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
 )
+hpp_proto_register_clang_tidy_input_targets(addressbook_proto3)
 
 add_library(addressbook_proto2 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/addressbook_proto2.proto)
 target_compile_features(addressbook_proto2 INTERFACE cxx_std_23)
@@ -39,6 +40,7 @@ protobuf_generate_hpp(
     TARGET addressbook_proto2
     IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR} # # required when the proto file is not in ${CMAKE_CURRENT_SOURCE_DIR}
 )
+hpp_proto_register_clang_tidy_input_targets(addressbook_proto2)
 
 add_library(any_demo INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/any_demo.proto)
 target_compile_features(any_demo INTERFACE cxx_std_23)
@@ -46,6 +48,7 @@ target_link_libraries(any_demo INTERFACE hpp_proto::hpp_proto)
 protobuf_generate_hpp(
     TARGET any_demo
     IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+hpp_proto_register_clang_tidy_input_targets(any_demo)
 
 add_subdirectory(regular)
 add_subdirectory(non_owning)

--- a/tutorial/compile_time_serialization/CMakeLists.txt
+++ b/tutorial/compile_time_serialization/CMakeLists.txt
@@ -3,6 +3,7 @@ if (NOT MSVC OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.43)
     target_compile_features(person INTERFACE cxx_std_23)
     protobuf_generate_hpp(TARGET person
         PROTOS person.proto)
+    hpp_proto_register_clang_tidy_input_targets(person)
     add_executable(compile_time_serialization compile_time_serialization.cpp)
     target_link_libraries(compile_time_serialization PRIVATE person)
 endif()

--- a/tutorial/grpc/CMakeLists.txt
+++ b/tutorial/grpc/CMakeLists.txt
@@ -10,6 +10,7 @@ target_compile_features(helloworld INTERFACE cxx_std_23)
 
 protobuf_generate_hpp(TARGET helloworld
     PROTOS helloworld.proto)
+hpp_proto_register_clang_tidy_input_targets(helloworld)
 
 target_link_libraries(helloworld INTERFACE gRPC::grpc++ hpp_proto::hpp_proto)
 


### PR DESCRIPTION
## Summary

Make the clang-tidy workflow lighter by generating required protobuf outputs first, then running clang-tidy directly from the compile database instead of compiling the full test/tutorial/fuzz target graph with CMake clang-tidy hooks enabled.

## What changed

- Added `hpp_proto_clang_tidy_inputs`, a top-level aggregate target that depends on self-registered generation input targets.
- Added `hpp_proto_register_clang_tidy_input_targets(...)` and registered generated proto/test/tutorial targets at their definition sites.
- Added `OUT_VAR`-based generation tracking for official gRPC/protobuf outputs without changing `protobuf_generate_hpp()`.
- Updated the clang-tidy GitHub Actions workflow to configure normally, build only generation inputs, filter repo-owned translation units from `compile_commands.json`, and run `run-clang-tidy` via ctcache.

## Why

The previous clang-tidy job used `CMAKE_CXX_CLANG_TIDY`, which ties linting to compilation and forces CI to build most tests just to run clang-tidy. Generating inputs separately keeps all repo translation units linted while avoiding unnecessary executable builds.

## Testing

- Reconfigured `build/clang-tidy-lite-verify` with Ninja, Clang, Release, and `HPP_PROTO_PROTOC=find`.
- Built `hpp_proto_clang_tidy_inputs` successfully.
- Queried Ninja deps and confirmed generated proto/test/tutorial inputs are registered.
- Ran `git diff --check` successfully.
- Ran one-file `run-clang-tidy` smoke to validate command shape; did not run full local clang-tidy because it is CI-heavy.

## Notes

- `protobuf_generate_hpp()` itself is unchanged.
- The workflow still targets all repo-owned translation units present in `compile_commands.json`; generated and dependency paths are filtered out.
