### PR TITLE
Prevent signed overflow in Duration JSON encoding

### DIFF
--- a/include/hpp_proto/json/duration_codec.hpp
+++ b/include/hpp_proto/json/duration_codec.hpp
@@ -22,7 +22,6 @@
 
 #pragma once
 #include <cstdint>
-#include <cstdlib>
 #include <hpp_proto/json.hpp>
 #include <iterator>
 #include <span>
@@ -37,8 +36,8 @@ struct duration_codec {
   static int64_t encode(auto const &value, auto &&b) noexcept {
     auto has_same_sign = [](auto x, auto y) { return x == 0 || y == 0 || ((x > 0) == (y > 0)); };
 
-    if (!has_same_sign(value.seconds, value.nanos) || std::abs(value.seconds) > 315'576'000'000LL ||
-        std::abs(value.nanos) > 999'999'999) {
+    if (value.seconds < -315'576'000'000LL || value.seconds > 315'576'000'000LL || value.nanos < -999'999'999 ||
+        value.nanos > 999'999'999 || !has_same_sign(value.seconds, value.nanos)) {
       return -1;
     }
 
@@ -52,12 +51,12 @@ struct duration_codec {
       it = std::next(it);
     }
 
-    auto positive_seconds = static_cast<uint64_t>(std::abs(value.seconds));
+    auto positive_seconds = static_cast<uint64_t>(value.seconds < 0 ? -value.seconds : value.seconds);
     it = glz::to_chars(it, positive_seconds);
     auto ix = static_cast<std::size_t>(std::distance(buffer.data(), it));
 
     if (value.nanos != 0) {
-      auto nanos = static_cast<uint32_t>(std::abs(value.nanos));
+      auto nanos = static_cast<uint32_t>(value.nanos < 0 ? -value.nanos : value.nanos);
       const auto write_3_digits = [](std::span<char> out, std::size_t &pos, uint32_t val) {
         out[pos] = static_cast<char>('0' + (val / 100));
         out[pos + 1] = static_cast<char>('0' + ((val / 10) % 10));

--- a/tests/well_known_types_tests.cpp
+++ b/tests/well_known_types_tests.cpp
@@ -27,6 +27,7 @@
 // Well-known type conformance cases use protobuf spec literals directly.
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,misc-const-correctness)
 
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <utility>
@@ -224,6 +225,10 @@ const ut::suite test_duration = [] {
   ut::expect(!hpp_proto::write_json(duration_t{.seconds = 0, .nanos = -1000000000}).has_value());
   ut::expect(!hpp_proto::write_json(duration_t{.seconds = 315576000001, .nanos = 0}).has_value());
   ut::expect(!hpp_proto::write_json(duration_t{.seconds = -315576000001, .nanos = 0}).has_value());
+  ut::expect(
+      !hpp_proto::write_json(duration_t{.seconds = std::numeric_limits<int64_t>::min(), .nanos = 0}).has_value());
+  ut::expect(
+      !hpp_proto::write_json(duration_t{.seconds = 0, .nanos = std::numeric_limits<int32_t>::min()}).has_value());
   ut::expect(!hpp_proto::write_json(duration_t{.seconds = 1, .nanos = -1}).has_value());
   ut::expect(!hpp_proto::write_json(duration_t{.seconds = -1, .nanos = 1}).has_value());
 };


### PR DESCRIPTION
## Summary

Prevent undefined behavior when encoding invalid protobuf `Duration` values containing minimum signed integers.

## What changed

- Validate seconds and nanoseconds against protobuf's allowed signed bounds before computing their magnitudes.
- Replace `std::abs` calls with safe negation after bounds validation.
- Add regression coverage for `INT64_MIN` seconds and `INT32_MIN` nanoseconds.

## Why

Calling `std::abs` on the minimum value of a signed integer overflows before the existing range check can reject the invalid duration. Validating first ensures malformed values from binary protobuf input are rejected without invoking undefined behavior.
