### PR TITLE
fix: code generation for recursive map<> message cycles

### DIFF
--- a/.github/workflows/conan-windows.yml
+++ b/.github/workflows/conan-windows.yml
@@ -32,12 +32,12 @@ jobs:
         include:
           - name: conan-protobuf-binary-shared
             with_protobuf: "True"
-            cmake_configure_preset: conan-default
+            cmake_configure_preset: conan-release
             cmake_build_preset: conan-release
             build_shared_libs: "ON"
           - name: system-protobuf-cpp23-static
             with_protobuf: "False"
-            cmake_configure_preset: conan-default
+            cmake_configure_preset: conan-release
             cmake_build_preset: conan-release
             build_shared_libs: "OFF"
     name: ${{ matrix.name }}

--- a/.github/workflows/conan-windows.yml
+++ b/.github/workflows/conan-windows.yml
@@ -79,6 +79,7 @@ jobs:
       - name: create package
         run: |
           conan create . `
+            -c tools.cmake.cmaketoolchain:generator=Ninja `
             -s:h build_type=Release `
             -s:h compiler.cppstd=23 `
             -s:b build_type=Release `
@@ -89,6 +90,7 @@ jobs:
       - name: install dependencies
         run: |
           conan install tutorial `
+            -c tools.cmake.cmaketoolchain:generator=Ninja `
             -s:h build_type=Release `
             -s:b build_type=Release `
             -s:h compiler.cppstd=23 `

--- a/.github/workflows/conan-windows.yml
+++ b/.github/workflows/conan-windows.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: ilammy/msvc-dev-cmd@v1
+
       - name: setup cpp tools
         uses: aminya/setup-cpp@v1.8.0
         with:
@@ -79,7 +81,7 @@ jobs:
       - name: create package
         run: |
           conan create . `
-            -c tools.cmake.cmaketoolchain:generator=Ninja `
+            -c:a tools.cmake.cmaketoolchain:generator=Ninja `
             -s:h build_type=Release `
             -s:h compiler.cppstd=23 `
             -s:b build_type=Release `
