### PR TITLE
Upgrade dependencies to latest stable releases

### DIFF
--- a/.github/workflows/auto-clang-format.yml
+++ b/.github/workflows/auto-clang-format.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Check clang-format version
       run: docker run --rm xianpengshen/clang-tools:22 clang-format --version
     - name: Run clang-format
@@ -17,7 +17,7 @@ jobs:
           \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \) \
           -print0 |
           xargs -0 docker run --rm -i -v "$PWD:/src" -w /src xianpengshen/clang-tools:22 clang-format -i
-    - uses: EndBug/add-and-commit@v9
+    - uses: EndBug/add-and-commit@v10
       with:
         author_name: Clang Robot
         author_email: huangming.huang@gmail.com

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -19,7 +19,7 @@ jobs:
         sanitizer: [address, undefined]  # Override this with the sanitizers you want.
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.0
+      uses: aminya/setup-cpp@v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -16,7 +16,7 @@ jobs:
         sanitizer: [address, undefined]
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.0
+      uses: aminya/setup-cpp@v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.0
+      uses: aminya/setup-cpp@v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.0
+      uses: aminya/setup-cpp@v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -17,7 +17,7 @@ jobs:
         sanitizer: [address, undefined]  
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.0
+      uses: aminya/setup-cpp@v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -26,7 +26,7 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -36,13 +36,13 @@ jobs:
           mkdir -p "${CCACHE_DIR}"
           mkdir -p "${CTCACHE_DIR}"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: ${{ env.CPM_SOURCE_CACHE }}
           key: clang-tidy-${{ runner.os }}-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: clang-tidy-${{ runner.os }}-ccache-${{ github.sha }}
@@ -50,7 +50,7 @@ jobs:
             clang-tidy-${{ runner.os }}-ccache-
 
       - name: Cache ctcache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CTCACHE_DIR }}
           key: clang-tidy-${{ runner.os }}-ctcache-${{ hashFiles('.clang-tidy', '.github/workflows/clang-tidy.yml') }}-${{ github.sha }}
@@ -59,10 +59,10 @@ jobs:
             clang-tidy-${{ runner.os }}-ctcache-
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
           compiler: llvm-22
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           ccache: true
           clang-tidy: true

--- a/.github/workflows/conan-windows.yml
+++ b/.github/workflows/conan-windows.yml
@@ -18,9 +18,9 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
-  PROTOC_VERSION: "34.0"
-  PROTOC_ZIP: protoc-34.0-win64.zip
-  PROTOC_SHA256: 76ddeb5ae7a31c8f9f7759d3b843a4cadda2150ac037ad0c1794665d6cf31fce
+  PROTOC_VERSION: "35.0"
+  PROTOC_ZIP: protoc-35.0-win64.zip
+  PROTOC_SHA256: d1cede9e308cc3eb072392af1c02ccae4bdd3d2f374ec2970dbd8cdfdaa91363
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
 jobs:
@@ -43,20 +43,20 @@ jobs:
     name: ${{ matrix.name }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
 
       - name: setup cpp tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           ccache: true
-          conan: "2.25.2"
+          conan: "2.30.0"
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.name }}-ccache-${{ github.sha }}

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -19,9 +19,9 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
-  PROTOC_VERSION: "34.0"
-  PROTOC_ZIP: protoc-34.0-linux-x86_64.zip
-  PROTOC_SHA256: e9a91b6fcfe4177ec2cd35fc8f15c1e811fa0ecdef9372755cd6d3513d5faaab
+  PROTOC_VERSION: "35.0"
+  PROTOC_ZIP: protoc-35.0-linux-x86_64.zip
+  PROTOC_SHA256: a45cda0989c17dd950db55f6fbe1e5814c50fda08e87aa422980ac1f89dddbbc
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
 jobs:
@@ -47,19 +47,19 @@ jobs:
       CXX: g++-13
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: setup cpp tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
           compiler: gcc-13
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           ccache: true
-          conan: "2.25.2"
+          conan: "2.30.0"
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.name }}-ccache-${{ github.sha }}

