### PR TITLE
Require exact Any type URL matches

### DIFF
--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -351,7 +351,9 @@ status pack_any(concepts::is_any auto &any, concepts::has_meta auto const &msg,
 
 status unpack_any(concepts::is_any auto const &any, concepts::has_meta auto &msg,
                   concepts::is_option_type auto &&...option) {
-  if (std::string_view{any.type_url}.ends_with(message_name(msg))) {
+  const std::string_view type_url{any.type_url};
+  const auto slash_pos = type_url.rfind('/');
+  if (slash_pos != std::string_view::npos && type_url.substr(slash_pos + 1) == message_name(msg)) {
     return read_binpb(msg, any.value, std::forward<decltype(option)>(option)...);
   }
   return std::errc::invalid_argument;

--- a/tests/any_test.cpp
+++ b/tests/any_test.cpp
@@ -56,6 +56,9 @@ const suite test_any = [] {
     expect(hpp_proto::unpack_any(message2.any_value.value(), fm2, ::hpp_proto::alloc_from(mr)).ok());
     expect(std::ranges::equal(paths, fm2.paths));
 
+    message2.any_value->type_url = "type.googleapis.com/Othergoogle.protobuf.FieldMask";
+    expect(!hpp_proto::unpack_any(message2.any_value.value(), fm2, ::hpp_proto::alloc_from(mr)).ok());
+
     expect(!hpp_proto::unpack_any<::proto3_unittest::ForeignMessage<Traits>>(message2.any_value.value(),
                                                                              ::hpp_proto::alloc_from(mr))
                 .has_value());


### PR DESCRIPTION
## Summary

Prevent protobuf `Any` values with suffix-colliding type names from being unpacked as the wrong message type.

## What changed

- Extract the final slash-delimited component from `Any.type_url`.
- Compare that component exactly with the requested protobuf message name.
- Add regression coverage for suffix collisions with owning and non-owning message traits.

## Why

The previous suffix comparison allowed a type such as `Othergoogle.protobuf.FieldMask` to pass validation for `google.protobuf.FieldMask`. Applications relying on `unpack_any` as a type boundary could therefore deserialize bytes under the wrong declared type.
