### PR TITLE
feat(protoc-plugin): concrete-class metadata emission mode

### DIFF
--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1191,7 +1191,10 @@ constexpr status deserialize_field(concepts::has_meta auto &item, auto meta, uin
 
 template <typename Meta>
 constexpr status deserialize_field(std::ranges::range auto &item, Meta meta, uint32_t tag,
-                                   concepts::is_basic_in auto &archive, auto &unknown_fields) {
+                                   concepts::is_basic_in auto &archive, auto &unknown_fields)
+  // std::optional is a range in C++26 (P3168); exclude it (and hpp_proto::optional)
+  // here so a singular optional<message> field uses the optional overload above.
+  requires(!concepts::optional<std::remove_reference_t<decltype(item)>>) {
   using type = std::remove_reference_t<decltype(item)>;
 
   if constexpr (concepts::contiguous_byte_range<type>) {

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -37,6 +37,17 @@ enum class serialization_mode : uint8_t { contiguous, adaptive, chunked };
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 namespace hpp_proto::pb_serializer {
 
+// std::optional is a range in C++26 (P3168), which would make a singular
+// optional<message> field ambiguous between the optional/dereferenceable serializer
+// overload and the repeated-field (range) overload. The range overloads below
+// exclude `concepts::optional` (which matches both std::optional and hpp_proto's
+// optional). The serialize_field range overload is additionally made disjoint from
+// the contiguous_byte_range (bytes) overload, so disambiguation does not rely on
+// concept subsumption (which is fragile across std library range concepts).
+template <typename T>
+concept serialize_repeated_range =
+    std::ranges::range<T> && !concepts::contiguous_byte_range<T> && !concepts::optional<T>;
+
 template <concepts::is_size_cache_iterator Iterator>
 constexpr decltype(auto) consume_size_cache_entry(Iterator &iterator) {
   decltype(auto) entry = *iterator;
@@ -229,7 +240,8 @@ struct size_cache_counter<T> {
   }
 
   template <typename Meta>
-  constexpr static std::size_t count(std::ranges::input_range auto const &item, Meta meta) {
+  constexpr static std::size_t count(std::ranges::input_range auto const &item, Meta meta)
+    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>) {
     using type = std::remove_cvref_t<decltype(item)>;
     if constexpr (concepts::contiguous_byte_range<type>) {
       return 0;
@@ -436,7 +448,8 @@ struct message_size_calculator<T> {
 
   template <typename Meta>
   constexpr static uint64_t field_size(std::ranges::input_range auto const &item, Meta meta,
-                                       concepts::is_size_cache_iterator auto &cache_itr) {
+                                       concepts::is_size_cache_iterator auto &cache_itr)
+    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>) {
     using type = std::remove_cvref_t<decltype(item)>;
     constexpr auto tag_size = static_cast<uint64_t>(varint_size(meta.number << 3U));
     if constexpr (concepts::contiguous_byte_range<type>) {
@@ -702,7 +715,7 @@ template <concepts::dereferenceable T>
   }
 }
 
-[[nodiscard]] constexpr bool serialize_field(std::ranges::range auto const &item, auto meta,
+[[nodiscard]] constexpr bool serialize_field(serialize_repeated_range auto const &item, auto meta,
                                              concepts::is_size_cache_iterator auto &cache_itr, auto &archive) {
   using Meta = decltype(meta);
   using type = std::remove_cvref_t<decltype(item)>;

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -678,10 +678,25 @@ struct code_generator {
 
     for (auto [m, no_non_map_usage] : used_by_messages) {
       if (!no_non_map_usage) {
-        m->parent_message()->has_recursive_map_field = true;
-        m->parent_message()->dependencies.erase(depended);
-        m->parent_message()->forward_messages.insert(depended);
-        return m->parent_message();
+        auto *owner = m->parent_message();
+        // Only break this map edge when its owner is still unresolved (i.e.
+        // genuinely part of the stalled cycle). Returning an already-resolved owner
+        // makes no progress in order_messages' main loop (it is push_back'd onto
+        // resolved_messages but never removed from unresolved_messages), which can
+        // spin forever. Minimal repro:
+        //   message A { B b = 1; }
+        //   message B { A a = 1; }
+        //   message Container { map<string, A> by_name = 1; }
+        // The A<->B cycle stalls the sort; Container resolves early (its map value
+        // is indirect, so it has no hard dependency); resolve_map_dependency_cycle
+        // then keeps returning the already-resolved Container.
+        if (std::ranges::find(unresolved, owner) == unresolved.end()) {
+          continue;
+        }
+        owner->has_recursive_map_field = true;
+        owner->dependencies.erase(depended);
+        owner->forward_messages.insert(depended);
+        return owner;
       }
     }
     return nullptr;
@@ -987,6 +1002,21 @@ struct msg_code_generator : code_generator {
     for (auto &e : descriptor.enums()) {
       process(e);
     }
+
+    // Forward-declare every top-level message before emitting any definitions, so
+    // an indirect/map/repeated reference to a message defined later always sees a
+    // declaration regardless of definition order. The per-message forward_messages
+    // set only covers edges broken during cycle resolution, so a message using e.g.
+    // map<string, X> that is ordered before X would otherwise fail to compile
+    // ("X is not a member"). protoc's own C++ backend forward-declares all messages
+    // up front for the same reason. Duplicate template forward declarations are
+    // well-formed, so this composes with the existing per-message declarations.
+    for (auto &m : descriptor.messages()) {
+      if (!m.is_map_entry()) {
+        format_to(target, "template <typename Traits>\nstruct {};\n", m.cpp_name);
+      }
+    }
+    format_to(target, "\n");
 
     for (auto *m : order_messages(descriptor.messages())) {
       process(*m, descriptor.proto().package);

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -584,6 +584,15 @@ struct code_generator {
   static std::vector<std::string> proto2_explicit_presences;
   static std::string directory_prefix;
   static bool preserve_proto_field_names;
+  // SPIKE: emit hand-friendly CONCRETE classes (std::string_view/std::span members,
+  // no Traits template) instead of trait-templated structs. Enabled via the
+  // plugin option "concrete=true".
+  static bool concrete;
+  // Concrete-only: retarget the package-derived namespace of the emitted metadata to
+  // this one (e.g. "pkg::api"), so the concrete classes coexist with the trait-
+  // templated pkg::proto (no ODR conflict). Option "concrete_namespace=pkg.api"
+  // (dotted; converted to ::). Empty = keep the proto package namespace.
+  static std::string concrete_namespace;
   std::size_t indent_num = 0;
   CodeGeneratorResponse::File &file;
   std::back_insert_iterator<std::string> target;
@@ -602,6 +611,51 @@ struct code_generator {
       return std::format("typename {}", type);
     }
     return std::string{type};
+  }
+
+  static void replace_all(std::string &s, std::string_view from, std::string_view to) {
+    if (from.empty()) {
+      return;
+    }
+    std::size_t pos = 0;
+    while ((pos = s.find(from, pos)) != std::string::npos) {
+      s.replace(pos, from.size(), to);
+      pos += to.size();
+    }
+  }
+
+  // Concrete-only: rewrite the package-derived namespace `from_ns` (e.g. pkg::proto, or
+  // pkg for a package-less file) to `to_ns` (e.g. pkg::api) in the fully-emitted file. The
+  // qualified-ref replace runs first (so it can't re-hit the block's `to_ns`); the
+  // namespace open/close are exact strings. Concrete output only references its own
+  // package's types plus google::/hpp_proto:: (untouched), so this is unambiguous.
+  static void retarget_concrete_namespace(std::string &content, const std::string &from_ns,
+                                          const std::string &to_ns) {
+    if (from_ns.empty() || to_ns.empty()) {
+      return;
+    }
+    replace_all(content, from_ns + "::", to_ns + "::");
+    replace_all(content, "namespace " + from_ns + " {", "namespace " + to_ns + " {");
+    replace_all(content, "} // namespace " + from_ns, "} // namespace " + to_ns);
+  }
+
+  // SPIKE: concrete mode skips msg_code_generator, which is where set_presence_rule
+  // normally runs. Replicate it here (shared by the meta + glaze concrete paths) so
+  // meta_options / glaze emit explicit_presence for oneof arms and proto3-optional
+  // fields. TODO(spike): fold this and msg_code_generator::set_presence_rule together.
+  static void set_concrete_presence(field_descriptor_t &f, std::string_view syntax) {
+    using enum FieldDescriptorProto::Label;
+    using enum FieldDescriptorProto::Type;
+    std::string qualified_name = std::string{f.qualified_parent_name()} + "." + f.proto().name;
+    f.is_cpp_optional =
+        (syntax != "proto2" || proto2_explicit_presences.empty())
+            ? f.explicit_presence()
+            : (f.proto().label == FieldDescriptorProto::Label::LABEL_OPTIONAL &&
+               (f.proto().type == FieldDescriptorProto::Type::TYPE_MESSAGE ||
+                f.proto().type == FieldDescriptorProto::Type::TYPE_GROUP ||
+                std::ranges::any_of(proto2_explicit_presences, [&qualified_name](const auto &s) {
+                  return qualified_name.starts_with(std::string_view{s}.substr(1));
+                })));
   }
 
   explicit code_generator(std::vector<CodeGeneratorResponse::File> &files)
@@ -962,6 +1016,8 @@ std::string code_generator::plugin_parameters;
 std::vector<std::string> code_generator::proto2_explicit_presences;
 std::string code_generator::directory_prefix;
 bool code_generator::preserve_proto_field_names = false;
+bool code_generator::concrete = false;
+std::string code_generator::concrete_namespace;
 
 struct msg_code_generator : code_generator {
   std::string syntax;
@@ -1296,7 +1352,113 @@ struct hpp_meta_generator : code_generator {
   std::string syntax;
   using code_generator::code_generator;
 
+  // SPIKE concrete emission: out-of-line pb_meta + non-template codec entry points
+  // into a generated .pb.cpp, so using TUs never instantiate the serializer.
+
+  // pb_meta declaration only - the trailing return type carries the field metadata
+  // tuple, which read_binpb/write_binpb pick up via decltype + ADL. Member pointers
+  // bind to the hand-written concrete class -> any field drift is a compile error.
+  void emit_concrete_pb_meta(message_descriptor_t &descriptor) {
+    if (descriptor.is_map_entry()) {
+      return;
+    }
+    for (auto &f : descriptor.fields()) {
+      set_concrete_presence(f, syntax);
+    }
+    format_to(target, "auto pb_meta(const {0} &) -> std::tuple<\n", descriptor.cpp_name);
+    indent_num += 2;
+    bool any = false;
+    for (auto &f : descriptor.fields()) {
+      if (!f.proto().oneof_index.has_value()) {
+        process(f, 0UL); // scalar / string / repeated / map
+        any = true;
+      } else {
+        auto index = *f.proto().oneof_index;
+        auto &oneof = descriptor.oneofs()[index];
+        if (oneof.fields()[0].proto().number == f.proto().number) {
+          process(oneof, descriptor); // emits oneof_field_meta<...>,
+          any = true;
+        }
+      }
+    }
+    indent_num -= 2;
+    if (any) { // strip the trailing ",\n" left by the last entry, then close the tuple.
+      auto &content = file.content;
+      content.resize(content.size() - 2);
+    }
+    format_to(target, ">;\n\n");
+
+    // Nested non-map messages (e.g. UpdateResponse.Error) get their pb_meta emitted
+    // inside the `Foo_` namespace, mirroring the hpp-proto nested-type convention so the
+    // member pointers (&Error::id) and ADL resolve to pkg::proto::UpdateResponse_::Error.
+    if (descriptor.has_non_map_nested_message) {
+      format_to(target, "namespace {}_ {{\n", descriptor.cpp_name);
+      for (auto &m : descriptor.messages()) {
+        if (!m.is_map_entry()) {
+          emit_concrete_pb_meta(m);
+        }
+      }
+      format_to(target, "}} // namespace {}_\n\n", descriptor.cpp_name);
+    }
+  }
+
+  // The out-of-line codec instantiation. read/write_binpb here see every pb_meta above
+  // via ADL, so emitting these AFTER all pb_meta makes cross-message references
+  // (oneof arms, map values) order-independent.
+  void emit_concrete_entry_points(message_descriptor_t &descriptor) {
+    if (descriptor.is_map_entry()) {
+      return;
+    }
+    format_to(target,
+              "bool decode({0} &msg, std::span<const std::byte> data, std::pmr::memory_resource &arena) {{\n"
+              // Non-padded read: the caller need not guarantee a readable trailing byte
+              // (mmap'd file reads, raw gRPC ByteBuffers). padded_input is only a varint
+              // end-check elision; decode is not on the hot path, so default to safe.
+              "  return ::hpp_proto::read_binpb(msg, data, ::hpp_proto::alloc_from(arena)).ok();\n"
+              "}}\n"
+              "bool encode(const {0} &msg, std::vector<std::byte> &out) {{\n"
+              "  return ::hpp_proto::write_binpb(msg, out).ok();\n"
+              "}}\n\n",
+              descriptor.cpp_name);
+  }
+
+  void process_concrete(file_descriptor_t &descriptor) {
+    auto file_name = descriptor.proto().name;
+    gen_file_header(file_name);
+    file.name = file_name.substr(0, file_name.size() - proto_suffix_length) + "pb.cpp";
+    syntax = descriptor.syntax;
+    // Include the HAND-WRITTEN message header (convention: <stem>.hpp). It declares
+    // the concrete structs (e.g. demo::PhraseQuery) plus the decode/encode entry
+    // points defined below. The generator does NOT emit the struct - the human owns it.
+    format_to(target,
+              "#include \"{}.hpp\"\n"
+              "#include <hpp_proto/binpb.hpp>\n\n",
+              basename(descriptor.proto().name, directory_prefix));
+    auto package = descriptor.proto().package;
+    auto ns = make_qualified_cpp_name(descriptor.namespace_prefix, "." + package);
+    if (!ns.empty()) {
+      format_to(target, "namespace {} {{\n\n", ns);
+    }
+    // Two passes: all pb_meta first (so member-pointer-bound metadata for every message
+    // is declared), then all entry points (each instantiates the serializer).
+    for (auto &m : descriptor.messages()) {
+      emit_concrete_pb_meta(m);
+    }
+    for (auto &m : descriptor.messages()) {
+      emit_concrete_entry_points(m);
+    }
+    if (!ns.empty()) {
+      format_to(target, "}} // namespace {}\n", ns);
+    }
+    format_to(target, "// clang-format on\n");
+    retarget_concrete_namespace(file.content, ns, concrete_namespace);
+  }
+
   void process(file_descriptor_t &descriptor) {
+    if (concrete) {
+      process_concrete(descriptor);
+      return;
+    }
     auto file_name = descriptor.proto().name;
     gen_file_header(file_name);
     file.name = file_name.substr(0, file_name.size() - proto_suffix_length) + "pb.hpp";
@@ -1415,6 +1577,32 @@ struct hpp_meta_generator : code_generator {
     return options;
   }
   // NOLINTEND(misc-no-recursion)
+
+  // SPIKE: concrete (non-templated) meta type for a map key/value sub-field, mirroring
+  // get_meta_type but emitting concrete view types instead of Traits:: forms.
+  static std::string concrete_map_meta_type(field_descriptor_t &field) {
+    using enum FieldDescriptorProto::Type;
+    switch (field.proto().type) {
+    case FieldDescriptorProto::Type::TYPE_STRING:
+      return "std::string_view";
+    case FieldDescriptorProto::Type::TYPE_BYTES:
+      return "std::span<const std::byte>";
+    case FieldDescriptorProto::Type::TYPE_MESSAGE:
+    case FieldDescriptorProto::Type::TYPE_GROUP: {
+      // strip the trailing <Traits> the templated qualified name carries.
+      std::string name = field.qualified_cpp_field_type;
+      if (auto pos = name.find('<'); pos != std::string::npos) {
+        name.resize(pos);
+      }
+      // by-value for non-recursive value types; indirect_view only for recursion.
+      return field.is_recursive ? std::format("::hpp_proto::indirect_view<{}>", name) : name;
+    }
+    default:
+      // scalar: the wire meta type (vint64_t, ...) or the plain concrete numeric type.
+      return field.cpp_meta_type == "void" ? field.qualified_cpp_field_type : field.cpp_meta_type;
+    }
+  }
+
   // NOLINTBEGIN(readability-function-cognitive-complexity)
   void process(field_descriptor_t &descriptor, std::size_t oneof_index) {
     auto options = meta_options(descriptor);
@@ -1427,7 +1615,18 @@ struct hpp_meta_generator : code_generator {
         return field.cpp_meta_type == "void" ? field.qualified_cpp_field_type : field.cpp_meta_type;
       };
       auto *type_desc = descriptor.message_field_type_descriptor();
-      if (type_desc->fields()[1].is_recursive) {
+      if (concrete) {
+        // map_entry<Kconcrete, Vconcrete, keyopts, valopts>. The element types must
+        // stay in sync with the hand-written map_view<K,V> (span-of-pair<K,V>):
+        // string->string_view; non-recursive message value stored BY VALUE; recursion
+        // -> indirect_view<V>. keyopts/valopts reuse meta_options (utf8_validation for
+        // a string key, none for a message value).
+        descriptor.cpp_meta_type = std::format(
+            "::hpp_proto::map_entry<{}, {}, {}, {}>", concrete_map_meta_type(type_desc->fields()[0]),
+            concrete_map_meta_type(type_desc->fields()[1]),
+            join_to_string(meta_options(type_desc->fields()[0]), " | "),
+            join_to_string(meta_options(type_desc->fields()[1]), " | "));
+      } else if (type_desc->fields()[1].is_recursive) {
         descriptor.cpp_meta_type = std::format(
             "::hpp_proto::map_entry<{}, typename Traits::template indirect_t<{}>, {}, {}>",
             type_as_template_arg(get_meta_type(type_desc->fields()[0])), get_meta_type(type_desc->fields()[1]),
@@ -1456,9 +1655,9 @@ struct hpp_meta_generator : code_generator {
       }
     }
 
-    auto cpp_name = (descriptor.parent_message() == nullptr)
-                        ? descriptor.cpp_name
-                        : descriptor.parent_message()->cpp_name + "<Traits>::" + descriptor.cpp_name;
+    auto cpp_name = (descriptor.parent_message() == nullptr) ? descriptor.cpp_name
+                    : concrete ? descriptor.parent_message()->cpp_name + "::" + descriptor.cpp_name
+                               : descriptor.parent_message()->cpp_name + "<Traits>::" + descriptor.cpp_name;
 
     if (descriptor.extendee_descriptor() == nullptr) {
       std::string access = (oneof_index == 0) ? "&" + cpp_name : std::to_string(oneof_index);
@@ -1533,7 +1732,11 @@ struct hpp_meta_generator : code_generator {
       }
       format_to(target, "{}::hpp_proto::oneof_field_meta<\n", indent());
       indent_num += 2;
-      format_to(target, "{}&{}::{},\n", indent(), parent.no_namespace_qualified_name, descriptor.cpp_name);
+      // concrete: bind to the hand-written std::variant member by pointer (no <Traits>).
+      // arm field_metas stay index-based (set below) - the codec dispatches on the
+      // variant alternative type, so no member pointer / arm type is needed per arm.
+      format_to(target, "{}&{}::{},\n", indent(),
+                concrete ? parent.cpp_name : parent.no_namespace_qualified_name, descriptor.cpp_name);
       std::size_t i = 0;
       for (auto &f : fields) {
         process(f, ++i);
@@ -1552,9 +1755,122 @@ struct hpp_meta_generator : code_generator {
 };
 
 struct glaze_meta_generator : code_generator {
+  std::string syntax;
   using code_generator::code_generator;
 
+  // SPIKE concrete emission: glz::meta + out-of-line read_json/write_json entry points
+  // into a generated .json.cpp, bound to the hand-written classes. Reuses the templated
+  // process(field)/process(oneof) bodies (as_optional_ref / as_oneof_member by member
+  // name are already concrete) - only the glz::meta wrapper is de-templatized.
+
+  // concrete fully-qualified name: strip the trailing <Traits> the qualified name carries.
+  static std::string concrete_qualified(const message_descriptor_t &descriptor) {
+    std::string name = descriptor.qualified_name;
+    if (auto pos = name.find('<'); pos != std::string::npos) {
+      name.resize(pos);
+    }
+    return name;
+  }
+
+  void emit_concrete_glz_meta(message_descriptor_t &descriptor) {
+    if (descriptor.is_map_entry()) {
+      return;
+    }
+    std::string name = concrete_qualified(descriptor);
+    for (auto &f : descriptor.fields()) {
+      set_concrete_presence(f, syntax);
+    }
+    format_to(target,
+              "template <>\n"
+              "struct glz::meta<{0}> {{\n"
+              "  using T = {0};\n"
+              "  static constexpr auto value = object(\n",
+              name);
+    for (auto &f : descriptor.fields()) {
+      if (!f.proto().oneof_index.has_value()) {
+        process(f); // "name", as_optional_ref<&T::member> (+ snake alias)
+      } else {
+        auto index = *f.proto().oneof_index;
+        auto &oneof = descriptor.oneofs()[index];
+        if (oneof.fields()[0].proto().number == f.proto().number) {
+          process(oneof); // "arm", as_oneof_member<&T::kind, idx> (+ alias)
+        }
+      }
+    }
+    if (!descriptor.fields().empty()) {
+      auto &content = file.content;
+      content.resize(content.size() - 2); // strip trailing ",\n"
+    }
+    format_to(target,
+              ");\n"
+              "}};\n\n"
+              "template <>\n"
+              "struct hpp_proto::has_glz<{0}> : std::true_type {{}};\n\n",
+              name);
+
+    // Nested enums (SortDir, Operator, Status, FieldClass, Metric, Mode) need their own
+    // glz::meta (enumerate); nested non-map messages (UpdateResponse.Error) need glz::meta
+    // too. process(enum)/this recurse use the qualified `Foo_::Bar` names (enum has no
+    // <Traits>; message qualified name is stripped of <Traits> by concrete_qualified).
+    for (auto &e : descriptor.enums()) {
+      process(e);
+    }
+    for (auto &m : descriptor.messages()) {
+      if (!m.is_map_entry()) {
+        emit_concrete_glz_meta(m);
+      }
+    }
+  }
+
+  void emit_concrete_json_entry_points(message_descriptor_t &descriptor) {
+    if (descriptor.is_map_entry()) {
+      return;
+    }
+    // Qualified ::hpp_proto::*_json calls (no ADL) so demo::read_json doesn't recurse.
+    format_to(target,
+              "bool write_json(const {0} &msg, std::string &out) {{\n"
+              "  return ::hpp_proto::write_json(msg, out).ok();\n"
+              "}}\n"
+              "bool read_json({0} &msg, std::string_view json, std::pmr::memory_resource &arena) {{\n"
+              "  return ::hpp_proto::read_json(msg, json, ::hpp_proto::alloc_from(arena)).ok();\n"
+              "}}\n\n",
+              descriptor.cpp_name);
+  }
+
+  void process_concrete(file_descriptor_t &descriptor) {
+    auto file_name = descriptor.proto().name;
+    gen_file_header(file_name);
+    file.name = file_name.substr(0, file_name.size() - proto_suffix_length) + "json.cpp";
+    syntax = descriptor.syntax;
+    format_to(target,
+              "#include \"{}.hpp\"\n"
+              "#include <hpp_proto/json.hpp>\n\n",
+              basename(descriptor.proto().name, directory_prefix));
+    // pass 1: glz::meta + has_glz specializations (global scope), order-independent.
+    for (auto &m : descriptor.messages()) {
+      emit_concrete_glz_meta(m);
+    }
+    // pass 2: read_json/write_json entry points (in the package namespace).
+    auto package = descriptor.proto().package;
+    auto ns = make_qualified_cpp_name(descriptor.namespace_prefix, "." + package);
+    if (!ns.empty()) {
+      format_to(target, "namespace {} {{\n\n", ns);
+    }
+    for (auto &m : descriptor.messages()) {
+      emit_concrete_json_entry_points(m);
+    }
+    if (!ns.empty()) {
+      format_to(target, "}} // namespace {}\n", ns);
+    }
+    format_to(target, "// clang-format on\n");
+    retarget_concrete_namespace(file.content, ns, concrete_namespace);
+  }
+
   void process(file_descriptor_t &descriptor) {
+    if (concrete) {
+      process_concrete(descriptor);
+      return;
+    }
     auto file_name = descriptor.proto().name;
     gen_file_header(file_name);
     file.name = file_name.substr(0, file_name.size() - proto_suffix_length) + "glz.hpp";
@@ -2165,6 +2481,10 @@ int main(int argc, const char **argv) {
       code_generator::proto2_explicit_presences.emplace_back(opt_value);
     } else if (opt_key == "preserve_proto_field_names") {
       code_generator::preserve_proto_field_names = (opt_value == "true" || opt_value.empty());
+    } else if (opt_key == "concrete_namespace") {
+      code_generator::concrete_namespace = make_qualified_cpp_name("", opt_value);
+    } else if (opt_key == "concrete") {
+      code_generator::concrete = (opt_value == "true" || opt_value.empty());
     } else if (opt_key == "export_request") {
       std::ofstream out{std::string(opt_value), std::ios::binary};
       if (!out) {
@@ -2207,22 +2527,37 @@ int main(int argc, const char **argv) {
       return 1;
     }
 
-    msg_code_generator msg_code(response.file);
-    msg_code.process(*descriptor);
+    // SPIKE: concrete mode emits ONLY the out-of-line .pb.cpp metadata (pb_meta +
+    // codec entry points) bound to HAND-WRITTEN message structs. The struct
+    // (.msg.hpp), glaze, descriptor, and service emitters all target the templated
+    // shape and are skipped (the human owns the classes; JSON/glaze comes next).
+    if (!code_generator::concrete) {
+      msg_code_generator msg_code(response.file);
+      msg_code.process(*descriptor);
+    } else {
+      // Concrete mode skips msg_code_generator, which is where order_messages() runs the
+      // map/repeated cycle resolution that sets field.is_recursive. Run it here (discard
+      // the order) so concrete_map_meta_type emits indirect_view<V> for recursive map
+      // values (e.g. map<string,Val>) instead of an incomplete by-value V.
+      (void)code_generator::order_messages((*descriptor).messages());
+    }
 
     hpp_meta_generator hpp_meta_code(response.file);
     hpp_meta_code.process(*descriptor);
 
+    // glaze runs in both modes (concrete -> .json.cpp out-of-line; default -> .glz.hpp).
     glaze_meta_generator glz_meta_code(response.file);
     glz_meta_code.process(*descriptor);
 
-    if (!descriptor->messages().empty()) {
-      desc_hpp_generator desc_hpp_code(response.file);
-      desc_hpp_code.process(*descriptor);
-    }
+    if (!code_generator::concrete) {
+      if (!descriptor->messages().empty()) {
+        desc_hpp_generator desc_hpp_code(response.file);
+        desc_hpp_code.process(*descriptor);
+      }
 
-    service_generator service_code(response.file);
-    service_code.process(*descriptor);
+      service_generator service_code(response.file);
+      service_code.process(*descriptor);
+    }
   }
 
   std::vector<char> data;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,17 @@ add_hpp_proto_test(
     SOURCES hpp_options_test.cpp
     LINK_LIBRARIES hpp_options_test_lib)
 
+add_hpp_proto_generated_test_lib(
+    NAME recursive_map_cycle_lib
+    SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/recursive_map_cycle.proto"
+    IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
+    PROTOC_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_hpp_proto_test(
+    NAME recursive_map_cycle_test
+    SOURCES recursive_map_cycle_test.cpp
+    LINK_LIBRARIES Boost::ut hpp_proto::hpp_proto_core recursive_map_cycle_lib)
+
 add_hpp_proto_test(
     NAME read_json_consistency_test
     SOURCES read_json_consistency_test.cpp

--- a/tests/recursive_map_cycle.proto
+++ b/tests/recursive_map_cycle.proto
@@ -1,0 +1,21 @@
+edition = "2024";
+
+package hpp_proto_test;
+
+// Regression: a hard message cycle (A <-> B) combined with a message that
+// references a cycle member through a map<> value. Before the fix, code
+// generation hung in order_messages; a naive termination fix then emitted code
+// that did not compile (a map<> user could be ordered before the value type's
+// forward declaration).
+message A {
+  B b = 1;
+}
+
+message B {
+  A a = 1;
+}
+
+message Container {
+  map<string, A> by_name = 1;
+  int32 n = 2;
+}

--- a/tests/recursive_map_cycle_test.cpp
+++ b/tests/recursive_map_cycle_test.cpp
@@ -1,0 +1,31 @@
+#include <recursive_map_cycle.pb.hpp>
+
+#include <boost/ut.hpp>
+#include <hpp_proto/binpb.hpp>
+#include <vector>
+
+// That this translation unit compiles at all is the primary assertion: code
+// generation for the A<->B cycle plus Container's map<string, A> used to hang in
+// order_messages, then (after a partial fix) emit non-compiling output. The
+// round-trip confirms the generated types are usable.
+const boost::ut::suite recursive_map_cycle = [] {
+  using namespace boost::ut;
+  using namespace hpp_proto_test;
+
+  "compiles_and_round_trips"_test = [] {
+    Container<> c;
+    c.n = 7;
+    c.by_name["x"]; // default-construct the map value (indirect_t<A>)
+
+    std::vector<std::byte> buf;
+    expect(hpp_proto::write_binpb(c, buf).ok());
+
+    Container<> out;
+    expect(hpp_proto::read_binpb(out, buf).ok());
+    expect(out.n.has_value());
+    expect(out.n.value() == 7_i);
+    expect(out.by_name.contains("x"));
+  };
+};
+
+int main() { return static_cast<int>(boost::ut::cfg<>.run({.report_errors = true})); }


### PR DESCRIPTION
## Summary
Adds an opt-in generator mode (`concrete=true`) that emits **out-of-line `pb_meta` + `glz::meta` metadata** bound to **hand-written concrete message classes**, instead of the default trait-templated message headers. A project can hand-write one concrete `struct` per message — owning its in-memory representation (custom field types, non-owning views, trivial destructibility, ABI stability) — and the generator binds hpp-proto's binary and glaze codecs to it by member pointer + field tag (name-independent).

## Why
The trait-templated headers instantiate the recursive (de)serializer in **every** TU that includes them — the dominant per-TU compile cost/memory in a large schema. Emitting the codec **out-of-line** in a generated `.cpp` means using-TUs include only lightweight concrete headers and never re-instantiate it. On a downstream engine (~65 messages, oneofs, maps, recursion, `NullValue` WKT) this turned a wire-header change from recompiling the heavy templated codec across ~all dependents into recompiling lightweight TUs plus two build-once metadata TUs, with per-using-TU peak compile RSS dropping accordingly.

## What it emits
- `concrete=true`: per `.proto`, emit `<stem>.pb.cpp` (binary `decode`/`encode`) + `<stem>.json.cpp` (glaze `read_json`/`write_json`) with non-template entry points, instead of `.msg.hpp`/`.pb.hpp`/`.glz.hpp`. The user supplies the matching hand-written headers.
- `concrete_namespace=<ns>` (dotted, e.g. `my.api` -> `my::api`): retargets the emitted metadata namespace so concrete + templated output for the same `.proto` coexist in one binary (distinct namespaces, no ODR clash) — enables incremental migration.
- Self-referential message/map cycles via `indirect_view` (reuses `order_messages`).

Opt-in; off by default.

## Notes
- Generator-only — no runtime changes; emitted `glz::meta` uses the existing glaze runtime.
- Concrete classes are hand-written by the user; this PR only emits the binding metadata.
- Depends on #176 (recursive-`map<>` `order_messages` fix) and #177 (C++26); both are included as the first two commits here since they're not yet merged — happy to rebase to just the concrete commit once they land.
- Holding off on tests pending your read of the approach — glad to add them in whatever shape fits.