--- a/.github/workflows/fetch_content.yml
+++ b/.github/workflows/fetch_content.yml
@@ -30,23 +30,23 @@ jobs:
         gcc: [13]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
           compiler: gcc-${{ matrix.gcc }}
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           ccache: true
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-ccache-${{ github.sha }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -33,23 +33,23 @@ jobs:
         cpm-local-packages-only: ["OFF", "ON"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
           compiler: gcc-${{ matrix.gcc }}
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           ccache: true
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ matrix.cpm-local-packages-only }}-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-${{ matrix.cpm-local-packages-only }}-ccache-${{ github.sha }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,23 +63,23 @@
           if: matrix.cmake_preset != 'ci-linux-asan-ubsan'
           run: |
             sudo apt-get install -y libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@v7
 
         - name: Setup required C++ tools
-          uses: aminya/setup-cpp@v1.8.0
+          uses: aminya/setup-cpp@v1.8.1
           with:
             compiler: ${{ matrix.compiler }}
-            cmake: "3.31.0"
+            cmake: "4.4.0"
             ninja: true
             ccache: true
 
-        - uses: actions/cache@v5
+        - uses: actions/cache@v6
           with:
             path: "**/cpm_modules"
             key: ${{ runner.os }}-${{ matrix.compiler }}-cxx${{ matrix.cpp_standard }}-${{ matrix.cmake_preset }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
         - name: Cache ccache
-          uses: actions/cache@v5
+          uses: actions/cache@v6
           with:
             path: ${{ env.CCACHE_DIR }}
             key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.compiler }}-cxx${{ matrix.cpp_standard }}-${{ matrix.cmake_preset }}-ccache-${{ github.sha }}
@@ -108,7 +108,7 @@
             cmake --build build --target coverage_filtered_info
 
         - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@v5
+          uses: codecov/codecov-action@v7
           if: matrix.cmake_preset == 'ci-linux-coverage'
           with:
             token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,15 +32,15 @@ jobs:
           - cmake_preset: ci-macos-coverage
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-ccache-${{ github.sha }}
@@ -48,9 +48,9 @@ jobs:
             ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-ccache-
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           ccache: true
 
@@ -99,7 +99,7 @@ jobs:
           cmake --build build --target coverage_filtered_info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         if: matrix.cmake_preset == 'ci-macos-coverage'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ubuntu-two-stage-host-protoc-gen-hpp.yml
