### PR TITLE
fix: C++26 compatibility - std::optional is a range (P3168)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,15 +31,23 @@
             - os: ubuntu-24.04
               compiler: gcc-14
               cmake_preset: ci-linux-release
+              cpp_standard: 23
             - os: ubuntu-24.04
               compiler: llvm-20
               cmake_preset: ci-linux-release
+              cpp_standard: 23
+            - os: ubuntu-24.04
+              compiler: llvm-22
+              cmake_preset: ci-linux-release
+              cpp_standard: 26
             - os: ubuntu-24.04
               compiler: llvm-20
               cmake_preset: ci-linux-asan-ubsan
+              cpp_standard: 23
             - os: ubuntu-24.04
               compiler: gcc-13
               cmake_preset: ci-linux-coverage
+              cpp_standard: 23
 
       runs-on: ${{ matrix.os }}
       defaults:
@@ -68,15 +76,15 @@
         - uses: actions/cache@v5
           with:
             path: "**/cpm_modules"
-            key: ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.cmake_preset }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
+            key: ${{ runner.os }}-${{ matrix.compiler }}-cxx${{ matrix.cpp_standard }}-${{ matrix.cmake_preset }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
         - name: Cache ccache
           uses: actions/cache@v5
           with:
             path: ${{ env.CCACHE_DIR }}
-            key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.cmake_preset }}-ccache-${{ github.sha }}
+            key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.compiler }}-cxx${{ matrix.cpp_standard }}-${{ matrix.cmake_preset }}-ccache-${{ github.sha }}
             restore-keys: |
-              ${{ github.workflow }}-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.cmake_preset }}-ccache-
+              ${{ github.workflow }}-${{ runner.os }}-${{ matrix.compiler }}-cxx${{ matrix.cpp_standard }}-${{ matrix.cmake_preset }}-ccache-
   
         - name: install lcov
           if: matrix.cmake_preset == 'ci-linux-coverage'
@@ -84,7 +92,7 @@
             sudo apt-get install -y lcov
             
         - name: configure
-          run: cmake --preset "${{ matrix.cmake_preset }}"
+          run: cmake --preset "${{ matrix.cmake_preset }}" -DCMAKE_CXX_STANDARD=${{ matrix.cpp_standard }}
   
         - name: build
           run: cmake --build build -j"$(nproc)"

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1191,7 +1191,10 @@ constexpr status deserialize_field(concepts::has_meta auto &item, auto meta, uin
 
 template <typename Meta>
 constexpr status deserialize_field(std::ranges::range auto &item, Meta meta, uint32_t tag,
-                                   concepts::is_basic_in auto &archive, auto &unknown_fields) {
+                                   concepts::is_basic_in auto &archive, auto &unknown_fields)
+  // std::optional is a range in C++26 (P3168); exclude it (and hpp_proto::optional)
+  // here so a singular optional<message> field uses the optional overload above.
+  requires(!concepts::optional<std::remove_reference_t<decltype(item)>>) {
   using type = std::remove_reference_t<decltype(item)>;
 
   if constexpr (concepts::contiguous_byte_range<type>) {

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -37,6 +37,17 @@ enum class serialization_mode : uint8_t { contiguous, adaptive, chunked };
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 namespace hpp_proto::pb_serializer {
 
+// std::optional is a range in C++26 (P3168), which would make a singular
+// optional<message> field ambiguous between the optional/dereferenceable serializer
+// overload and the repeated-field (range) overload. The range overloads below
+// exclude `concepts::optional` (which matches both std::optional and hpp_proto's
+// optional). The serialize_field range overload is additionally made disjoint from
+// the contiguous_byte_range (bytes) overload, so disambiguation does not rely on
+// concept subsumption (which is fragile across std library range concepts).
+template <typename T>
+concept serialize_repeated_range =
+    std::ranges::range<T> && !concepts::contiguous_byte_range<T> && !concepts::optional<T>;
+
 template <concepts::is_size_cache_iterator Iterator>
 constexpr decltype(auto) consume_size_cache_entry(Iterator &iterator) {
   decltype(auto) entry = *iterator;
@@ -229,7 +240,8 @@ struct size_cache_counter<T> {
   }
 
   template <typename Meta>
-  constexpr static std::size_t count(std::ranges::input_range auto const &item, Meta meta) {
+  constexpr static std::size_t count(std::ranges::input_range auto const &item, Meta meta)
+    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>) {
     using type = std::remove_cvref_t<decltype(item)>;
     if constexpr (concepts::contiguous_byte_range<type>) {
       return 0;
@@ -436,7 +448,8 @@ struct message_size_calculator<T> {
 
   template <typename Meta>
   constexpr static uint64_t field_size(std::ranges::input_range auto const &item, Meta meta,
-                                       concepts::is_size_cache_iterator auto &cache_itr) {
+                                       concepts::is_size_cache_iterator auto &cache_itr)
+    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>) {
     using type = std::remove_cvref_t<decltype(item)>;
     constexpr auto tag_size = static_cast<uint64_t>(varint_size(meta.number << 3U));
     if constexpr (concepts::contiguous_byte_range<type>) {
@@ -702,7 +715,7 @@ template <concepts::dereferenceable T>
   }
 }
 
-[[nodiscard]] constexpr bool serialize_field(std::ranges::range auto const &item, auto meta,
+[[nodiscard]] constexpr bool serialize_field(serialize_repeated_range auto const &item, auto meta,
                                              concepts::is_size_cache_iterator auto &cache_itr, auto &archive) {
   using Meta = decltype(meta);
   using type = std::remove_cvref_t<decltype(item)>;


### PR DESCRIPTION
## Summary

Fixes a C++26 build break. `std::optional` models a range in C++26 (P3168), which makes a singular `optional<message>` field ambiguous in the serializer's overload resolution. No behavior change under C++23.

## What changed

- Exclude `concepts::optional` (matches both `std::optional` and `hpp_proto::optional`) from the repeated-field (range) serializer overloads: `count`, `field_size`, and `serialize_field` in `binpb/serialize.hpp`, and `deserialize_field` in `binpb/deserialize.hpp`.
- Additionally make `serialize_field`'s range overload disjoint from the `contiguous_byte_range` (bytes) overload (`&& !concepts::contiguous_byte_range`), so disambiguation does not rely on std range-concept subsumption.

## Why

Under C++26, `std::optional<T>` satisfies `std::ranges::range`, so a singular `optional<message>` field now matches BOTH the optional/dereferenceable overload and the repeated-field (range) overload -> ambiguous, and the project fails to compile at `-std=c++26`. Excluding `concepts::optional` from the range overloads routes optionals back to the optional overload.

The extra `!contiguous_byte_range` on `serialize_field`'s range overload is necessary because adding any atomic constraint to that overload otherwise breaks its subsumption ordering against the bytes overload, which would make `std::string`/`bytes` fields ambiguous. Making the two overloads disjoint avoids relying on std range-concept subsumption entirely.

## Testing

- Full `ctest` suite passes under C++23 (no regression).
- Verified the fix compiles and round-trips a real edition-2024 schema (many `optional<message>` fields, maps, oneofs, recursion) byte-for-byte against Google protobuf under `-std=gnu++26`.

## Notes

- No behavior change under C++23; this is purely overload-set disambiguation for forward compatibility with C++26.
- The bug only manifests under C++26, which the current CI may not target, so it is not caught by a C++23-only test. Happy to add a C++26 build lane / test if that would be useful.
