### PR TITLE
Fix installed cross-package protoc-gen-hpp target

### DIFF
--- a/.github/workflows/ubuntu-two-stage-host-protoc-gen-hpp.yml
+++ b/.github/workflows/ubuntu-two-stage-host-protoc-gen-hpp.yml
@@ -22,6 +22,10 @@ env:
 jobs:
   build_and_test_with_host_plugin:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake: ["3.28.3", "3.31.0"]
     steps:
       - uses: actions/checkout@v6
 
@@ -29,7 +33,7 @@ jobs:
         uses: aminya/setup-cpp@v1.8.0
         with:
           compiler: gcc-13
-          cmake: "3.31.0"
+          cmake: ${{ matrix.cmake }}
           ninja: true
 
       - name: Install protobuf/grpc tools
@@ -58,3 +62,43 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build --output-on-failure
+
+      - name: Install external-plugin build
+        run: |
+          cmake --install build --prefix "${{ github.workspace }}/install-cross"
+
+      - name: Write cross consumer fixture
+        run: |
+          mkdir -p cross-consumer
+          cat > cross-consumer/CMakeLists.txt <<'EOF'
+          cmake_minimum_required(VERSION 3.25)
+          project(hpp_proto_cross_consumer LANGUAGES CXX)
+
+          find_package(hpp_proto CONFIG REQUIRED)
+
+          add_library(cross_consumer_messages INTERFACE)
+          protobuf_generate_hpp(
+            TARGET cross_consumer_messages
+            PROTOS "${CMAKE_CURRENT_SOURCE_DIR}/message.proto"
+            PROTOC_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+          EOF
+          cat > cross-consumer/message.proto <<'EOF'
+          syntax = "proto3";
+          package hpp_proto_cross_consumer;
+
+          message Smoke {
+            string value = 1;
+          }
+          EOF
+          cat > cross-toolchain.cmake <<'EOF'
+          set(CMAKE_SYSTEM_NAME Generic)
+          EOF
+
+      - name: Configure installed package from cross consumer
+        run: |
+          cmake -S cross-consumer -B cross-consumer-build -G Ninja \
+            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install-cross" \
+            -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/cross-toolchain.cmake"
+
+      - name: Build cross consumer
+        run: cmake --build cross-consumer-build -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,15 @@ if(HPP_PROTO_PROTOC_GEN_HPP)
     message(FATAL_ERROR
       "HPP_PROTO_PROTOC_GEN_HPP does not exist: ${HPP_PROTO_PROTOC_GEN_HPP}")
   endif()
-  if(NOT IS_EXECUTABLE "${HPP_PROTO_PROTOC_GEN_HPP}")
+  if(IS_DIRECTORY "${HPP_PROTO_PROTOC_GEN_HPP}")
     message(FATAL_ERROR
-      "HPP_PROTO_PROTOC_GEN_HPP is not executable: ${HPP_PROTO_PROTOC_GEN_HPP}")
+      "HPP_PROTO_PROTOC_GEN_HPP must be a file: ${HPP_PROTO_PROTOC_GEN_HPP}")
+  endif()
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
+    if(NOT IS_EXECUTABLE "${HPP_PROTO_PROTOC_GEN_HPP}")
+      message(FATAL_ERROR
+        "HPP_PROTO_PROTOC_GEN_HPP is not executable: ${HPP_PROTO_PROTOC_GEN_HPP}")
+    endif()
   endif()
 endif()
 

--- a/hpp_proto-config.cmake.in
+++ b/hpp_proto-config.cmake.in
@@ -3,6 +3,9 @@ include(CMakeFindDependencyMacro)
 
 get_filename_component(_hpp_proto_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
 set(HPP_PROTO_ROOT "${_hpp_proto_prefix}")
+if(NOT PROTOC_GEN_HPP_PROGRAM)
+    set(PROTOC_GEN_HPP_PROGRAM "@HPP_PROTO_PROTOC_GEN_HPP@")
+endif()
 
 find_dependency(glaze)
 if(NOT @is_utf8_ADDED@)
@@ -30,6 +33,18 @@ if(NOT TARGET hpp_proto::protoc)
     # Create executable imported target hpp_proto::protoc
     add_executable(hpp_proto::protoc IMPORTED)
     set_property(TARGET hpp_proto::protoc PROPERTY IMPORTED_LOCATION "${PROTOC_PROGRAM}")
+endif()
+
+if(NOT TARGET hpp_proto::protoc-gen-hpp)
+    if(NOT PROTOC_GEN_HPP_PROGRAM)
+        message(FATAL_ERROR "Could not find 'protoc-gen-hpp'. Set PROTOC_GEN_HPP_PROGRAM to an absolute path.")
+    endif()
+    get_filename_component(PROTOC_GEN_HPP_PROGRAM "${PROTOC_GEN_HPP_PROGRAM}" ABSOLUTE)
+    if(NOT EXISTS "${PROTOC_GEN_HPP_PROGRAM}" OR IS_DIRECTORY "${PROTOC_GEN_HPP_PROGRAM}")
+        message(FATAL_ERROR "PROTOC_GEN_HPP_PROGRAM must be an existing file: ${PROTOC_GEN_HPP_PROGRAM}")
+    endif()
+    add_executable(hpp_proto::protoc-gen-hpp IMPORTED)
+    set_property(TARGET hpp_proto::protoc-gen-hpp PROPERTY IMPORTED_LOCATION "${PROTOC_GEN_HPP_PROGRAM}")
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/protobuf_generate_hpp.cmake")


### PR DESCRIPTION
## Summary

Fix installed hpp-proto CMake packages so cross-compiled consumers can use `protobuf_generate_hpp()` with a host `protoc-gen-hpp`.

## What changed

- Create a fallback imported `hpp_proto::protoc-gen-hpp` target in the installed package config when it is not exported.
- Avoid using `IS_EXECUTABLE` with CMake versions before 3.29 while preserving path validation.
- Extend the two-stage host plugin workflow with CMake 3.28.3 and 3.31.0 coverage plus an installed cross-consumer smoke test.

## Why

Issue #174 reports that installed cross builds fail during CMake generation because `$<TARGET_FILE:hpp_proto::protoc-gen-hpp>` cannot resolve when the package was configured with an external host plugin. The installed config now recreates the imported target from `PROTOC_GEN_HPP_PROGRAM`, seeded from `HPP_PROTO_PROTOC_GEN_HPP`, so consumers have the target needed by `protobuf_generate_hpp()`.

## Testing

- `cmake -S . -B build/issue174-smoke -G Ninja -DHPP_PROTO_TESTS=OFF -DHPP_PROTO_PROTOC=find`
- `cmake --build build/issue174-smoke --target protoc-gen-hpp -j2`
- `cmake -S . -B build/issue174-external -G Ninja -DHPP_PROTO_TESTS=OFF -DHPP_PROTO_PROTOC=find -DHPP_PROTO_PROTOC_GEN_HPP="$PWD/build/issue174-smoke/bin/protoc-gen-hpp"`
- `cmake --build build/issue174-external -j2`
- `cmake --install build/issue174-external --prefix build/issue174-prefix`
- configured and built a minimal cross-style consumer against `build/issue174-prefix`
- `git diff --check`

## Notes

- Fixes #174.
- Consumers may still override the baked plugin path by setting `PROTOC_GEN_HPP_PROGRAM` before `find_package(hpp_proto)`.