+++ b/.github/workflows/ubuntu-two-stage-host-protoc-gen-hpp.yml
@@ -25,12 +25,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cmake: ["3.28.3", "3.31.0"]
+        cmake: ["4.4.0"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
           compiler: gcc-13
           cmake: ${{ matrix.cmake }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -20,16 +20,16 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   VCPKG_DEFAULT_TRIPLET: x64-linux
-  PROTOC_VERSION: "34.0"
-  PROTOC_ZIP: protoc-34.0-linux-x86_64.zip
-  PROTOC_SHA256: e9a91b6fcfe4177ec2cd35fc8f15c1e811fa0ecdef9372755cd6d3513d5faaab
+  PROTOC_VERSION: "35.0"
+  PROTOC_ZIP: protoc-35.0-linux-x86_64.zip
+  PROTOC_SHA256: a45cda0989c17dd950db55f6fbe1e5814c50fda08e87aa422980ac1f89dddbbc
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: install build tools
         run: |
@@ -52,9 +52,9 @@ jobs:
           echo "PROTOC_BIN=$PROTOC_DIR/bin" >> "$GITHUB_ENV"
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           vcpkg: true
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,14 +34,14 @@ jobs:
             compiler_env: mingw
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
         if: ${{ matrix.compiler_env == 'msvc' }}
 
       - name: Setup MinGW
         if: ${{ matrix.compiler_env == 'mingw' }}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@v2.32.0
         with:
           update: true
           install: mingw-w64-x86_64-gcc
@@ -51,13 +51,13 @@ jobs:
         shell: pwsh
         run: Add-Content -Path $env:GITHUB_PATH -Value "C:\msys64\mingw64\bin"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-${{ matrix.compiler_env }}-ccache-${{ github.sha }}
@@ -65,18 +65,18 @@ jobs:
             ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-${{ matrix.compiler_env }}-ccache-
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.0
+        uses: aminya/setup-cpp@v1.8.1
         with:
-          cmake: "3.31.0"
+          cmake: "4.4.0"
           ninja: true
           ccache: true
 
       - name: Install Protoc
         shell: pwsh
         run: |
-          $version = "34.0"
+          $version = "35.0"
           $zip = "protoc-$version-win64.zip"
-          $sha256 = "76ddeb5ae7a31c8f9f7759d3b843a4cadda2150ac037ad0c1794665d6cf31fce"
+          $sha256 = "d1cede9e308cc3eb072392af1c02ccae4bdd3d2f374ec2970dbd8cdfdaa91363"
           $url = "https://github.com/protocolbuffers/protobuf/releases/download/v$version/$zip"
           $dest = "$env:RUNNER_TEMP\protoc"
           $zipPath = "$dest\$zip"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -25,9 +25,9 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:1.7.8
+        uses: docker://rhysd/actionlint:1.7.12
         with:
           args: -color

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ find_package(glaze CONFIG REQUIRED)
 find_package(is_utf8 CONFIG REQUIRED)
 ```
 
-`glaze` v7.4.0 installs a usable CMake package config. As of `simdutf/is_utf8` v1.4.1, the upstream install rules need a small fix before `find_package(is_utf8 CONFIG REQUIRED)` works: `is_utf8-config.cmake` includes `is_utf8Targets.cmake`, but the project does not install that export file by default. When packaging or installing `is_utf8` yourself, add an export install rule equivalent to:
+`glaze` v7.8.4 installs a usable CMake package config. As of `simdutf/is_utf8` v1.4.1, the upstream install rules need a small fix before `find_package(is_utf8 CONFIG REQUIRED)` works: `is_utf8-config.cmake` includes `is_utf8Targets.cmake`, but the project does not install that export file by default. When packaging or installing `is_utf8` yourself, add an export install rule equivalent to:
 
 ```cmake
 install(EXPORT is_utf8Targets

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -10,11 +10,13 @@ add_library(hpp_benchmark_messages_lib INTERFACE ${proto_files})
 protobuf_generate_hpp(TARGET hpp_benchmark_messages_lib
     PROTOC_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/hpp
     PLUGIN_OPTIONS "namespace_prefix=hpp")
+target_include_directories(hpp_benchmark_messages_lib INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(google_benchmark_messages_lib OBJECT ${proto_files})
 protobuf_generate(TARGET google_benchmark_messages_lib
     LANGUAGE cpp)
 target_link_libraries(google_benchmark_messages_lib PUBLIC protobuf::libprotobuf)
+target_include_directories(google_benchmark_messages_lib PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(google_benchmark_messages_lite_lib OBJECT benchmark_messages_proto3_lite.proto)
 protobuf_generate(TARGET google_benchmark_messages_lite_lib

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -45,7 +45,7 @@ endif()
 if(DEFINED EXTRACTED_CPM_VERSION)
   set(CURRENT_CPM_VERSION "${EXTRACTED_CPM_VERSION}${CPM_DEVELOPMENT}")
 else()
-  set(CURRENT_CPM_VERSION 0.42.1)
+  set(CURRENT_CPM_VERSION 0.43.1)
 endif()
 
 get_filename_component(CPM_CURRENT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
@@ -258,7 +258,9 @@ endfunction()
 
 # Try to infer package name and version from a url
 function(cpm_package_name_and_ver_from_url url outName outVer)
-  if(url MATCHES "[/\\?]([a-zA-Z0-9_\\.-]+)\\.(tar|tar\\.gz|tar\\.bz2|zip|ZIP)(\\?|/|$)")
+  if(url MATCHES
+     "[/\\?]([a-zA-Z0-9_\\.-]+)\\.(tar|tar\\.gz|tar\\.bz2|tar\\.xz|tar\\.zst|zip|ZIP)(\\?|/|$)"
+  )
     # We matched an archive
     set(filename "${CMAKE_MATCH_1}")
 
@@ -766,10 +768,23 @@ function(CPMAddPackage)
     return()
   endif()
 
+  if(NOT DEFINED CPM_${CPM_ARGS_NAME}_SOURCE AND DEFINED ENV{CPM_${CPM_ARGS_NAME}_SOURCE})
+    # Normalize separators to support Windows paths when reading from environment variables.
+    file(TO_CMAKE_PATH "$ENV{CPM_${CPM_ARGS_NAME}_SOURCE}" CPM_${CPM_ARGS_NAME}_SOURCE)
+    message(WARNING "${CPM_INDENT} '${CPM_ARGS_NAME}' version overridden by environment variable "
+                    "CPM_${CPM_ARGS_NAME}_SOURCE='${CPM_${CPM_ARGS_NAME}_SOURCE}'"
+    )
+  endif()
+
   # Check for manual overrides
   if(NOT CPM_ARGS_FORCE AND NOT "${CPM_${CPM_ARGS_NAME}_SOURCE}" STREQUAL "")
     set(PACKAGE_SOURCE ${CPM_${CPM_ARGS_NAME}_SOURCE})
     set(CPM_${CPM_ARGS_NAME}_SOURCE "")
+    if(NOT DEFINED ENV{CPM_${CPM_ARGS_NAME}_SOURCE})
+      message(WARNING "${CPM_INDENT} '${CPM_ARGS_NAME}' version overridden by CMake variable "
+                      "CPM_${CPM_ARGS_NAME}_SOURCE='${PACKAGE_SOURCE}'"
+      )
+    endif()
     CPMAddPackage(
       NAME "${CPM_ARGS_NAME}"
       SOURCE_DIR "${PACKAGE_SOURCE}"
@@ -1241,6 +1256,7 @@ function(cpm_parse_option OPTION)
   else()
     math(EXPR OPTION_KEY_LENGTH "${OPTION_KEY_LENGTH}+1")
     string(SUBSTRING "${OPTION}" "${OPTION_KEY_LENGTH}" "-1" OPTION_VALUE)
+    string(STRIP "${OPTION_VALUE}" OPTION_VALUE)
   endif()
   set(OPTION_KEY
       "${OPTION_KEY}"

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,7 @@ class HppProtoConan(ConanFile):
             check_min_cppstd(self, "23")
 
     def requirements(self):
-        self.requires("glaze/7.4.0")
+        self.requires("glaze/7.8.4")
 
     def build_requirements(self):
         self.protoc_mode = self.conf.get("user.hpp_proto:protoc", default="find")

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -1192,9 +1192,10 @@ constexpr status deserialize_field(concepts::has_meta auto &item, auto meta, uin
 template <typename Meta>
 constexpr status deserialize_field(std::ranges::range auto &item, Meta meta, uint32_t tag,
                                    concepts::is_basic_in auto &archive, auto &unknown_fields)
-  // std::optional is a range in C++26 (P3168); exclude it (and hpp_proto::optional)
-  // here so a singular optional<message> field uses the optional overload above.
-  requires(!concepts::optional<std::remove_reference_t<decltype(item)>>) {
+    // std::optional is a range in C++26 (P3168); exclude it (and hpp_proto::optional)
+    // here so a singular optional<message> field uses the optional overload above.
+  requires(!concepts::optional<std::remove_reference_t<decltype(item)>>)
+{
   using type = std::remove_reference_t<decltype(item)>;
 
   if constexpr (concepts::contiguous_byte_range<type>) {

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -241,7 +241,8 @@ struct size_cache_counter<T> {
 
   template <typename Meta>
   constexpr static std::size_t count(std::ranges::input_range auto const &item, Meta meta)
-    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>) {
+    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>)
+  {
     using type = std::remove_cvref_t<decltype(item)>;
     if constexpr (concepts::contiguous_byte_range<type>) {
       return 0;
@@ -449,7 +450,8 @@ struct message_size_calculator<T> {
   template <typename Meta>
   constexpr static uint64_t field_size(std::ranges::input_range auto const &item, Meta meta,
                                        concepts::is_size_cache_iterator auto &cache_itr)
-    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>) {
+    requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>)
+  {
     using type = std::remove_cvref_t<decltype(item)>;
     constexpr auto tag_size = static_cast<uint64_t>(varint_size(meta.number << 3U));
     if constexpr (concepts::contiguous_byte_range<type>) {

--- a/ports/README.md
+++ b/ports/README.md
@@ -13,7 +13,7 @@ This directory contains local vcpkg overlay ports used by this repository.
 - `ports/hpp-proto`: local port for this project.
   - Default mode is `find` (looks for `protoc` on system `PATH`).
   - Feature `vcpkg-protobuf` uses `protobuf`/`protoc` from vcpkg host tools.
-- `ports/glaze`: pinned overlay port for `glaze` `7.4.0`.
+- `ports/glaze`: pinned overlay port for `glaze` `7.8.4`.
   - This overrides the registry `glaze` port when `--overlay-ports` points to this directory.
 
 ## How Overlay Resolution Works

--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 e209dc177416f18fb0068b20ecea461fa4ee5adf17a8473ad8163291822627e8dca51d8fa12db5c42f1519e4aa1536fdaaeab1e337c7af69730b0a8a2fc921ba
+    SHA512 77cbede7ce25165eb5cbfb48501af78d1d2e3deb85f846b5e98bdd2931702d4f5d6bdeb720c1119417f711e2c5f4dfecdfa5271771024047828d931ad53d311b
     HEAD_REF main
 )
 

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "7.4.0",
+  "version": "7.8.4",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/tests/gpb_proto_json/gpb_proto_json.cpp
+++ b/tests/gpb_proto_json/gpb_proto_json.cpp
@@ -10,7 +10,7 @@ namespace gpb_based {
 namespace gpb = google::protobuf;
 std::string binpb_to_json(const gpb::DescriptorPool &pool, const char *message_name, std::string_view data) {
   const auto *message_descriptor = pool.FindMessageTypeByName(message_name);
-  const gpb::DynamicMessageFactory factory(&pool);
+  gpb::DynamicMessageFactory factory(&pool);
 
   std::unique_ptr<gpb::Message> message{factory.GetPrototype(message_descriptor)->New()};
   message->ParseFromArray(data.data(), static_cast<int>(data.size()));

--- a/third-parties.cmake
+++ b/third-parties.cmake
@@ -6,7 +6,7 @@ if(CMAKE_VERSION GREATER_EQUAL 3.25)
     set(system_package SYSTEM)
 endif()
 
-set(HPP_PROTO_GLAZE_VERSION 7.4.0)
+set(HPP_PROTO_GLAZE_VERSION 7.8.4)
 CPMAddPackage(
     NAME glaze
     GIT_TAG v${HPP_PROTO_GLAZE_VERSION}
@@ -40,7 +40,7 @@ else()
     set(is_utf8_ADDED OFF)
 endif()
 
-set(HPP_PROTO_PROTOC_VERSION "34.0")
+set(HPP_PROTO_PROTOC_VERSION "35.0")
 
 if(HPP_PROTO_CORE_TESTS_ONLY)
     message(STATUS "HPP_PROTO_CORE_TESTS_ONLY=ON: skipping protoc setup")
@@ -70,7 +70,7 @@ if(HPP_PROTO_BENCHMARKS)
     CPMAddPackage(
         NAME benchmark
         GITHUB_REPOSITORY google/benchmark
-        VERSION 1.9.4
+        VERSION 1.9.5
         OPTIONS
         "BENCHMARK_ENABLE_TESTING OFF"
         "BENCHMARK_ENABLE_INSTALL OFF"

--- a/third-parties.cmake
+++ b/third-parties.cmake
@@ -11,6 +11,7 @@ CPMAddPackage(
     NAME glaze
     GIT_TAG v${HPP_PROTO_GLAZE_VERSION}
     GITHUB_REPOSITORY stephenberry/glaze
+    OPTIONS "glaze_INSTALL ON"
     ${system_package}
 )
 if(glaze_ADDED)

--- a/tutorial/conanfile.txt
+++ b/tutorial/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 hpp_proto/1.0.0
-glaze/7.4.0
+glaze/7.8.4
 
 [generators]
 CMakeDeps


### PR DESCRIPTION
## Summary

Upgrade the project’s C++ dependencies, package-manager metadata, build tooling, and GitHub Actions to their latest stable versions available across the supported dependency channels.

## What changed

- Upgrade Glaze to 7.8.4, Protobuf/protoc to 35.0, Google Benchmark to 1.9.5, and CPM.cmake to 0.43.1.
- Synchronize Conan, vcpkg overlay, tutorial, documentation, and protoc download metadata, including refreshed archive checksums.
- Upgrade CI tooling and actions, including CMake 4.4.0, Conan 2.30.0, checkout v7, cache v6, Codecov v7, and current stable setup actions.
- Adapt the Protobuf JSON test helper to the Protobuf 35 `DynamicMessageFactory` API and expose generated benchmark include directories.

## Why

Keep the project current with supported upstream releases and exercise those versions consistently across direct builds, packaging workflows, and CI.