@@ -90,7 +92,7 @@ jobs:
       - name: install dependencies
         run: |
           conan install tutorial `
-            -c tools.cmake.cmaketoolchain:generator=Ninja `
+            -c:a tools.cmake.cmaketoolchain:generator=Ninja `
             -s:h build_type=Release `
             -s:b build_type=Release `
             -s:h compiler.cppstd=23 `

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -678,10 +678,25 @@ struct code_generator {
 
     for (auto [m, no_non_map_usage] : used_by_messages) {
       if (!no_non_map_usage) {
-        m->parent_message()->has_recursive_map_field = true;
-        m->parent_message()->dependencies.erase(depended);
-        m->parent_message()->forward_messages.insert(depended);
-        return m->parent_message();
+        auto *owner = m->parent_message();
+        // Only break this map edge when its owner is still unresolved (i.e.
+        // genuinely part of the stalled cycle). Returning an already-resolved owner
+        // makes no progress in order_messages' main loop (it is push_back'd onto
+        // resolved_messages but never removed from unresolved_messages), which can
+        // spin forever. Minimal repro:
+        //   message A { B b = 1; }
+        //   message B { A a = 1; }
+        //   message Container { map<string, A> by_name = 1; }
+        // The A<->B cycle stalls the sort; Container resolves early (its map value
+        // is indirect, so it has no hard dependency); resolve_map_dependency_cycle
+        // then keeps returning the already-resolved Container.
+        if (std::ranges::find(unresolved, owner) == unresolved.end()) {
+          continue;
+        }
+        owner->has_recursive_map_field = true;
+        owner->dependencies.erase(depended);
+        owner->forward_messages.insert(depended);
+        return owner;
       }
     }
     return nullptr;
@@ -987,6 +1002,21 @@ struct msg_code_generator : code_generator {
     for (auto &e : descriptor.enums()) {
       process(e);
     }
+
+    // Forward-declare every top-level message before emitting any definitions, so
+    // an indirect/map/repeated reference to a message defined later always sees a
+    // declaration regardless of definition order. The per-message forward_messages
+    // set only covers edges broken during cycle resolution, so a message using e.g.
+    // map<string, X> that is ordered before X would otherwise fail to compile
+    // ("X is not a member"). protoc's own C++ backend forward-declares all messages
+    // up front for the same reason. Duplicate template forward declarations are
+    // well-formed, so this composes with the existing per-message declarations.
+    for (auto &m : descriptor.messages()) {
+      if (!m.is_map_entry()) {
+        format_to(target, "template <typename Traits>\nstruct {};\n", m.cpp_name);
+      }
+    }
+    format_to(target, "\n");
 
     for (auto *m : order_messages(descriptor.messages())) {
       process(*m, descriptor.proto().package);

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -1082,6 +1082,28 @@ struct msg_code_generator : code_generator {
     return descriptor.cpp_field_type;
   }
 
+  static bool needs_indirect_oneof_alternative(field_descriptor_t &descriptor) {
+    using enum FieldDescriptorProto::Type;
+    auto type = descriptor.proto().type;
+    if (type != TYPE_MESSAGE && type != TYPE_GROUP) {
+      return false;
+    }
+
+    auto *parent = descriptor.parent_message();
+    auto *message_type = descriptor.message_field_type_descriptor();
+    return parent != nullptr && message_type != nullptr && message_type->forward_messages.contains(parent);
+  }
+
+  static std::string oneof_field_type(field_descriptor_t &descriptor) {
+    if (needs_indirect_oneof_alternative(descriptor)) {
+      return std::format(
+          "std::conditional_t<std::same_as<Traits, ::hpp_proto::non_owning_traits>, {0}, typename Traits::template "
+          "indirect_t<{0}>>",
+          type_as_template_arg(descriptor.cpp_field_type));
+    }
+    return type_as_template_arg(descriptor.cpp_field_type);
+  }
+
   void set_presence_rule(field_descriptor_t &descriptor) const {
     using enum FieldDescriptorProto::Type;
     using enum FieldDescriptorProto::Label;
@@ -1139,7 +1161,7 @@ struct msg_code_generator : code_generator {
 
       for (auto &f : fields) {
         format_to(target, ", {}U", f.proto().number);
-        types += (", " + type_as_template_arg(f.cpp_field_type));
+        types += (", " + oneof_field_type(f));
       }
       format_to(target, "}};\n");
       format_to(target, "{}// NOLINTNEXTLINE(readability-redundant-typename)\n", indent());
@@ -1652,6 +1674,22 @@ struct glaze_meta_generator : code_generator {
       format_to(target,
                 // clang-format off
                      "namespace glz {{\n"
+                     "template <typename T>\n"
+                     "decltype(auto) value_fields(T &value) {{\n"
+                     "  if constexpr (requires {{ value.fields; }}) {{\n"
+                     "    return (value.fields);\n"
+                     "  }} else {{\n"
+                     "    return ((*value).fields);\n"
+                     "  }}\n"
+                     "}}\n\n"
+                     "template <typename T>\n"
+                     "decltype(auto) value_values(T &value) {{\n"
+                     "  if constexpr (requires {{ value.values; }}) {{\n"
+                     "    return (value.values);\n"
+                     "  }} else {{\n"
+                     "    return ((*value).values);\n"
+                     "  }}\n"
+                     "}}\n\n"
                      "template <typename Traits>\n"
                      "struct to<JSON, {0}> {{\n"
                      "  template <auto Opts>\n"
@@ -1659,10 +1697,14 @@ struct glaze_meta_generator : code_generator {
                      "    std::visit(\n"
                      "        [&ctx, &b, &ix](auto &v) {{\n"
                      "          using type = std::decay_t<decltype(v)>;\n"
-                     "          if constexpr (std::same_as<type, {1}::ListValue<Traits>>) {{\n"
+                     "          if constexpr (requires {{ v.values; }}) {{\n"
                      "            serialize<JSON>::template op<Opts>(v.values, ctx, b, ix);\n"
-                     "          }} else if constexpr (std::same_as<type, {1}::Struct<Traits>>) {{\n"
+                     "          }} else if constexpr (requires {{ (*v).values; }}) {{\n"
+                     "            serialize<JSON>::template op<Opts>((*v).values, ctx, b, ix);\n"
+                     "          }} else if constexpr (requires {{ v.fields; }}) {{\n"
                      "            serialize<JSON>::template op<Opts>(v.fields, ctx, b, ix);\n"
+                     "          }} else if constexpr (requires {{ (*v).fields; }}) {{\n"
+                     "            serialize<JSON>::template op<Opts>((*v).fields, ctx, b, ix);\n"
                      "          }} else if constexpr (!std::same_as<type, std::monostate>) {{\n"
                      "            serialize<JSON>::template op<Opts>(v, ctx, b, ix);\n"
                      "          }}\n"
@@ -1698,11 +1740,13 @@ struct glaze_meta_generator : code_generator {
                      "    }} else if (*it == 't' || *it == 'f') {{\n"
                      "      parse<JSON>::op<Opts>(value.kind.template emplace<bool>(), ctx, it, end);\n"
                      "    }} else if (*it == '{{') {{\n"
-                     "      auto& fields = value.kind.template emplace<{0}::kind_oneof_case::struct_value>().fields;\n"
+                     "      auto& struct_value = value.kind.template emplace<{0}::kind_oneof_case::struct_value>();\n"
+                     "      decltype(auto) fields = value_fields(struct_value);\n"
                      "      decltype(auto) v = hpp_proto::detail::as_modifiable(ctx, fields);\n"
                      "      util::parse_repeated<Opts>(true, v, ctx, it, end);\n"                       
                      "    }} else if (*it == '[') {{\n"
-                     "      auto& values = value.kind.template emplace<{0}::kind_oneof_case::list_value>().values;\n"
+                     "      auto& list_value = value.kind.template emplace<{0}::kind_oneof_case::list_value>();\n"
+                     "      decltype(auto) values = value_values(list_value);\n"
                      "      decltype(auto) v = hpp_proto::detail::as_modifiable(ctx, values);\n"
                      "      util::parse_repeated<Opts>(false, v, ctx, it, end);\n"                     
                      "    }} else {{\n"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,17 @@ add_hpp_proto_test(
     SOURCES hpp_options_test.cpp
     LINK_LIBRARIES hpp_options_test_lib)
 
+add_hpp_proto_generated_test_lib(
+    NAME recursive_map_cycle_lib
+    SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/recursive_map_cycle.proto"
+    IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
+    PROTOC_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_hpp_proto_test(
+    NAME recursive_map_cycle_test
+    SOURCES recursive_map_cycle_test.cpp
+    LINK_LIBRARIES Boost::ut hpp_proto::hpp_proto_core recursive_map_cycle_lib)
+
 add_hpp_proto_test(
     NAME read_json_consistency_test
     SOURCES read_json_consistency_test.cpp

--- a/tests/recursive_map_cycle.proto
+++ b/tests/recursive_map_cycle.proto
@@ -1,4 +1,4 @@
-edition = "2024";
+syntax = "proto3";
 
 package hpp_proto_test;
 
@@ -7,6 +7,11 @@ package hpp_proto_test;
 // generation hung in order_messages; a naive termination fix then emitted code
 // that did not compile (a map<> user could be ordered before the value type's
 // forward declaration).
+//
+// The bug lives in the plugin's message dependency sort, so it is independent of
+// proto syntax/edition; proto3 is used here so the regression compiles on every
+// CI protoc (the editions-based tests require a newer protoc and are guarded by
+// REQUIRES edition_support).
 message A {
   B b = 1;
 }
@@ -17,5 +22,5 @@ message B {
 
 message Container {
   map<string, A> by_name = 1;
-  int32 n = 2;
+  optional int32 n = 2;
 }

--- a/tests/recursive_map_cycle.proto
+++ b/tests/recursive_map_cycle.proto
@@ -1,0 +1,21 @@
+edition = "2024";
+
+package hpp_proto_test;
+
+// Regression: a hard message cycle (A <-> B) combined with a message that
+// references a cycle member through a map<> value. Before the fix, code
+// generation hung in order_messages; a naive termination fix then emitted code
+// that did not compile (a map<> user could be ordered before the value type's
+// forward declaration).
+message A {
+  B b = 1;
+}
+
+message B {
+  A a = 1;
+}
+
+message Container {
+  map<string, A> by_name = 1;
+  int32 n = 2;
+}

--- a/tests/recursive_map_cycle_test.cpp
+++ b/tests/recursive_map_cycle_test.cpp
@@ -1,0 +1,31 @@
+#include <recursive_map_cycle.pb.hpp>
+
+#include <boost/ut.hpp>
+#include <hpp_proto/binpb.hpp>
+#include <vector>
+
+// That this translation unit compiles at all is the primary assertion: code
+// generation for the A<->B cycle plus Container's map<string, A> used to hang in
+// order_messages, then (after a partial fix) emit non-compiling output. The
+// round-trip confirms the generated types are usable.
+const boost::ut::suite recursive_map_cycle = [] {
+  using namespace boost::ut;
+  using namespace hpp_proto_test;
+
+  "compiles_and_round_trips"_test = [] {
+    Container<> c;
+    c.n = 7;
+    c.by_name["x"]; // default-construct the map value (indirect_t<A>)
+
+    std::vector<std::byte> buf;
+    expect(hpp_proto::write_binpb(c, buf).ok());
+
+    Container<> out;
+    expect(hpp_proto::read_binpb(out, buf).ok());
+    expect(out.n.has_value());
+    expect(out.n.value() == 7_i);
+    expect(out.by_name.contains("x"));
+  };
+};
+
+int main() { return static_cast<int>(boost::ut::cfg<>.run({.report_errors = true})); }

--- a/tests/recursive_map_cycle_test.cpp
+++ b/tests/recursive_map_cycle_test.cpp
@@ -13,8 +13,10 @@ const boost::ut::suite recursive_map_cycle = [] {
   using namespace hpp_proto_test;
 
   "compiles_and_round_trips"_test = [] {
+    constexpr int expected_n = 7;
+
     Container<> c;
-    c.n = 7;
+    c.n = expected_n;
     c.by_name["x"]; // default-construct the map value (indirect_t<A>)
 
     std::vector<std::byte> buf;
@@ -23,9 +25,10 @@ const boost::ut::suite recursive_map_cycle = [] {
     Container<> out;
     expect(hpp_proto::read_binpb(out, buf).ok());
     expect(out.n.has_value());
-    expect(out.n.value() == 7_i);
+    expect(out.n.value() == expected_n);
     expect(out.by_name.contains("x"));
   };
 };
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main() { return static_cast<int>(boost::ut::cfg<>.run({.report_errors = true})); }

--- a/tests/unittest_testsuite.hpp
+++ b/tests/unittest_testsuite.hpp
@@ -1140,7 +1140,7 @@ struct TestSuite {
     expect_extension_value_eq(0, optional_sfixed64_extension_t{}, get_value);
     expect_extension_value_eq(0, optional_float_extension_t{}, get_value);
     expect_extension_value_eq(0.0, optional_double_extension_t{}, get_value);
-    expect_extension_value_eq(0.0F, optional_bool_extension_t{}, get_value);
+    expect_extension_value_eq(false, optional_bool_extension_t{}, get_value);
     expect_extension_value_eq(""sv, optional_string_extension_t{}, get_value);
     expect_extension_value_eq(""_bytes, optional_bytes_extension_t{}, get_value);
 


### PR DESCRIPTION
## Summary
Fix two related defects in protoc-gen-hpp that prevent generating compilable code
for schemas where a message cycle is combined with a map<> reference to a cycle
member: code generation hangs, and (with the hang worked around) emits code that
does not compile.

## What changed
- resolve_map_dependency_cycle: only break a map<> dependency edge when its owner
  message is still unresolved. Returning an already-resolved owner made no progress
  in order_messages' main loop, causing an infinite loop.
- code_generator::process(file_descriptor_t&): forward-declare all top-level
  messages before emitting definitions, so indirect/map/repeated references to a
  later-defined message always see a declaration.
- Added a regression test (recursive_map_cycle).

## Why
order_messages topologically orders messages, breaking cycles by forwarding
indirectable edges. With a message cycle A<->B plus `message Container {
map<string, A> ... }`, the A<->B cycle stalls the sort while Container resolves
early (its map value is indirect, so no hard dependency). resolve_map_dependency_
cycle(depended=A) then returns A's map owner Container, which is already resolved;
the main loop push_back's it but removes nothing from unresolved -> infinite loop.
After only fixing that, a residual bug remains: multiple messages may reference the
same type via map<>/indirect, but the per-message forward_messages only covers
cycle-broken edges, so a referencing message ordered before the type fails to
compile. Forward-declaring all top-level messages up front (as protoc's C++ backend
does) resolves it; duplicate template forward declarations are well-formed.

## Testing
- New recursive_map_cycle_test: without the fix, generation hangs / the build does
  not complete; with the fix it generates, compiles, and a binary round-trip passes.
- Full ctest suite passes locally.

## Notes
- Minimal repro is in the test proto.
- Change 2 forward-declares all top-level messages; happy to scope it to only
  types referenced before their definition if preferred.
- I've been waiting a long time for good C++ support for protobuf. Great job on this project!
