### PR TITLE
Harden descriptor pool schema validation

### DIFF
--- a/docs/dynamic_message.md
+++ b/docs/dynamic_message.md
@@ -34,8 +34,8 @@ target_link_libraries(your_target PRIVATE hpp_proto::dynamic_message)
 
 * `dynamic_message_factory` has no default constructor. Create it via `dynamic_message_factory::create(...)`.
 * `create(...)` returns `std::expected<dynamic_message_factory, dynamic_message_errc>`.
-* `create(...)` overloads accept an optional allocator parameter via
-  `dynamic_message_factory::impl_allocator_type`.
+* `create(...)` overloads accept optional `descriptor_memory_options`. The factory owns the limited descriptor
+  resource and arena; a custom `upstream` resource remains caller-owned and must outlive the factory.
 * By design, `create(...)` does not catch `std::bad_alloc` thrown by standard containers.
 
 ```cpp
@@ -357,6 +357,7 @@ For instance, adding a new person to an address book might look like this:
 
 When working with dynamic messages, it's crucial to keep the following in mind:
 
+*   **Descriptor Input Trust**: `dynamic_message_factory::create()` accepts trusted, prevalidated descriptor input and does not impose a serialized-buffer size limit. If descriptors come from an untrusted source, enforce transport and buffer-size limits before materializing the complete input and calling the factory. Factory-owned decoding, validation, and descriptor-pool allocations remain bounded by `dynamic_message_factory::max_descriptor_memory_bytes` by default.
 *   **Memory Resource Lifetime**: The `std::pmr::monotonic_buffer_resource` (or any `std::pmr::memory_resource`) you provide must remain alive and valid for as long as any `message_value_mref`, `message_value_cref`, or field references (`*_field_mref`/`*_cref`) that use that resource are in scope. Dynamic messages allocate all their internal data (strings, vectors, nested messages) from this resource.
 *   **Repeated Field References**: Operations that modify the size or capacity of repeated fields (e.g., `reserve`, `resize`, `push_back`, `emplace_back` on a `repeated_*_field_mref`) can invalidate existing references to elements within that repeated field. Always reacquire references to individual elements after such mutations.
 *   **Message Field Presence**: When reading scalar, string, bytes, or enum fields, accessing an unset field will return its default value. However, for nested message fields, always check `has_value()` before dereferencing (`.value()`) to ensure the message has been materialized. Directly accessing an unset message field can lead to undefined behavior.

--- a/docs/dynamic_message.md
+++ b/docs/dynamic_message.md
@@ -34,8 +34,8 @@ target_link_libraries(your_target PRIVATE hpp_proto::dynamic_message)
 
 * `dynamic_message_factory` has no default constructor. Create it via `dynamic_message_factory::create(...)`.
 * `create(...)` returns `std::expected<dynamic_message_factory, dynamic_message_errc>`.
-* `create(...)` overloads accept optional `descriptor_memory_options`. The factory owns the limited descriptor
-  resource and arena; a custom `upstream` resource remains caller-owned and must outlive the factory.
+* `create(...)` overloads accept an optional PMR allocator. Its resource is used as the upstream for factory-owned
+  descriptor storage and must outlive the factory.
 * By design, `create(...)` does not catch `std::bad_alloc` thrown by standard containers.
 
 ```cpp
@@ -357,7 +357,7 @@ For instance, adding a new person to an address book might look like this:
 
 When working with dynamic messages, it's crucial to keep the following in mind:
 
-*   **Descriptor Input Trust**: `dynamic_message_factory::create()` accepts trusted, prevalidated descriptor input and does not impose a serialized-buffer size limit. If descriptors come from an untrusted source, enforce transport and buffer-size limits before materializing the complete input and calling the factory. Factory-owned decoding, validation, and descriptor-pool allocations remain bounded by `dynamic_message_factory::max_descriptor_memory_bytes` by default.
+*   **Descriptor Input Trust**: `dynamic_message_factory::create()` accepts trusted, prevalidated descriptor input and does not impose a serialized-buffer size limit. If descriptors come from an untrusted source, enforce transport and buffer-size limits before materializing the complete input and calling the factory.
 *   **Memory Resource Lifetime**: The `std::pmr::monotonic_buffer_resource` (or any `std::pmr::memory_resource`) you provide must remain alive and valid for as long as any `message_value_mref`, `message_value_cref`, or field references (`*_field_mref`/`*_cref`) that use that resource are in scope. Dynamic messages allocate all their internal data (strings, vectors, nested messages) from this resource.
 *   **Repeated Field References**: Operations that modify the size or capacity of repeated fields (e.g., `reserve`, `resize`, `push_back`, `emplace_back` on a `repeated_*_field_mref`) can invalidate existing references to elements within that repeated field. Always reacquire references to individual elements after such mutations.
 *   **Message Field Presence**: When reading scalar, string, bytes, or enum fields, accessing an unset field will return its default value. However, for nested message fields, always check `has_value()` before dereferencing (`.value()`) to ensure the message has been materialized. Directly accessing an unset message field can lead to undefined behavior.

--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -287,16 +287,28 @@ struct extension_base { // NOLINT(bugprone-crtp-constructor-accessibility)
   template <typename Traits>
   status get_from(const Extendee<Traits> &extendee, concepts::is_option_type auto &&...option) {
     auto &fields = pb_serializer::get_unknown_fields(extendee);
-    decltype(fields.begin()) itr;
-
     if constexpr (requires { fields.find(number()); }) {
-      itr = fields.find(number());
+      const auto itr = fields.find(number());
+      if (itr != fields.end()) {
+        return read_binpb(*static_cast<T *>(this), itr->second, std::forward<decltype(option)>(option)...);
+      }
     } else {
-      itr = std::find_if(fields.begin(), fields.end(), [](const auto &item) { return item.first == number(); });
-    }
-
-    if (itr != fields.end()) {
-      return read_binpb(*static_cast<T *>(this), itr->second, std::forward<decltype(option)>(option)...);
+      auto &extension = *static_cast<T *>(this);
+      pb_context ctx{std::forward<decltype(option)>(option)...};
+      bool found = false;
+      // Non-owning extension storage can contain multiple entries for one field number.
+      // Deserialize them into the same object so protobuf merge ordering is preserved.
+      for (const auto &[field_number, data] : fields) {
+        if (field_number == number()) {
+          if (!found) {
+            extension = {};
+            found = true;
+          }
+          if (auto result = pb_serializer::deserialize(extension, data, ctx); !result.ok()) {
+            return result;
+          }
+        }
+      }
     }
 
     return {};

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -950,8 +950,7 @@ private:
           return copy_features(default_features.fixed_features.value(), resource_);
         }
 
-        auto features = copy_features(default_features.overridable_features.value(), resource_);
-        return merge_features(features, file.options, resource_);
+        return copy_features(default_features.overridable_features.value(), resource_);
       }
     }
     return std::unexpected(descriptor_pool_errc::validation_error);

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -539,93 +539,43 @@ public:
 
 private:
   friend class dynamic_message_factory;
-  static constexpr std::size_t max_schema_nodes = 131'072;
-  static constexpr std::size_t max_schema_fields = 65'536;
-  static constexpr std::size_t max_dependency_edges = 65'536;
-  static constexpr std::size_t max_message_nesting_depth = 100;
-
   struct descriptor_counter {
     std::size_t files = 0;
     std::size_t messages = 0;
     std::size_t fields = 0;
     std::size_t oneofs = 0;
     std::size_t enums = 0;
-    std::size_t dependency_edges = 0;
-    std::size_t schema_nodes = 0;
-    bool valid = true;
 
     explicit descriptor_counter(const FileDescriptorSet &fileset) {
       for (const auto &f : fileset.file) {
-        if (!count_file(f)) {
-          valid = false;
-          return;
-        }
+        count_file(f);
       }
     }
 
-    bool add_nodes(std::size_t count) {
-      if (count > max_schema_nodes - schema_nodes) {
-        return false;
-      }
-      schema_nodes += count;
-      return true;
-    }
-
-    bool add_fields(std::size_t count) {
-      if (count > max_schema_fields - fields || !add_nodes(count)) {
-        return false;
-      }
-      fields += count;
-      return true;
-    }
-
-    bool add_enum_values(const auto &enums) {
-      return std::ranges::all_of(enums,
-                                 [this](const auto &enumeration) { return add_nodes(enumeration.value.size()); });
-    }
-
-    bool count_file(const FileDescriptorProto &file) {
-      if (!add_nodes(1) || file.dependency.size() > max_dependency_edges - dependency_edges) {
-        return false;
-      }
+    void count_file(const FileDescriptorProto &file) {
       files++;
-      dependency_edges += file.dependency.size();
       for (const auto &m : file.message_type) {
-        if (!count_message(m)) {
-          return false;
-        }
-      }
-      if (!add_nodes(file.enum_type.size()) || !add_enum_values(file.enum_type) || !add_fields(file.extension.size())) {
-        return false;
+        count_message(m);
       }
       enums += file.enum_type.size();
-      return true;
+      fields += file.extension.size();
     }
 
-    bool count_message(const DescriptorProto &root) {
-      if (!add_nodes(1)) {
-        return false;
-      }
+    void count_message(const DescriptorProto &root) {
       messages++;
-      std::vector<std::pair<const DescriptorProto *, std::size_t>> pending{{&root, 1}};
+      std::vector<const DescriptorProto *> pending{&root};
       while (!pending.empty()) {
-        const auto [message_ptr, depth] = pending.back();
+        const auto *message_ptr = pending.back();
         pending.pop_back();
         const auto &message = *message_ptr;
-        if (!add_nodes(message.enum_type.size()) || !add_nodes(message.oneof_decl.size()) ||
-            !add_fields(message.field.size()) || !add_fields(message.extension.size()) ||
-            !add_enum_values(message.enum_type) || !add_nodes(message.nested_type.size()) ||
-            (!message.nested_type.empty() && depth >= max_message_nesting_depth)) {
-          return false;
-        }
         enums += message.enum_type.size();
         oneofs += message.oneof_decl.size();
+        fields += message.field.size() + message.extension.size();
         messages += message.nested_type.size();
         for (const auto &nested : message.nested_type) {
-          pending.emplace_back(&nested, depth + 1);
+          pending.push_back(&nested);
         }
       }
-      return true;
     }
   };
 
@@ -640,9 +590,6 @@ private:
     enum_map_.clear();
 
     const descriptor_counter counter(fileset_);
-    if (!counter.valid) {
-      return std::unexpected(descriptor_pool_errc::validation_error);
-    }
     reserve_storage(counter);
     return build_files_from_fileset()
         .and_then([this] { return link_file_dependencies(); })

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -81,6 +81,51 @@ class descriptor_pool {
     }
   }
 
+  template <typename Options>
+  [[nodiscard]] static Options make_empty_options(std::pmr::memory_resource *resource) {
+    using uninterpreted_options = decltype(std::declval<Options>().uninterpreted_option);
+    using extensions = decltype(std::declval<Options>().unknown_fields_.fields);
+    if constexpr (std::same_as<Options, google::protobuf::FileOptions<typename AddOns::traits_type>>) {
+      using string = decltype(std::declval<Options>().java_package);
+      return {.java_package = with_resource<string>(resource),
+              .java_outer_classname = with_resource<string>(resource),
+              .go_package = with_resource<string>(resource),
+              .objc_class_prefix = with_resource<string>(resource),
+              .csharp_namespace = with_resource<string>(resource),
+              .swift_prefix = with_resource<string>(resource),
+              .php_class_prefix = with_resource<string>(resource),
+              .php_namespace = with_resource<string>(resource),
+              .php_metadata_namespace = with_resource<string>(resource),
+              .ruby_package = with_resource<string>(resource),
+              .uninterpreted_option = with_resource<uninterpreted_options>(resource),
+              .unknown_fields_ = {.fields = with_resource<extensions>(resource)}};
+    } else if constexpr (std::same_as<Options, google::protobuf::FieldOptions<typename AddOns::traits_type>>) {
+      using targets = decltype(std::declval<Options>().targets);
+      using edition_defaults = decltype(std::declval<Options>().edition_defaults);
+      return {.targets = with_resource<targets>(resource),
+              .edition_defaults = with_resource<edition_defaults>(resource),
+              .uninterpreted_option = with_resource<uninterpreted_options>(resource),
+              .unknown_fields_ = {.fields = with_resource<extensions>(resource)}};
+    } else {
+      return {.uninterpreted_option = with_resource<uninterpreted_options>(resource),
+              .unknown_fields_ = {.fields = with_resource<extensions>(resource)}};
+    }
+  }
+
+  template <typename Options>
+  [[nodiscard]] static Options copy_options(const std::optional<Options> &source, std::pmr::memory_resource *resource) {
+    using uninterpreted_options = decltype(std::declval<Options>().uninterpreted_option);
+    if constexpr (!std::constructible_from<uninterpreted_options, std::pmr::memory_resource *>) {
+      return source.value_or(Options{});
+    } else {
+      auto result = make_empty_options<Options>(resource);
+      if (source.has_value()) {
+        hpp_proto::merge(result, *source, hpp_proto::alloc_from(*resource));
+      }
+      return result;
+    }
+  }
+
 public:
   // NOLINTBEGIN(bugprone-unchecked-optional-access)
   using traits_type = AddOns::traits_type;
@@ -120,7 +165,7 @@ public:
   public:
     field_descriptor_base(const FieldDescriptorProto &proto, message_descriptor_t *parent,
                           const auto &inherited_options, std::pmr::memory_resource *resource)
-        : proto_(proto), parent_message_(parent), options_(proto.options.value_or(FieldOptions{})) {
+        : proto_(proto), parent_message_(parent), options_(copy_options(proto.options, resource)) {
       options_.features = merge_features(inherited_options.features.value(), proto.options, resource);
 
       setup_presence();
@@ -261,7 +306,7 @@ public:
     explicit oneof_descriptor_base(const OneofDescriptorProto &proto, const MessageOptions &inherited_options,
                                    std::pmr::memory_resource *resource)
         : proto_(proto), fields_(with_resource<decltype(fields_)>(resource)),
-          options_(proto.options.value_or(OneofOptions{})) {
+          options_(copy_options(proto.options, resource)) {
       options_.features = merge_features(inherited_options.features.value(), proto.options, resource);
     }
 
@@ -311,7 +356,7 @@ public:
                                   file_descriptor_t *parent_file, message_descriptor_t *parent_message,
                                   std::pmr::memory_resource *resource)
         : proto_(proto), full_name_(std::move(full_name)), parent_file_(parent_file), parent_message_(parent_message),
-          options_(proto.options.value_or(EnumOptions{})) {
+          options_(copy_options(proto.options, resource)) {
       options_.features = merge_features(inherited_options.features.value(), proto.options, resource);
     }
     ~enum_descriptor_base() = default;
@@ -363,8 +408,7 @@ public:
         : proto_(proto), full_name_(std::move(full_name)), parent_file_(parent_file), parent_message_(parent_message),
           fields_(with_resource<decltype(fields_)>(resource)), enums_(with_resource<decltype(enums_)>(resource)),
           oneofs_(with_resource<decltype(oneofs_)>(resource)), messages_(with_resource<decltype(messages_)>(resource)),
-          extensions_(with_resource<decltype(extensions_)>(resource)),
-          options_(proto.options.value_or(MessageOptions{})) {
+          extensions_(with_resource<decltype(extensions_)>(resource)), options_(copy_options(proto.options, resource)) {
       options_.features = merge_features(inherited_options.features.value(), proto_.options, resource);
     }
 
@@ -435,7 +479,7 @@ public:
           messages_(with_resource<decltype(messages_)>(resource)),
           extensions_(with_resource<decltype(extensions_)>(resource)),
           dependencies_(with_resource<decltype(dependencies_)>(resource)),
-          options_(proto.options.value_or(FileOptions{})) {
+          options_(copy_options(proto.options, resource)) {
       options_.features = merge_features(default_features, proto.options, resource);
     }
 
@@ -793,6 +837,20 @@ private:
     return features;
   }
 
+  template <typename SourceFeatureSet>
+  static FeatureSet copy_features(const SourceFeatureSet &source,
+                                  [[maybe_unused]] std::pmr::memory_resource *resource) {
+    return {.field_presence = source.field_presence,
+            .enum_type = source.enum_type,
+            .repeated_field_encoding = source.repeated_field_encoding,
+            .utf8_validation = source.utf8_validation,
+            .message_encoding = source.message_encoding,
+            .json_format = source.json_format,
+            .enforce_naming_style = source.enforce_naming_style,
+            .default_symbol_visibility = source.default_symbol_visibility,
+            .unknown_fields_ = {}};
+  }
+
   FileDescriptorSet fileset_;
   vector_t<file_descriptor_t> files_;
   vector_t<message_descriptor_t> messages_;
@@ -807,7 +865,7 @@ private:
   std::pmr::memory_resource *resource_;
   std::pmr::memory_resource *scratch_resource_;
 
-  static google::protobuf::FeatureSetDefaults<traits_type> get_cpp_edition_defaults() {
+  static google::protobuf::FeatureSetDefaults<> get_cpp_edition_defaults() {
     // from https://github.com/protocolbuffers/protobuf/blob/v33.0/src/google/protobuf/cpp_edition_defaults.h
     //"\n#\030\204\007\"\003\302>\000*\031\010\001\020\002\030\002
     //\003(\0010\0028\002@\001\302>\006\010\001\020\003\030\000\n#\030\347\007\"\003\302>\000*\031\010\002\020\001\030\001
@@ -816,34 +874,37 @@ private:
     //\002(\0010\0018\001@\002\302>\006\010\000\020\001\030\001*\003\302>\000 \346\007(\351\007"sv
     using namespace google::protobuf::FeatureSet_;
     using namespace VisibilityFeature_;
-    static auto default_feature_set =
-        std::initializer_list<typename google::protobuf::FeatureSetDefaults<traits_type>::FeatureSetEditionDefault>{
+    static const auto default_feature_set =
+        std::initializer_list<google::protobuf::FeatureSetDefaults<>::FeatureSetEditionDefault>{
             {.edition = google::protobuf::Edition::EDITION_LEGACY,
              .overridable_features = {},
-             .fixed_features = FeatureSet{.field_presence = FieldPresence::EXPLICIT,
-                                          .enum_type = EnumType::CLOSED,
-                                          .repeated_field_encoding = RepeatedFieldEncoding::EXPANDED,
-                                          .utf8_validation = Utf8Validation::NONE,
-                                          .message_encoding = MessageEncoding::LENGTH_PREFIXED,
-                                          .json_format = JsonFormat::LEGACY_BEST_EFFORT,
-                                          .enforce_naming_style = EnforceNamingStyle::STYLE_LEGACY,
-                                          .default_symbol_visibility = DefaultSymbolVisibility::EXPORT_ALL,
-                                          .unknown_fields_ = {}},
+             .fixed_features =
+                 google::protobuf::FeatureSet<>{.field_presence = FieldPresence::EXPLICIT,
+                                                .enum_type = EnumType::CLOSED,
+                                                .repeated_field_encoding = RepeatedFieldEncoding::EXPANDED,
+                                                .utf8_validation = Utf8Validation::NONE,
+                                                .message_encoding = MessageEncoding::LENGTH_PREFIXED,
+                                                .json_format = JsonFormat::LEGACY_BEST_EFFORT,
+                                                .enforce_naming_style = EnforceNamingStyle::STYLE_LEGACY,
+                                                .default_symbol_visibility = DefaultSymbolVisibility::EXPORT_ALL,
+                                                .unknown_fields_ = {}},
              .unknown_fields_ = {}},
             {.edition = google::protobuf::Edition::EDITION_PROTO3,
              .overridable_features = {},
-             .fixed_features = FeatureSet{.field_presence = FieldPresence::IMPLICIT,
-                                          .enum_type = EnumType::OPEN,
-                                          .repeated_field_encoding = RepeatedFieldEncoding::PACKED,
-                                          .utf8_validation = Utf8Validation::VERIFY,
-                                          .message_encoding = MessageEncoding::LENGTH_PREFIXED,
-                                          .json_format = JsonFormat::ALLOW,
-                                          .enforce_naming_style = EnforceNamingStyle::STYLE_LEGACY,
-                                          .default_symbol_visibility = DefaultSymbolVisibility::EXPORT_ALL,
-                                          .unknown_fields_ = {}},
+             .fixed_features =
+                 google::protobuf::FeatureSet<>{.field_presence = FieldPresence::IMPLICIT,
+                                                .enum_type = EnumType::OPEN,
+                                                .repeated_field_encoding = RepeatedFieldEncoding::PACKED,
+                                                .utf8_validation = Utf8Validation::VERIFY,
+                                                .message_encoding = MessageEncoding::LENGTH_PREFIXED,
+                                                .json_format = JsonFormat::ALLOW,
+                                                .enforce_naming_style = EnforceNamingStyle::STYLE_LEGACY,
+                                                .default_symbol_visibility = DefaultSymbolVisibility::EXPORT_ALL,
+                                                .unknown_fields_ = {}},
              .unknown_fields_ = {}},
             {.edition = google::protobuf::Edition::EDITION_2023,
-             .overridable_features = FeatureSet{.field_presence = FieldPresence::EXPLICIT,
+             .overridable_features =
+                 google::protobuf::FeatureSet<>{.field_presence = FieldPresence::EXPLICIT,
                                                 .enum_type = EnumType::OPEN,
                                                 .repeated_field_encoding = RepeatedFieldEncoding::PACKED,
                                                 .utf8_validation = Utf8Validation::VERIFY,
@@ -855,7 +916,8 @@ private:
              .fixed_features = {},
              .unknown_fields_ = {}},
             {.edition = google::protobuf::Edition::EDITION_2024,
-             .overridable_features = FeatureSet{.field_presence = FieldPresence::EXPLICIT,
+             .overridable_features =
+                 google::protobuf::FeatureSet<>{.field_presence = FieldPresence::EXPLICIT,
                                                 .enum_type = EnumType::OPEN,
                                                 .repeated_field_encoding = RepeatedFieldEncoding::PACKED,
                                                 .utf8_validation = Utf8Validation::VERIFY,
@@ -883,10 +945,10 @@ private:
     for (const auto &default_features : cpp_edition_defaults.defaults) {
       if (default_features.edition == current_edition_) {
         if (current_edition_ <= google::protobuf::Edition::EDITION_PROTO3) {
-          return default_features.fixed_features.value();
+          return copy_features(default_features.fixed_features.value(), resource_);
         }
 
-        auto features = default_features.overridable_features.value_or(FeatureSet{});
+        auto features = copy_features(default_features.overridable_features.value(), resource_);
         return merge_features(features, file.options, resource_);
       }
     }

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -100,9 +100,10 @@ public:
 
 private:
   [[nodiscard]] static FileDescriptorSet make_fileset(std::pmr::memory_resource *resource) {
-    FileDescriptorSet result;
-    result.file = with_resource<decltype(result.file)>(resource);
-    return result;
+    using file_container = decltype(FileDescriptorSet{}.file);
+    using extension_container = decltype(FileDescriptorSet{}.unknown_fields_.fields);
+    return {.file = with_resource<file_container>(resource),
+            .unknown_fields_ = {.fields = with_resource<extension_container>(resource)}};
   }
 
   [[nodiscard]] string_t make_string(std::string_view value) const {

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -72,6 +72,15 @@ class descriptor_pool {
   template <typename T, typename U>
   using map_t = AddOns::template map_t<T, U>;
 
+  template <typename T>
+  [[nodiscard]] static T with_resource(std::pmr::memory_resource *resource) {
+    if constexpr (std::constructible_from<T, std::pmr::memory_resource *>) {
+      return T{resource};
+    } else {
+      return T{};
+    }
+  }
+
 public:
   // NOLINTBEGIN(bugprone-unchecked-optional-access)
   using traits_type = AddOns::traits_type;
@@ -89,15 +98,29 @@ public:
   using FileOptions = google::protobuf::FileOptions<traits_type>;
   using FileDescriptorSet = google::protobuf::FileDescriptorSet<traits_type>;
 
+private:
+  [[nodiscard]] static FileDescriptorSet make_fileset(std::pmr::memory_resource *resource) {
+    FileDescriptorSet result;
+    result.file = with_resource<decltype(result.file)>(resource);
+    return result;
+  }
+
+  [[nodiscard]] string_t make_string(std::string_view value) const {
+    auto result = with_resource<string_t>(resource_);
+    result.assign(value);
+    return result;
+  }
+
+public:
   class message_descriptor_t;
   class enum_descriptor_t;
   class file_descriptor_t;
   class field_descriptor_base {
   public:
     field_descriptor_base(const FieldDescriptorProto &proto, message_descriptor_t *parent,
-                          const auto &inherited_options)
+                          const auto &inherited_options, std::pmr::memory_resource *resource)
         : proto_(proto), parent_message_(parent), options_(proto.options.value_or(FieldOptions{})) {
-      options_.features = merge_features(inherited_options.features.value(), proto.options);
+      options_.features = merge_features(inherited_options.features.value(), proto.options, resource);
 
       setup_presence();
       setup_repeated();
@@ -226,15 +249,19 @@ public:
                              public AddOns::template field_descriptor<field_descriptor_t> {
   public:
     using addon_type = AddOns::template field_descriptor<field_descriptor_t>;
-    field_descriptor_t(const FieldDescriptorProto &proto, message_descriptor_t *parent, const auto &inherited_options)
-        : field_descriptor_base(proto, parent, inherited_options), addon_type(*this, inherited_options) {}
+    field_descriptor_t(const FieldDescriptorProto &proto, message_descriptor_t *parent, const auto &inherited_options,
+                       std::pmr::memory_resource *resource)
+        : field_descriptor_base(proto, parent, inherited_options, resource),
+          addon_type(*this, inherited_options, resource) {}
   };
 
   class oneof_descriptor_base {
   public:
-    explicit oneof_descriptor_base(const OneofDescriptorProto &proto, const MessageOptions &inherited_options)
-        : proto_(proto), options_(proto.options.value_or(OneofOptions{})) {
-      options_.features = merge_features(inherited_options.features.value(), proto.options);
+    explicit oneof_descriptor_base(const OneofDescriptorProto &proto, const MessageOptions &inherited_options,
+                                   std::pmr::memory_resource *resource)
+        : proto_(proto), fields_(with_resource<decltype(fields_)>(resource)),
+          options_(proto.options.value_or(OneofOptions{})) {
+      options_.features = merge_features(inherited_options.features.value(), proto.options, resource);
     }
 
     ~oneof_descriptor_base() = default;
@@ -272,17 +299,19 @@ public:
     using addon_type = AddOns::template oneof_descriptor<oneof_descriptor_t>;
 
   public:
-    oneof_descriptor_t(const OneofDescriptorProto &proto, const MessageOptions &inherited_options)
-        : oneof_descriptor_base(proto, inherited_options), addon_type(*this, inherited_options) {}
+    oneof_descriptor_t(const OneofDescriptorProto &proto, const MessageOptions &inherited_options,
+                       std::pmr::memory_resource *resource)
+        : oneof_descriptor_base(proto, inherited_options, resource), addon_type(*this, inherited_options, resource) {}
   };
 
   class enum_descriptor_base {
   public:
     explicit enum_descriptor_base(const EnumDescriptorProto &proto, string_t &&full_name, const auto &inherited_options,
-                                  file_descriptor_t *parent_file, message_descriptor_t *parent_message)
+                                  file_descriptor_t *parent_file, message_descriptor_t *parent_message,
+                                  std::pmr::memory_resource *resource)
         : proto_(proto), full_name_(std::move(full_name)), parent_file_(parent_file), parent_message_(parent_message),
           options_(proto.options.value_or(EnumOptions{})) {
-      options_.features = merge_features(inherited_options.features.value(), proto.options);
+      options_.features = merge_features(inherited_options.features.value(), proto.options, resource);
     }
     ~enum_descriptor_base() = default;
     enum_descriptor_base(const enum_descriptor_base &) = delete;
@@ -319,18 +348,23 @@ public:
   public:
     using addon_type = AddOns::template enum_descriptor<enum_descriptor_t>;
     explicit enum_descriptor_t(const EnumDescriptorProto &proto, string_t &&full_name, const auto &inherited_options,
-                               file_descriptor_t *parent_file, message_descriptor_t *parent_message)
-        : enum_descriptor_base(proto, std::move(full_name), inherited_options, parent_file, parent_message),
-          addon_type(*this, inherited_options) {}
+                               file_descriptor_t *parent_file, message_descriptor_t *parent_message,
+                               std::pmr::memory_resource *resource)
+        : enum_descriptor_base(proto, std::move(full_name), inherited_options, parent_file, parent_message, resource),
+          addon_type(*this, inherited_options, resource) {}
   };
 
   class message_descriptor_base {
   public:
     explicit message_descriptor_base(const DescriptorProto &proto, string_t full_name, const auto &inherited_options,
-                                     file_descriptor_t *parent_file, message_descriptor_t *parent_message)
+                                     file_descriptor_t *parent_file, message_descriptor_t *parent_message,
+                                     std::pmr::memory_resource *resource)
         : proto_(proto), full_name_(std::move(full_name)), parent_file_(parent_file), parent_message_(parent_message),
+          fields_(with_resource<decltype(fields_)>(resource)), enums_(with_resource<decltype(enums_)>(resource)),
+          oneofs_(with_resource<decltype(oneofs_)>(resource)), messages_(with_resource<decltype(messages_)>(resource)),
+          extensions_(with_resource<decltype(extensions_)>(resource)),
           options_(proto.options.value_or(MessageOptions{})) {
-      options_.features = merge_features(inherited_options.features.value(), proto_.options);
+      options_.features = merge_features(inherited_options.features.value(), proto_.options, resource);
     }
 
     message_descriptor_base(const message_descriptor_base &) = delete;
@@ -385,16 +419,23 @@ public:
     using field_type = field_descriptor_t;
 
     explicit message_descriptor_t(const DescriptorProto &proto, string_t &&full_name, const auto &inherited_options,
-                                  file_descriptor_t *parent_file, message_descriptor_t *parent_message)
-        : message_descriptor_base(proto, std::move(full_name), inherited_options, parent_file, parent_message),
-          addon_type(*this, inherited_options) {}
+                                  file_descriptor_t *parent_file, message_descriptor_t *parent_message,
+                                  std::pmr::memory_resource *resource)
+        : message_descriptor_base(proto, std::move(full_name), inherited_options, parent_file, parent_message,
+                                  resource),
+          addon_type(*this, inherited_options, resource) {}
   };
 
   class file_descriptor_base {
   public:
-    explicit file_descriptor_base(const FileDescriptorProto &proto, const FeatureSet &default_features)
-        : proto_(proto), options_(proto.options.value_or(FileOptions{})) {
-      options_.features = merge_features(default_features, proto.options);
+    explicit file_descriptor_base(const FileDescriptorProto &proto, const FeatureSet &default_features,
+                                  std::pmr::memory_resource *resource)
+        : proto_(proto), enums_(with_resource<decltype(enums_)>(resource)),
+          messages_(with_resource<decltype(messages_)>(resource)),
+          extensions_(with_resource<decltype(extensions_)>(resource)),
+          dependencies_(with_resource<decltype(dependencies_)>(resource)),
+          options_(proto.options.value_or(FileOptions{})) {
+      options_.features = merge_features(default_features, proto.options, resource);
     }
 
     file_descriptor_base(const file_descriptor_base &) = delete;
@@ -430,8 +471,9 @@ public:
   class file_descriptor_t : public file_descriptor_base, public AddOns::template file_descriptor<file_descriptor_t> {
   public:
     using addon_type = AddOns::template file_descriptor<file_descriptor_t>;
-    explicit file_descriptor_t(const FileDescriptorProto &proto, const FeatureSet &default_features)
-        : file_descriptor_base(proto, default_features), addon_type(*this) {}
+    explicit file_descriptor_t(const FileDescriptorProto &proto, const FeatureSet &default_features,
+                               std::pmr::memory_resource *resource)
+        : file_descriptor_base(proto, default_features, resource), addon_type(*this, resource) {}
   };
 
   static std::expected<FileDescriptorSet, descriptor_pool_errc>
@@ -511,29 +553,24 @@ public:
   [[nodiscard]] const map_t<std::string_view, message_descriptor_t *> &message_map() const { return message_map_; }
   [[nodiscard]] const map_t<std::string_view, enum_descriptor_t *> &enum_map() const { return enum_map_; }
 
-  descriptor_pool() = default;
+  descriptor_pool() : descriptor_pool(std::pmr::get_default_resource()) {}
+
+  explicit descriptor_pool(std::pmr::memory_resource *resource, std::pmr::memory_resource *scratch_resource = nullptr)
+      : fileset_(make_fileset(resource)), files_(with_resource<decltype(files_)>(resource)),
+        messages_(with_resource<decltype(messages_)>(resource)), enums_(with_resource<decltype(enums_)>(resource)),
+        oneofs_(with_resource<decltype(oneofs_)>(resource)), fields_(with_resource<decltype(fields_)>(resource)),
+        file_map_(with_resource<decltype(file_map_)>(resource)),
+        message_map_(with_resource<decltype(message_map_)>(resource)),
+        enum_map_(with_resource<decltype(enum_map_)>(resource)), resource_(resource),
+        scratch_resource_(scratch_resource != nullptr ? scratch_resource : resource) {}
 
   /**
    * @brief Initialize the pool from a FileDescriptorSet.
    *
    * @return expected<void, descriptor_pool_errc> with validation_error on invalid schema.
    */
-  [[nodiscard]] std::expected<void, descriptor_pool_errc> init(FileDescriptorSet &&fileset)
-    requires(!std::is_trivially_destructible_v<FileDescriptorSet>)
-  {
+  [[nodiscard]] std::expected<void, descriptor_pool_errc> init(FileDescriptorSet &&fileset) {
     fileset_.file = std::move(fileset).file;
-    return init();
-  }
-
-  /**
-   * @brief Initialize the pool from a FileDescriptorSet using a PMR default resource.
-   *
-   * @return expected<void, descriptor_pool_errc> with validation_error on invalid schema.
-   */
-  [[nodiscard]] std::expected<void, descriptor_pool_errc> init(FileDescriptorSet &&fileset,
-                                                               std::pmr::memory_resource &mr) {
-    fileset_.file = std::move(fileset).file;
-    const default_resource_guard guard{mr};
     return init();
   }
 
@@ -546,7 +583,8 @@ private:
     std::size_t oneofs = 0;
     std::size_t enums = 0;
 
-    explicit descriptor_counter(const FileDescriptorSet &fileset) {
+    explicit descriptor_counter(const FileDescriptorSet &fileset, std::pmr::memory_resource *scratch_resource)
+        : scratch_resource_(scratch_resource) {
       for (const auto &f : fileset.file) {
         count_file(f);
       }
@@ -563,7 +601,8 @@ private:
 
     void count_message(const DescriptorProto &root) {
       messages++;
-      std::vector<const DescriptorProto *> pending{&root};
+      std::pmr::vector<const DescriptorProto *> pending{scratch_resource_};
+      pending.push_back(&root);
       while (!pending.empty()) {
         const auto *message_ptr = pending.back();
         pending.pop_back();
@@ -577,6 +616,8 @@ private:
         }
       }
     }
+
+    std::pmr::memory_resource *scratch_resource_;
   };
 
   std::expected<void, descriptor_pool_errc> init() {
@@ -589,7 +630,7 @@ private:
     message_map_.clear();
     enum_map_.clear();
 
-    const descriptor_counter counter(fileset_);
+    const descriptor_counter counter(fileset_, scratch_resource_);
     reserve_storage(counter);
     return build_files_from_fileset()
         .and_then([this] { return link_file_dependencies(); })
@@ -625,7 +666,7 @@ private:
           return std::unexpected(descriptor_pool_errc::validation_error);
         }
         return select_features(proto).and_then([&](const auto &features) -> std::expected<void, descriptor_pool_errc> {
-          return build(files_.emplace_back(proto, std::move(features)));
+          return build(files_.emplace_back(proto, std::move(features), resource_));
         });
       });
       if (!result.has_value()) {
@@ -649,7 +690,7 @@ private:
   }
 
   [[nodiscard]] std::expected<void, descriptor_pool_errc> validate_file_dependency_acyclic() const {
-    std::vector<std::size_t> incoming_edges(files_.size());
+    std::pmr::vector<std::size_t> incoming_edges(files_.size(), scratch_resource_);
     for (std::size_t i = 0; i < files_.size(); ++i) {
       for (const auto *dep : files_[i].dependencies_) {
         const auto dep_index = static_cast<std::size_t>(dep - files_.data());
@@ -657,7 +698,7 @@ private:
       }
     }
 
-    std::vector<std::size_t> pending;
+    std::pmr::vector<std::size_t> pending{scratch_resource_};
     pending.reserve(files_.size());
     for (std::size_t i = 0; i < incoming_edges.size(); ++i) {
       if (incoming_edges[i] == 0) {
@@ -737,12 +778,12 @@ private:
     return {};
   }
 
-  static FeatureSet merge_features(FeatureSet features, const auto &options) {
+  static FeatureSet merge_features(FeatureSet features, const auto &options, std::pmr::memory_resource *resource) {
     if (options.has_value()) {
       const auto &overriding_features = options->features;
       if (overriding_features.has_value()) {
         if constexpr (std::is_trivially_destructible_v<FeatureSet>) {
-          hpp_proto::merge(features, *options->features, hpp_proto::alloc_from(*std::pmr::get_default_resource()));
+          hpp_proto::merge(features, *options->features, hpp_proto::alloc_from(*resource));
         } else {
           hpp_proto::merge(features, *options->features);
         }
@@ -762,21 +803,8 @@ private:
   map_t<std::string_view, message_descriptor_t *> message_map_;
   map_t<std::string_view, enum_descriptor_t *> enum_map_;
   google::protobuf::Edition current_edition_ = {};
-
-  class default_resource_guard {
-  public:
-    explicit default_resource_guard(std::pmr::memory_resource &resource) : prev_(std::pmr::get_default_resource()) {
-      std::pmr::set_default_resource(&resource);
-    }
-    ~default_resource_guard() { std::pmr::set_default_resource(prev_); }
-    default_resource_guard(const default_resource_guard &) = delete;
-    default_resource_guard &operator=(const default_resource_guard &) = delete;
-    default_resource_guard(default_resource_guard &&) = delete;
-    default_resource_guard &operator=(default_resource_guard &&) = delete;
-
-  private:
-    std::pmr::memory_resource *prev_;
-  };
+  std::pmr::memory_resource *resource_;
+  std::pmr::memory_resource *scratch_resource_;
 
   static google::protobuf::FeatureSetDefaults<traits_type> get_cpp_edition_defaults() {
     // from https://github.com/protocolbuffers/protobuf/blob/v33.0/src/google/protobuf/cpp_edition_defaults.h
@@ -858,14 +886,14 @@ private:
         }
 
         auto features = default_features.overridable_features.value_or(FeatureSet{});
-        return merge_features(features, file.options);
+        return merge_features(features, file.options, resource_);
       }
     }
     return std::unexpected(descriptor_pool_errc::validation_error);
   }
 
-  static string_t join_by_dot(std::string_view x, std::string_view y) {
-    string_t result;
+  [[nodiscard]] string_t join_by_dot(std::string_view x, std::string_view y) const {
+    auto result = with_resource<string_t>(resource_);
     result.resize(x.size() + y.size() + 1);
     auto it = std::copy(x.begin(), x.end(), result.begin());
     *it++ = '.';
@@ -895,9 +923,9 @@ private:
         if (proto.name.empty()) {
           return std::unexpected(descriptor_pool_errc::validation_error);
         }
-        auto &message =
-            messages_.emplace_back(proto, !package.empty() ? join_by_dot(package, proto.name) : string_t{proto.name},
-                                   descriptor.options_, &descriptor, static_cast<message_descriptor_t *>(nullptr));
+        auto &message = messages_.emplace_back(
+            proto, !package.empty() ? join_by_dot(package, proto.name) : make_string(proto.name), descriptor.options_,
+            &descriptor, static_cast<message_descriptor_t *>(nullptr), resource_);
         return build(message).transform([&] { descriptor.messages_.push_back(&message); });
       });
       if (!result.has_value()) {
@@ -910,8 +938,9 @@ private:
       if (proto.name.empty()) {
         return std::unexpected(descriptor_pool_errc::validation_error);
       }
-      auto &e = enums_.emplace_back(proto, !package.empty() ? join_by_dot(package, proto.name) : string_t{proto.name},
-                                    descriptor.options_, &descriptor, nullptr);
+      auto &e =
+          enums_.emplace_back(proto, !package.empty() ? join_by_dot(package, proto.name) : make_string(proto.name),
+                              descriptor.options_, &descriptor, nullptr, resource_);
       if (!enum_map_.try_emplace(e.full_name(), &e).second) {
         return std::unexpected(descriptor_pool_errc::validation_error);
       }
@@ -921,14 +950,15 @@ private:
   }
 
   std::expected<void, descriptor_pool_errc> build(message_descriptor_t &root) {
-    std::vector<message_descriptor_t *> pending{&root};
+    std::pmr::vector<message_descriptor_t *> pending{scratch_resource_};
+    pending.push_back(&root);
     while (!pending.empty()) {
       auto &descriptor = *pending.back();
       pending.pop_back();
 
       descriptor.oneofs_.reserve(descriptor.proto_.oneof_decl.size());
       for (auto &proto : descriptor.proto_.oneof_decl) {
-        auto &oneof = oneofs_.emplace_back(proto, descriptor.options_);
+        auto &oneof = oneofs_.emplace_back(proto, descriptor.options_, resource_);
         descriptor.oneofs_.push_back(&oneof);
       }
 
@@ -941,7 +971,7 @@ private:
           return std::unexpected(descriptor_pool_errc::validation_error);
         }
         auto &message = messages_.emplace_back(proto, join_by_dot(descriptor.full_name(), proto.name),
-                                               descriptor.options_, descriptor.parent_file_, &descriptor);
+                                               descriptor.options_, descriptor.parent_file_, &descriptor, resource_);
         descriptor.messages_.push_back(&message);
       }
       for (auto it = descriptor.messages_.rbegin(); it != descriptor.messages_.rend(); ++it) {
@@ -954,7 +984,7 @@ private:
           return std::unexpected(descriptor_pool_errc::validation_error);
         }
         auto &e = enums_.emplace_back(proto, join_by_dot(descriptor.full_name(), proto.name), descriptor.options_,
-                                      descriptor.parent_file_, &descriptor);
+                                      descriptor.parent_file_, &descriptor, resource_);
         if (!enum_map_.try_emplace(e.full_name(), &e).second) {
           return std::unexpected(descriptor_pool_errc::validation_error);
         }
@@ -972,8 +1002,8 @@ private:
 
   // NOLINTNEXTLINE(readability-function-cognitive-complexity)
   std::expected<void, descriptor_pool_errc> build_fields(message_descriptor_t &descriptor) {
-    auto to_default_json_name = [](std::string_view proto_name) {
-      std::string json_name;
+    auto to_default_json_name = [this](std::string_view proto_name) {
+      std::pmr::string json_name{scratch_resource_};
       json_name.reserve(proto_name.size());
       bool upper_next = false;
       for (const char ch : proto_name) {
@@ -991,17 +1021,18 @@ private:
       return json_name;
     };
     auto has_custom_json_name = [&](const FieldDescriptorProto &field) {
-      return !field.json_name.empty() && field.json_name != to_default_json_name(field.name);
+      const auto default_name = to_default_json_name(field.name);
+      return !field.json_name.empty() && std::string_view{field.json_name} != std::string_view{default_name};
     };
 
     descriptor.fields_.reserve(descriptor.proto_.field.size());
-    std::unordered_set<int32_t> seen_field_numbers;
+    std::pmr::unordered_set<int32_t> seen_field_numbers{scratch_resource_};
     seen_field_numbers.reserve(descriptor.proto_.field.size());
-    std::unordered_set<std::string_view> seen_field_names;
+    std::pmr::unordered_set<std::string_view> seen_field_names{scratch_resource_};
     seen_field_names.reserve(descriptor.proto_.field.size());
-    std::unordered_set<std::string_view> seen_json_names;
+    std::pmr::unordered_set<std::string_view> seen_json_names{scratch_resource_};
     seen_json_names.reserve(descriptor.proto_.field.size());
-    std::unordered_set<std::string_view> seen_custom_json_names;
+    std::pmr::unordered_set<std::string_view> seen_custom_json_names{scratch_resource_};
     seen_custom_json_names.reserve(descriptor.proto_.field.size());
     for (auto &proto : descriptor.proto_.field) {
       if (!is_valid_field_number(proto.number)) {
@@ -1026,7 +1057,7 @@ private:
       if (custom_json_name) {
         seen_custom_json_names.insert(proto.json_name);
       }
-      auto &field = fields_.emplace_back(proto, &descriptor, descriptor.options_);
+      auto &field = fields_.emplace_back(proto, &descriptor, descriptor.options_, resource_);
       if (descriptor.is_map_entry()) {
         field.set_explicit_presence();
       }
@@ -1057,7 +1088,7 @@ private:
       if constexpr (std::same_as<decltype(&parent), message_descriptor_t *>) {
         msg_desc = &parent;
       }
-      auto &field = fields_.emplace_back(proto, msg_desc, parent.options_);
+      auto &field = fields_.emplace_back(proto, msg_desc, parent.options_, resource_);
       parent.extensions_.push_back(&field);
     }
     return {};

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -539,9 +539,9 @@ public:
 
 private:
   friend class dynamic_message_factory;
-  static constexpr std::size_t max_schema_nodes = 1'000'000;
-  static constexpr std::size_t max_schema_fields = 250'000;
-  static constexpr std::size_t max_dependency_edges = 250'000;
+  static constexpr std::size_t max_schema_nodes = 131'072;
+  static constexpr std::size_t max_schema_fields = 65'536;
+  static constexpr std::size_t max_dependency_edges = 65'536;
   static constexpr std::size_t max_message_nesting_depth = 100;
 
   struct descriptor_counter {
@@ -580,12 +580,8 @@ private:
     }
 
     bool add_enum_values(const auto &enums) {
-      for (const auto &enumeration : enums) {
-        if (!add_nodes(enumeration.value.size())) {
-          return false;
-        }
-      }
-      return true;
+      return std::ranges::all_of(enums,
+                                 [this](const auto &enumeration) { return add_nodes(enumeration.value.size()); });
     }
 
     bool count_file(const FileDescriptorProto &file) {

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 #include <cassert>
+#include <concepts>
 #include <cstdint>
 #include <expected>
 #include <iostream>
@@ -156,6 +157,10 @@ public:
   using FileDescriptorSet = google::protobuf::FileDescriptorSet<traits_type>;
 
 private:
+  static constexpr bool file_storage_uses_pmr = requires(const decltype(FileDescriptorSet{}.file) &files) {
+    { files.get_allocator().resource() } -> std::same_as<std::pmr::memory_resource *>;
+  };
+
   [[nodiscard]] static FileDescriptorSet make_fileset(std::pmr::memory_resource *resource) {
     using file_container = decltype(FileDescriptorSet{}.file);
     using extension_container = decltype(FileDescriptorSet{}.unknown_fields_.fields);
@@ -626,12 +631,31 @@ public:
    *
    * @return expected<void, descriptor_pool_errc> with validation_error on invalid schema.
    */
-  [[nodiscard]] std::expected<void, descriptor_pool_errc> init(FileDescriptorSet &&fileset) {
+  [[nodiscard]] std::expected<void, descriptor_pool_errc> init(FileDescriptorSet &&fileset)
+    requires(!file_storage_uses_pmr)
+  {
+    return init_fileset(std::move(fileset));
+  }
+
+protected:
+  /**
+   * @brief Initialize a PMR-backed pool from storage prepared with the pool's memory resource.
+   *
+   * This overload is protected so internal builders can ensure the FileDescriptorSet and pool
+   * share the same memory resource.
+   */
+  [[nodiscard]] std::expected<void, descriptor_pool_errc> init(FileDescriptorSet &&fileset)
+    requires file_storage_uses_pmr
+  {
+    return init_fileset(std::move(fileset));
+  }
+
+private:
+  [[nodiscard]] std::expected<void, descriptor_pool_errc> init_fileset(FileDescriptorSet &&fileset) {
     fileset_.file = std::move(fileset).file;
     return init();
   }
 
-private:
   friend class dynamic_message_factory;
   struct descriptor_counter {
     std::size_t files = 0;

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -128,7 +128,7 @@ class descriptor_pool {
       if (source.has_value()) {
         if constexpr (requires { result.features; }) {
           if (source->features.has_value()) {
-            using feature_set = typename decltype(result.features)::value_type;
+            using feature_set = decltype(result.features)::value_type;
             result.features.emplace(make_empty_feature_set<feature_set>(resource));
           }
         }

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -823,32 +823,23 @@ private:
     return {};
   }
 
-  static FeatureSet merge_features(FeatureSet features, const auto &options, std::pmr::memory_resource *resource) {
+  static FeatureSet merge_features(const FeatureSet &source, const auto &options, std::pmr::memory_resource *resource) {
+    auto features = copy_features(source, resource);
     if (options.has_value()) {
       const auto &overriding_features = options->features;
       if (overriding_features.has_value()) {
-        if constexpr (std::is_trivially_destructible_v<FeatureSet>) {
-          hpp_proto::merge(features, *options->features, hpp_proto::alloc_from(*resource));
-        } else {
-          hpp_proto::merge(features, *options->features);
-        }
+        hpp_proto::merge(features, *overriding_features, hpp_proto::alloc_from(*resource));
       }
     }
     return features;
   }
 
   template <typename SourceFeatureSet>
-  static FeatureSet copy_features(const SourceFeatureSet &source,
-                                  [[maybe_unused]] std::pmr::memory_resource *resource) {
-    return {.field_presence = source.field_presence,
-            .enum_type = source.enum_type,
-            .repeated_field_encoding = source.repeated_field_encoding,
-            .utf8_validation = source.utf8_validation,
-            .message_encoding = source.message_encoding,
-            .json_format = source.json_format,
-            .enforce_naming_style = source.enforce_naming_style,
-            .default_symbol_visibility = source.default_symbol_visibility,
-            .unknown_fields_ = {}};
+  static FeatureSet copy_features(const SourceFeatureSet &source, std::pmr::memory_resource *resource) {
+    using extensions = decltype(std::declval<FeatureSet>().unknown_fields_.fields);
+    FeatureSet result{.unknown_fields_ = {.fields = with_resource<extensions>(resource)}};
+    hpp_proto::merge(result, source, hpp_proto::alloc_from(*resource));
+    return result;
   }
 
   FileDescriptorSet fileset_;

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -542,6 +542,7 @@ private:
   static constexpr std::size_t max_schema_nodes = 1'000'000;
   static constexpr std::size_t max_schema_fields = 250'000;
   static constexpr std::size_t max_dependency_edges = 250'000;
+  static constexpr std::size_t max_message_nesting_depth = 100;
 
   struct descriptor_counter {
     std::size_t files = 0;
@@ -578,6 +579,15 @@ private:
       return true;
     }
 
+    bool add_enum_values(const auto &enums) {
+      for (const auto &enumeration : enums) {
+        if (!add_nodes(enumeration.value.size())) {
+          return false;
+        }
+      }
+      return true;
+    }
+
     bool count_file(const FileDescriptorProto &file) {
       if (!add_nodes(1) || file.dependency.size() > max_dependency_edges - dependency_edges) {
         return false;
@@ -589,7 +599,7 @@ private:
           return false;
         }
       }
-      if (!add_nodes(file.enum_type.size()) || !add_fields(file.extension.size())) {
+      if (!add_nodes(file.enum_type.size()) || !add_enum_values(file.enum_type) || !add_fields(file.extension.size())) {
         return false;
       }
       enums += file.enum_type.size();
@@ -601,20 +611,22 @@ private:
         return false;
       }
       messages++;
-      std::vector<const DescriptorProto *> pending{&root};
+      std::vector<std::pair<const DescriptorProto *, std::size_t>> pending{{&root, 1}};
       while (!pending.empty()) {
-        const auto &message = *pending.back();
+        const auto [message_ptr, depth] = pending.back();
         pending.pop_back();
+        const auto &message = *message_ptr;
         if (!add_nodes(message.enum_type.size()) || !add_nodes(message.oneof_decl.size()) ||
             !add_fields(message.field.size()) || !add_fields(message.extension.size()) ||
-            !add_nodes(message.nested_type.size())) {
+            !add_enum_values(message.enum_type) || !add_nodes(message.nested_type.size()) ||
+            (!message.nested_type.empty() && depth >= max_message_nesting_depth)) {
           return false;
         }
         enums += message.enum_type.size();
         oneofs += message.oneof_decl.size();
         messages += message.nested_type.size();
         for (const auto &nested : message.nested_type) {
-          pending.push_back(&nested);
+          pending.emplace_back(&nested, depth + 1);
         }
       }
       return true;
@@ -965,43 +977,46 @@ private:
     return {};
   }
 
-  std::expected<void, descriptor_pool_errc> build(message_descriptor_t &descriptor) {
-    descriptor.oneofs_.reserve(descriptor.proto_.oneof_decl.size());
-    for (auto &proto : descriptor.proto_.oneof_decl) {
-      auto &oneof = oneofs_.emplace_back(proto, descriptor.options_);
-      descriptor.oneofs_.push_back(&oneof);
-    }
+  std::expected<void, descriptor_pool_errc> build(message_descriptor_t &root) {
+    std::vector<message_descriptor_t *> pending{&root};
+    while (!pending.empty()) {
+      auto &descriptor = *pending.back();
+      pending.pop_back();
 
-    if (!message_map_.try_emplace(descriptor.full_name(), &descriptor).second) {
-      return std::unexpected(descriptor_pool_errc::validation_error);
-    }
-    descriptor.messages_.reserve(descriptor.proto_.nested_type.size());
-    std::expected<void, descriptor_pool_errc> result;
-    for (auto &proto : descriptor.proto_.nested_type) {
-      result = result.and_then([&]() -> std::expected<void, descriptor_pool_errc> {
+      descriptor.oneofs_.reserve(descriptor.proto_.oneof_decl.size());
+      for (auto &proto : descriptor.proto_.oneof_decl) {
+        auto &oneof = oneofs_.emplace_back(proto, descriptor.options_);
+        descriptor.oneofs_.push_back(&oneof);
+      }
+
+      if (!message_map_.try_emplace(descriptor.full_name(), &descriptor).second) {
+        return std::unexpected(descriptor_pool_errc::validation_error);
+      }
+      descriptor.messages_.reserve(descriptor.proto_.nested_type.size());
+      for (auto &proto : descriptor.proto_.nested_type) {
         if (proto.name.empty()) {
           return std::unexpected(descriptor_pool_errc::validation_error);
         }
         auto &message = messages_.emplace_back(proto, join_by_dot(descriptor.full_name(), proto.name),
                                                descriptor.options_, descriptor.parent_file_, &descriptor);
-        return build(message).transform([&] { descriptor.messages_.push_back(&message); });
-      });
-      if (!result.has_value()) {
-        return result;
+        descriptor.messages_.push_back(&message);
       }
-    }
+      for (auto it = descriptor.messages_.rbegin(); it != descriptor.messages_.rend(); ++it) {
+        pending.push_back(*it);
+      }
 
-    descriptor.enums_.reserve(descriptor.proto_.enum_type.size());
-    for (auto &proto : descriptor.proto_.enum_type) {
-      if (proto.name.empty()) {
-        return std::unexpected(descriptor_pool_errc::validation_error);
+      descriptor.enums_.reserve(descriptor.proto_.enum_type.size());
+      for (auto &proto : descriptor.proto_.enum_type) {
+        if (proto.name.empty()) {
+          return std::unexpected(descriptor_pool_errc::validation_error);
+        }
+        auto &e = enums_.emplace_back(proto, join_by_dot(descriptor.full_name(), proto.name), descriptor.options_,
+                                      descriptor.parent_file_, &descriptor);
+        if (!enum_map_.try_emplace(e.full_name(), &e).second) {
+          return std::unexpected(descriptor_pool_errc::validation_error);
+        }
+        descriptor.enums_.push_back(&e);
       }
-      auto &e = enums_.emplace_back(proto, join_by_dot(descriptor.full_name(), proto.name), descriptor.options_,
-                                    descriptor.parent_file_, &descriptor);
-      if (!enum_map_.try_emplace(e.full_name(), &e).second) {
-        return std::unexpected(descriptor_pool_errc::validation_error);
-      }
-      descriptor.enums_.push_back(&e);
     }
     return {};
   }

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -81,6 +81,12 @@ class descriptor_pool {
     }
   }
 
+  template <typename FeatureSetT>
+  [[nodiscard]] static FeatureSetT make_empty_feature_set(std::pmr::memory_resource *resource) {
+    using extensions = decltype(std::declval<FeatureSetT>().unknown_fields_.fields);
+    return {.unknown_fields_ = {.fields = with_resource<extensions>(resource)}};
+  }
+
   template <typename Options>
   [[nodiscard]] static Options make_empty_options(std::pmr::memory_resource *resource) {
     using uninterpreted_options = decltype(std::declval<Options>().uninterpreted_option);
@@ -120,6 +126,12 @@ class descriptor_pool {
     } else {
       auto result = make_empty_options<Options>(resource);
       if (source.has_value()) {
+        if constexpr (requires { result.features; }) {
+          if (source->features.has_value()) {
+            using feature_set = typename decltype(result.features)::value_type;
+            result.features.emplace(make_empty_feature_set<feature_set>(resource));
+          }
+        }
         hpp_proto::merge(result, *source, hpp_proto::alloc_from(*resource));
       }
       return result;
@@ -836,8 +848,7 @@ private:
 
   template <typename SourceFeatureSet>
   static FeatureSet copy_features(const SourceFeatureSet &source, std::pmr::memory_resource *resource) {
-    using extensions = decltype(std::declval<FeatureSet>().unknown_fields_.fields);
-    FeatureSet result{.unknown_fields_ = {.fields = with_resource<extensions>(resource)}};
+    auto result = make_empty_feature_set<FeatureSet>(resource);
     hpp_proto::merge(result, source, hpp_proto::alloc_from(*resource));
     return result;
   }

--- a/include/hpp_proto/descriptor_pool.hpp
+++ b/include/hpp_proto/descriptor_pool.hpp
@@ -539,36 +539,85 @@ public:
 
 private:
   friend class dynamic_message_factory;
+  static constexpr std::size_t max_schema_nodes = 1'000'000;
+  static constexpr std::size_t max_schema_fields = 250'000;
+  static constexpr std::size_t max_dependency_edges = 250'000;
+
   struct descriptor_counter {
     std::size_t files = 0;
     std::size_t messages = 0;
     std::size_t fields = 0;
     std::size_t oneofs = 0;
     std::size_t enums = 0;
+    std::size_t dependency_edges = 0;
+    std::size_t schema_nodes = 0;
+    bool valid = true;
 
     explicit descriptor_counter(const FileDescriptorSet &fileset) {
       for (const auto &f : fileset.file) {
-        count_file(f);
+        if (!count_file(f)) {
+          valid = false;
+          return;
+        }
       }
     }
 
-    void count_file(const FileDescriptorProto &file) {
+    bool add_nodes(std::size_t count) {
+      if (count > max_schema_nodes - schema_nodes) {
+        return false;
+      }
+      schema_nodes += count;
+      return true;
+    }
+
+    bool add_fields(std::size_t count) {
+      if (count > max_schema_fields - fields || !add_nodes(count)) {
+        return false;
+      }
+      fields += count;
+      return true;
+    }
+
+    bool count_file(const FileDescriptorProto &file) {
+      if (!add_nodes(1) || file.dependency.size() > max_dependency_edges - dependency_edges) {
+        return false;
+      }
       files++;
+      dependency_edges += file.dependency.size();
       for (const auto &m : file.message_type) {
-        count_message(m);
+        if (!count_message(m)) {
+          return false;
+        }
+      }
+      if (!add_nodes(file.enum_type.size()) || !add_fields(file.extension.size())) {
+        return false;
       }
       enums += file.enum_type.size();
-      fields += file.extension.size();
+      return true;
     }
 
-    void count_message(const DescriptorProto &message) {
-      messages++;
-      for (const auto &m : message.nested_type) {
-        count_message(m);
+    bool count_message(const DescriptorProto &root) {
+      if (!add_nodes(1)) {
+        return false;
       }
-      enums += message.enum_type.size();
-      fields += message.field.size() + message.extension.size();
-      oneofs += message.oneof_decl.size();
+      messages++;
+      std::vector<const DescriptorProto *> pending{&root};
+      while (!pending.empty()) {
+        const auto &message = *pending.back();
+        pending.pop_back();
+        if (!add_nodes(message.enum_type.size()) || !add_nodes(message.oneof_decl.size()) ||
+            !add_fields(message.field.size()) || !add_fields(message.extension.size()) ||
+            !add_nodes(message.nested_type.size())) {
+          return false;
+        }
+        enums += message.enum_type.size();
+        oneofs += message.oneof_decl.size();
+        messages += message.nested_type.size();
+        for (const auto &nested : message.nested_type) {
+          pending.push_back(&nested);
+        }
+      }
+      return true;
     }
   };
 
@@ -583,6 +632,9 @@ private:
     enum_map_.clear();
 
     const descriptor_counter counter(fileset_);
+    if (!counter.valid) {
+      return std::unexpected(descriptor_pool_errc::validation_error);
+    }
     reserve_storage(counter);
     return build_files_from_fileset()
         .and_then([this] { return link_file_dependencies(); })
@@ -642,35 +694,35 @@ private:
   }
 
   [[nodiscard]] std::expected<void, descriptor_pool_errc> validate_file_dependency_acyclic() const {
-    enum class visit_state : uint8_t { unvisited, visiting, visited };
-    std::vector<visit_state> states(files_.size(), visit_state::unvisited);
-
-    auto dfs = [&](auto &&self, std::size_t file_index) -> bool {
-      auto &state = states[file_index];
-      if (state == visit_state::visiting) {
-        return false;
-      }
-      if (state == visit_state::visited) {
-        return true;
-      }
-
-      state = visit_state::visiting;
-      for (const auto *dep : files_[file_index].dependencies_) {
-        const auto dep_index = static_cast<std::size_t>(dep - files_.data());
-        if (!self(self, dep_index)) {
-          return false;
-        }
-      }
-      state = visit_state::visited;
-      return true;
-    };
-
+    std::vector<std::size_t> incoming_edges(files_.size());
     for (std::size_t i = 0; i < files_.size(); ++i) {
-      if (states[i] == visit_state::unvisited && !dfs(dfs, i)) {
-        return std::unexpected(descriptor_pool_errc::validation_error);
+      for (const auto *dep : files_[i].dependencies_) {
+        const auto dep_index = static_cast<std::size_t>(dep - files_.data());
+        incoming_edges[dep_index]++;
       }
     }
-    return {};
+
+    std::vector<std::size_t> pending;
+    pending.reserve(files_.size());
+    for (std::size_t i = 0; i < incoming_edges.size(); ++i) {
+      if (incoming_edges[i] == 0) {
+        pending.push_back(i);
+      }
+    }
+
+    std::size_t visited = 0;
+    for (std::size_t next = 0; next < pending.size(); ++next) {
+      const auto file_index = pending[next];
+      visited++;
+      for (const auto *dep : files_[file_index].dependencies_) {
+        const auto dep_index = static_cast<std::size_t>(dep - files_.data());
+        if (--incoming_edges[dep_index] == 0) {
+          pending.push_back(dep_index);
+        }
+      }
+    }
+    return visited == files_.size() ? std::expected<void, descriptor_pool_errc>{}
+                                    : std::unexpected(descriptor_pool_errc::validation_error);
   }
 
   std::expected<void, descriptor_pool_errc> build_message_fields_and_extensions() {
@@ -983,25 +1035,16 @@ private:
     auto has_custom_json_name = [&](const FieldDescriptorProto &field) {
       return !field.json_name.empty() && field.json_name != to_default_json_name(field.name);
     };
-    auto has_custom_json_conflict = [&](const FieldDescriptorProto &lhs, const FieldDescriptorProto &rhs) {
-      if (has_custom_json_name(lhs)) {
-        if (lhs.json_name == rhs.name || lhs.json_name == rhs.json_name) {
-          return true;
-        }
-      }
-      if (has_custom_json_name(rhs)) {
-        if (rhs.json_name == lhs.name || rhs.json_name == lhs.json_name) {
-          return true;
-        }
-      }
-      return false;
-    };
 
     descriptor.fields_.reserve(descriptor.proto_.field.size());
     std::unordered_set<int32_t> seen_field_numbers;
     seen_field_numbers.reserve(descriptor.proto_.field.size());
     std::unordered_set<std::string_view> seen_field_names;
     seen_field_names.reserve(descriptor.proto_.field.size());
+    std::unordered_set<std::string_view> seen_json_names;
+    seen_json_names.reserve(descriptor.proto_.field.size());
+    std::unordered_set<std::string_view> seen_custom_json_names;
+    seen_custom_json_names.reserve(descriptor.proto_.field.size());
     for (auto &proto : descriptor.proto_.field) {
       if (!is_valid_field_number(proto.number)) {
         return std::unexpected(descriptor_pool_errc::validation_error);
@@ -1009,13 +1052,21 @@ private:
       if (!seen_field_numbers.insert(proto.number).second) {
         return std::unexpected(descriptor_pool_errc::validation_error);
       }
-      if (!seen_field_names.insert(proto.name).second) {
+      if (seen_field_names.contains(proto.name)) {
         return std::unexpected(descriptor_pool_errc::validation_error);
       }
-      if (std::ranges::any_of(descriptor.fields_, [&](const auto *existing) {
-            return has_custom_json_conflict(existing->proto(), proto);
-          })) {
+      const bool custom_json_name = has_custom_json_name(proto);
+      if (seen_custom_json_names.contains(proto.name) || seen_custom_json_names.contains(proto.json_name) ||
+          (custom_json_name &&
+           (seen_field_names.contains(proto.json_name) || seen_json_names.contains(proto.json_name)))) {
         return std::unexpected(descriptor_pool_errc::validation_error);
+      }
+      seen_field_names.insert(proto.name);
+      if (!proto.json_name.empty()) {
+        seen_json_names.insert(proto.json_name);
+      }
+      if (custom_json_name) {
+        seen_custom_json_names.insert(proto.json_name);
       }
       auto &field = fields_.emplace_back(proto, &descriptor, descriptor.options_);
       if (descriptor.is_map_entry()) {

--- a/include/hpp_proto/dynamic_message/factory.hpp
+++ b/include/hpp_proto/dynamic_message/factory.hpp
@@ -30,9 +30,7 @@
 #include <ranges>
 #include <span>
 #include <string_view>
-#include <utility>
 
-#include <google/protobuf/descriptor.pb.hpp>
 #include <hpp_proto/binpb/concepts.hpp>
 #include <hpp_proto/dynamic_message/expected_message_mref.hpp>
 #include <hpp_proto/dynamic_message/export.hpp>
@@ -54,9 +52,6 @@ class dynamic_message_factory_impl;
  * consistent with the `read_binpb()` contract.
  */
 class HPP_PROTO_DYNAMIC_MESSAGE_EXPORT dynamic_message_factory {
-private:
-  using file_descriptor_set_type = ::google::protobuf::FileDescriptorSet<non_owning_traits>;
-
 public:
   using allocator_type = std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl>;
 
@@ -74,9 +69,6 @@ private:
   explicit dynamic_message_factory(impl_ptr impl) noexcept;
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_fileset(file_descriptor_set_type &&fileset, allocator_type allocator);
-
-  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
   create_from_descs(std::span<const file_descriptor_pb> descs, allocator_type allocator);
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
@@ -88,17 +80,6 @@ public:
   dynamic_message_factory &operator=(const dynamic_message_factory &) = delete;
   dynamic_message_factory &operator=(dynamic_message_factory &&) noexcept;
   ~dynamic_message_factory();
-
-  /**
-   * @brief Construct and initialize from FileDescriptorSet.
-   * @details This is a trusted-input API. It does not catch std::bad_alloc thrown by standard containers.
-   * @param allocator Allocator used to create the internal implementation and as the upstream resource for descriptor
-   *                  storage. Its memory resource must outlive the returned factory.
-   */
-  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(file_descriptor_set_type &&fileset, allocator_type allocator = {}) {
-    return create_from_fileset(std::move(fileset), allocator);
-  }
 
   /**
    * @brief Construct and initialize from distinct serialized file descriptors.

--- a/include/hpp_proto/dynamic_message/factory.hpp
+++ b/include/hpp_proto/dynamic_message/factory.hpp
@@ -58,6 +58,8 @@ public:
   using allocator_type = std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl>;
   /// Maximum aggregate bytes accepted by serialized descriptor factory overloads.
   static constexpr std::size_t max_serialized_descriptor_bytes = std::size_t{16} * 1024U * 1024U;
+  /// Maximum memory allocated for decoded descriptors and the resulting descriptor pool.
+  static constexpr std::size_t max_descriptor_memory_bytes = std::size_t{64} * 1024U * 1024U;
 
   /// enable to pass dynamic_message_factory as an option to read_json()/write_json()
   using option_type = std::reference_wrapper<dynamic_message_factory>;
@@ -90,9 +92,10 @@ public:
 
   /**
    * @brief Construct and initialize from FileDescriptorSet.
-   * @details This is a trusted-input API and does not enforce a serialized-size or parser-recursion limit. Prefer a
-   *          serialized overload for untrusted input. This API does not catch std::bad_alloc thrown by standard
-   *          containers.
+   * @details This is a trusted-input API and does not enforce a serialized-size or parser-recursion limit. Descriptor
+   *          storage is limited to max_descriptor_memory_bytes. Exhausting that budget returns
+   *          descriptor_memory_limit_exceeded; unrelated std::bad_alloc exceptions remain uncaught. Prefer a
+   *          serialized overload for untrusted input.
    * @param allocator Allocator used to create the internal impl object. Its memory_resource()
    *                  must outlive the returned factory instance.
    */
@@ -104,7 +107,8 @@ public:
   /**
    * @brief Construct and initialize from distinct serialized file descriptors.
    * @details Returns descriptor_size_limit_exceeded when the aggregate encoded descriptors exceed
-   *          max_serialized_descriptor_bytes. This API does not catch std::bad_alloc thrown by standard containers.
+   *          max_serialized_descriptor_bytes, or descriptor_memory_limit_exceeded when decoded descriptors and pool
+   *          storage exceed max_descriptor_memory_bytes. Unrelated std::bad_alloc exceptions remain uncaught.
    * @param allocator Allocator used to create the internal impl object. Its memory_resource()
    *                  must outlive the returned factory instance.
    */
@@ -117,8 +121,9 @@ public:
   /**
    * @brief Construct and initialize from serialized FileDescriptorSet bytes.
    * @details Returns descriptor_size_limit_exceeded when the input exceeds max_serialized_descriptor_bytes. Binary
-   *          parsing also enforces its default recursion limit. This API does not catch std::bad_alloc thrown by
-   *          standard containers.
+   *          parsing also enforces its default recursion limit. Decoded descriptors and pool storage are limited to
+   *          max_descriptor_memory_bytes; exhausting that budget returns descriptor_memory_limit_exceeded. Unrelated
+   *          std::bad_alloc exceptions remain uncaught.
    * @param allocator Allocator used to create the internal impl object. Its memory_resource()
    *                  must outlive the returned factory instance.
    */

--- a/include/hpp_proto/dynamic_message/factory.hpp
+++ b/include/hpp_proto/dynamic_message/factory.hpp
@@ -44,30 +44,37 @@ namespace detail {
 class dynamic_message_factory_impl;
 } // namespace detail
 
+inline constexpr std::size_t max_descriptor_memory_bytes = std::size_t{64} * 1024U * 1024U;
+
+/**
+ * @brief Per-factory descriptor-memory configuration.
+ *
+ * Raising the limit permits larger schemas but increases the memory available to descriptor construction.
+ * `std::numeric_limits<std::size_t>::max()` can be used as an effectively unlimited value. Serialized input size is
+ * deliberately not limited here: callers must bound untrusted input before invoking the factory. The factory owns
+ * the limited resource and descriptor arena constructed from this configuration, but it does not own `upstream`.
+ */
+struct descriptor_memory_options {
+  /// Maximum live bytes allocated for decoding, descriptor storage, indexing, and validation scratch space.
+  std::size_t limit = max_descriptor_memory_bytes;
+  /// Non-owning upstream resource used for the factory implementation and its owned limited descriptor resource.
+  std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
+};
+
 /**
  * @brief Factory that builds dynamic message instances from descriptor sets.
  *
  * Instances are created via `create(...)` and own an internal implementation
- * object that stores descriptor state and PMR resources.
+ * object that stores descriptor state and PMR resources. Descriptor inputs are
+ * trusted and prevalidated. Callers receiving serialized descriptors from an
+ * untrusted source must bound and validate the input before calling `create()`,
+ * consistent with the `read_binpb()` contract.
  */
 class HPP_PROTO_DYNAMIC_MESSAGE_EXPORT dynamic_message_factory {
 private:
   using file_descriptor_set_type = ::google::protobuf::FileDescriptorSet<non_owning_traits>;
 
 public:
-  using allocator_type = std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl>;
-
-  /**
-   * @brief Default wire-size limit for serialized descriptor inputs: 16 MiB.
-   *
-   * This limit applies before decoding to the complete serialized `FileDescriptorSet`, or to the sum of all encoded
-   * `FileDescriptorProto` values passed through the distinct-descriptor overload. It bounds input retention and the
-   * parser work directly attributable to encoded bytes, but it does not bound decoded memory: very small protobuf
-   * submessages can expand into much larger C++ objects. The in-memory `FileDescriptorSet` overload has no encoded
-   * representation and therefore does not use this limit.
-   */
-  static constexpr std::size_t max_serialized_descriptor_bytes = std::size_t{16} * 1024U * 1024U;
-
   /**
    * @brief Default live-memory limit for factory-owned descriptor state: 64 MiB.
    *
@@ -78,21 +85,7 @@ public:
    * can include allocator or arena growth overhead. It does not include the factory implementation object itself,
    * caller-owned input buffers, or unrelated allocations outside descriptor construction.
    */
-  static constexpr std::size_t max_descriptor_memory_bytes = std::size_t{64} * 1024U * 1024U;
-
-  /**
-   * @brief Per-factory resource limits.
-   *
-   * Raising either limit permits larger schemas but increases the CPU or memory available to untrusted descriptors.
-   * `std::numeric_limits<std::size_t>::max()` can be used as an effectively unlimited value when input is trusted.
-   * Defaults preserve the 16 MiB encoded-input and 64 MiB live-memory limits above.
-   */
-  struct limits {
-    /// Maximum encoded bytes accepted by serialized factory overloads; ignored by the in-memory overload.
-    std::size_t max_serialized_bytes = max_serialized_descriptor_bytes;
-    /// Maximum live bytes allocated for decoding, descriptor storage, indexing, and validation scratch space.
-    std::size_t max_memory_bytes = max_descriptor_memory_bytes;
-  };
+  static constexpr std::size_t max_descriptor_memory_bytes = hpp_proto::max_descriptor_memory_bytes;
 
   /// enable to pass dynamic_message_factory as an option to read_json()/write_json()
   using option_type = std::reference_wrapper<dynamic_message_factory>;
@@ -108,14 +101,13 @@ private:
   explicit dynamic_message_factory(impl_ptr impl) noexcept;
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_fileset(file_descriptor_set_type &&fileset, limits resource_limits, allocator_type allocator);
+  create_from_fileset(file_descriptor_set_type &&fileset, descriptor_memory_options memory_options);
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_descs(std::span<const file_descriptor_pb> descs, limits resource_limits, allocator_type allocator);
+  create_from_descs(std::span<const file_descriptor_pb> descs, descriptor_memory_options memory_options);
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, limits resource_limits,
-                    allocator_type allocator);
+  create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, descriptor_memory_options memory_options);
 
 public:
   dynamic_message_factory(const dynamic_message_factory &) = delete;
@@ -126,67 +118,48 @@ public:
 
   /**
    * @brief Construct and initialize from FileDescriptorSet.
-   * @details This is a trusted-input API and does not enforce a serialized-size or parser-recursion limit. Descriptor
-   *          storage is limited to max_descriptor_memory_bytes. Exhausting that budget returns
-   *          descriptor_memory_limit_exceeded; unrelated std::bad_alloc exceptions remain uncaught. Prefer a
-   *          serialized overload for untrusted input.
-   * @param allocator Allocator used to create the internal impl object. Its memory_resource()
-   *                  must outlive the returned factory instance.
+   * @details This is a trusted-input API. Descriptor storage is limited to max_descriptor_memory_bytes. Exhausting
+   *          that budget returns descriptor_memory_limit_exceeded; unrelated std::bad_alloc exceptions remain
+   *          uncaught.
+   * @param memory_options Descriptor-memory limit and non-null upstream resource. The upstream resource must outlive
+   *                       the returned factory instance.
    */
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(file_descriptor_set_type &&fileset, allocator_type allocator = {}) {
-    return create_from_fileset(std::move(fileset), limits{}, allocator);
-  }
-
-  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(file_descriptor_set_type &&fileset, limits resource_limits, allocator_type allocator = {}) {
-    return create_from_fileset(std::move(fileset), resource_limits, allocator);
+  create(file_descriptor_set_type &&fileset, descriptor_memory_options memory_options = {}) {
+    return create_from_fileset(std::move(fileset), memory_options);
   }
 
   /**
    * @brief Construct and initialize from distinct serialized file descriptors.
-   * @details Returns descriptor_size_limit_exceeded when the aggregate encoded descriptors exceed
-   *          max_serialized_descriptor_bytes, or descriptor_memory_limit_exceeded when decoded descriptors and pool
-   *          storage exceed max_descriptor_memory_bytes. Unrelated std::bad_alloc exceptions remain uncaught.
-   * @param allocator Allocator used to create the internal impl object. Its memory_resource()
-   *                  must outlive the returned factory instance.
+   * @details The encoded descriptors are trusted, prevalidated input and are not size-limited by the factory. Callers
+   *          accepting them from an untrusted source must enforce an aggregate input bound before calling `create()`.
+   *          Decoded descriptors and pool storage are limited to max_descriptor_memory_bytes; exhausting that budget
+   *          returns descriptor_memory_limit_exceeded. Unrelated std::bad_alloc exceptions remain uncaught.
+   * @param memory_options Descriptor-memory limit and non-null upstream resource. The upstream resource must outlive
+   *                       the returned factory instance.
    */
   template <std::size_t N>
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(const distinct_file_descriptor_pb_array<N> &descs, allocator_type allocator = {}) {
-    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), limits{},
-                             allocator);
-  }
-
-  template <std::size_t N>
-  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(const distinct_file_descriptor_pb_array<N> &descs, limits resource_limits, allocator_type allocator = {}) {
-    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), resource_limits,
-                             allocator);
+  create(const distinct_file_descriptor_pb_array<N> &descs, descriptor_memory_options memory_options = {}) {
+    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), memory_options);
   }
 
   /**
    * @brief Construct and initialize from serialized FileDescriptorSet bytes.
-   * @details Returns descriptor_size_limit_exceeded when the input exceeds max_serialized_descriptor_bytes. Binary
-   *          parsing also enforces its default recursion limit. Decoded descriptors and pool storage are limited to
-   *          max_descriptor_memory_bytes; exhausting that budget returns descriptor_memory_limit_exceeded. Unrelated
-   *          std::bad_alloc exceptions remain uncaught.
-   * @param allocator Allocator used to create the internal impl object. Its memory_resource()
-   *                  must outlive the returned factory instance.
+   * @details The byte range is trusted, prevalidated input and is not size-limited by the factory. Callers accepting
+   *          it from an untrusted source must enforce a transport or buffer-size bound before calling `create()`.
+   *          Binary parsing still enforces its default recursion limit. Decoded descriptors and pool storage are
+   *          limited to max_descriptor_memory_bytes; exhausting that budget returns descriptor_memory_limit_exceeded.
+   *          Unrelated std::bad_alloc exceptions remain uncaught.
+   * @param memory_options Descriptor-memory limit and non-null upstream resource. The upstream resource must outlive
+   *                       the returned factory instance.
    */
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb, allocator_type allocator = {}) {
+  create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb,
+         descriptor_memory_options memory_options = {}) {
     return create_from_binpb(std::as_bytes(std::span{std::ranges::data(file_descriptor_set_binpb),
                                                      std::ranges::size(file_descriptor_set_binpb)}),
-                             limits{}, allocator);
-  }
-
-  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb, limits resource_limits,
-         allocator_type allocator = {}) {
-    return create_from_binpb(std::as_bytes(std::span{std::ranges::data(file_descriptor_set_binpb),
-                                                     std::ranges::size(file_descriptor_set_binpb)}),
-                             resource_limits, allocator);
+                             memory_options);
   }
 
   /**

--- a/include/hpp_proto/dynamic_message/factory.hpp
+++ b/include/hpp_proto/dynamic_message/factory.hpp
@@ -44,24 +44,6 @@ namespace detail {
 class dynamic_message_factory_impl;
 } // namespace detail
 
-inline constexpr std::size_t max_descriptor_memory_bytes = std::size_t{64} * 1024U * 1024U;
-
-/**
- * @brief Per-factory descriptor-memory configuration.
- *
- * Raising the limit permits larger schemas but increases the memory available to descriptor construction.
- * `std::numeric_limits<std::size_t>::max()` can be used as an effectively unlimited value. Serialized input size is
- * deliberately not limited here: callers must bound untrusted input before invoking the factory. The factory owns
- * the limited resource and descriptor arena constructed from this configuration, but it does not own `upstream`.
- */
-struct descriptor_memory_options {
-  /// Maximum live bytes allocated for decoding, descriptor storage, indexing, and validation scratch space.
-  std::size_t limit = max_descriptor_memory_bytes;
-  /// Non-owning upstream resource used for the factory implementation and its owned limited descriptor resource.
-  /// Passing nullptr makes dynamic_message_factory::create() return invalid_descriptor_memory_options.
-  std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
-};
-
 /**
  * @brief Factory that builds dynamic message instances from descriptor sets.
  *
@@ -76,17 +58,7 @@ private:
   using file_descriptor_set_type = ::google::protobuf::FileDescriptorSet<non_owning_traits>;
 
 public:
-  /**
-   * @brief Default live-memory limit for factory-owned descriptor state: 64 MiB.
-   *
-   * This limit applies to every factory entry point. It covers allocations made by binary decoding, persistent
-   * descriptor-pool containers and descriptor internals, plus temporary validation structures. Persistent state uses
-   * a monotonic arena, so its allocation remains live until the factory is destroyed; temporary scratch allocations
-   * restore budget when released. The budget counts bytes requested from the caller's upstream memory resource and
-   * can include allocator or arena growth overhead. It does not include the factory implementation object itself,
-   * caller-owned input buffers, or unrelated allocations outside descriptor construction.
-   */
-  static constexpr std::size_t max_descriptor_memory_bytes = hpp_proto::max_descriptor_memory_bytes;
+  using allocator_type = std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl>;
 
   /// enable to pass dynamic_message_factory as an option to read_json()/write_json()
   using option_type = std::reference_wrapper<dynamic_message_factory>;
@@ -102,13 +74,13 @@ private:
   explicit dynamic_message_factory(impl_ptr impl) noexcept;
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_fileset(file_descriptor_set_type &&fileset, descriptor_memory_options memory_options);
+  create_from_fileset(file_descriptor_set_type &&fileset, allocator_type allocator);
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_descs(std::span<const file_descriptor_pb> descs, descriptor_memory_options memory_options);
+  create_from_descs(std::span<const file_descriptor_pb> descs, allocator_type allocator);
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, descriptor_memory_options memory_options);
+  create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, allocator_type allocator);
 
 public:
   dynamic_message_factory(const dynamic_message_factory &) = delete;
@@ -119,48 +91,43 @@ public:
 
   /**
    * @brief Construct and initialize from FileDescriptorSet.
-   * @details This is a trusted-input API. Descriptor storage is limited to max_descriptor_memory_bytes. Exhausting
-   *          that budget returns descriptor_memory_limit_exceeded; unrelated std::bad_alloc exceptions remain
-   *          uncaught.
-   * @param memory_options Descriptor-memory limit and upstream resource. A null upstream returns
-   *                       invalid_descriptor_memory_options; otherwise the resource must outlive the returned factory.
+   * @details This is a trusted-input API. It does not catch std::bad_alloc thrown by standard containers.
+   * @param allocator Allocator used to create the internal implementation and as the upstream resource for descriptor
+   *                  storage. Its memory resource must outlive the returned factory.
    */
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(file_descriptor_set_type &&fileset, descriptor_memory_options memory_options = {}) {
-    return create_from_fileset(std::move(fileset), memory_options);
+  create(file_descriptor_set_type &&fileset, allocator_type allocator = {}) {
+    return create_from_fileset(std::move(fileset), allocator);
   }
 
   /**
    * @brief Construct and initialize from distinct serialized file descriptors.
    * @details The encoded descriptors are trusted, prevalidated input and are not size-limited by the factory. Callers
    *          accepting them from an untrusted source must enforce an aggregate input bound before calling `create()`.
-   *          Decoded descriptors and pool storage are limited to max_descriptor_memory_bytes; exhausting that budget
-   *          returns descriptor_memory_limit_exceeded. Unrelated std::bad_alloc exceptions remain uncaught.
-   * @param memory_options Descriptor-memory limit and upstream resource. A null upstream returns
-   *                       invalid_descriptor_memory_options; otherwise the resource must outlive the returned factory.
+   *          This API does not catch std::bad_alloc thrown by standard containers.
+   * @param allocator Allocator used to create the internal implementation and as the upstream resource for descriptor
+   *                  storage. Its memory resource must outlive the returned factory.
    */
   template <std::size_t N>
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(const distinct_file_descriptor_pb_array<N> &descs, descriptor_memory_options memory_options = {}) {
-    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), memory_options);
+  create(const distinct_file_descriptor_pb_array<N> &descs, allocator_type allocator = {}) {
+    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), allocator);
   }
 
   /**
    * @brief Construct and initialize from serialized FileDescriptorSet bytes.
    * @details The byte range is trusted, prevalidated input and is not size-limited by the factory. Callers accepting
    *          it from an untrusted source must enforce a transport or buffer-size bound before calling `create()`.
-   *          Binary parsing still enforces its default recursion limit. Decoded descriptors and pool storage are
-   *          limited to max_descriptor_memory_bytes; exhausting that budget returns descriptor_memory_limit_exceeded.
-   *          Unrelated std::bad_alloc exceptions remain uncaught.
-   * @param memory_options Descriptor-memory limit and upstream resource. A null upstream returns
-   *                       invalid_descriptor_memory_options; otherwise the resource must outlive the returned factory.
+   *          Binary parsing still enforces its default recursion limit. This API does not catch std::bad_alloc thrown
+   *          by standard containers.
+   * @param allocator Allocator used to create the internal implementation and as the upstream resource for descriptor
+   *                  storage. Its memory resource must outlive the returned factory.
    */
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb,
-         descriptor_memory_options memory_options = {}) {
+  create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb, allocator_type allocator = {}) {
     return create_from_binpb(std::as_bytes(std::span{std::ranges::data(file_descriptor_set_binpb),
                                                      std::ranges::size(file_descriptor_set_binpb)}),
-                             memory_options);
+                             allocator);
   }
 
   /**

--- a/include/hpp_proto/dynamic_message/factory.hpp
+++ b/include/hpp_proto/dynamic_message/factory.hpp
@@ -56,6 +56,8 @@ private:
 
 public:
   using allocator_type = std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl>;
+  /// Maximum aggregate bytes accepted by serialized descriptor factory overloads.
+  static constexpr std::size_t max_serialized_descriptor_bytes = std::size_t{16} * 1024U * 1024U;
 
   /// enable to pass dynamic_message_factory as an option to read_json()/write_json()
   using option_type = std::reference_wrapper<dynamic_message_factory>;
@@ -88,7 +90,9 @@ public:
 
   /**
    * @brief Construct and initialize from FileDescriptorSet.
-   * @details This API does not catch std::bad_alloc thrown by standard containers.
+   * @details This is a trusted-input API and does not enforce a serialized-size or parser-recursion limit. Prefer a
+   *          serialized overload for untrusted input. This API does not catch std::bad_alloc thrown by standard
+   *          containers.
    * @param allocator Allocator used to create the internal impl object. Its memory_resource()
    *                  must outlive the returned factory instance.
    */
@@ -99,7 +103,8 @@ public:
 
   /**
    * @brief Construct and initialize from distinct serialized file descriptors.
-   * @details This API does not catch std::bad_alloc thrown by standard containers.
+   * @details Returns descriptor_size_limit_exceeded when the aggregate encoded descriptors exceed
+   *          max_serialized_descriptor_bytes. This API does not catch std::bad_alloc thrown by standard containers.
    * @param allocator Allocator used to create the internal impl object. Its memory_resource()
    *                  must outlive the returned factory instance.
    */
@@ -111,7 +116,9 @@ public:
 
   /**
    * @brief Construct and initialize from serialized FileDescriptorSet bytes.
-   * @details This API does not catch std::bad_alloc thrown by standard containers.
+   * @details Returns descriptor_size_limit_exceeded when the input exceeds max_serialized_descriptor_bytes. Binary
+   *          parsing also enforces its default recursion limit. This API does not catch std::bad_alloc thrown by
+   *          standard containers.
    * @param allocator Allocator used to create the internal impl object. Its memory_resource()
    *                  must outlive the returned factory instance.
    */

--- a/include/hpp_proto/dynamic_message/factory.hpp
+++ b/include/hpp_proto/dynamic_message/factory.hpp
@@ -58,6 +58,7 @@ struct descriptor_memory_options {
   /// Maximum live bytes allocated for decoding, descriptor storage, indexing, and validation scratch space.
   std::size_t limit = max_descriptor_memory_bytes;
   /// Non-owning upstream resource used for the factory implementation and its owned limited descriptor resource.
+  /// Passing nullptr makes dynamic_message_factory::create() return invalid_descriptor_memory_options.
   std::pmr::memory_resource *upstream = std::pmr::get_default_resource();
 };
 
@@ -121,8 +122,8 @@ public:
    * @details This is a trusted-input API. Descriptor storage is limited to max_descriptor_memory_bytes. Exhausting
    *          that budget returns descriptor_memory_limit_exceeded; unrelated std::bad_alloc exceptions remain
    *          uncaught.
-   * @param memory_options Descriptor-memory limit and non-null upstream resource. The upstream resource must outlive
-   *                       the returned factory instance.
+   * @param memory_options Descriptor-memory limit and upstream resource. A null upstream returns
+   *                       invalid_descriptor_memory_options; otherwise the resource must outlive the returned factory.
    */
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
   create(file_descriptor_set_type &&fileset, descriptor_memory_options memory_options = {}) {
@@ -135,8 +136,8 @@ public:
    *          accepting them from an untrusted source must enforce an aggregate input bound before calling `create()`.
    *          Decoded descriptors and pool storage are limited to max_descriptor_memory_bytes; exhausting that budget
    *          returns descriptor_memory_limit_exceeded. Unrelated std::bad_alloc exceptions remain uncaught.
-   * @param memory_options Descriptor-memory limit and non-null upstream resource. The upstream resource must outlive
-   *                       the returned factory instance.
+   * @param memory_options Descriptor-memory limit and upstream resource. A null upstream returns
+   *                       invalid_descriptor_memory_options; otherwise the resource must outlive the returned factory.
    */
   template <std::size_t N>
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
@@ -151,8 +152,8 @@ public:
    *          Binary parsing still enforces its default recursion limit. Decoded descriptors and pool storage are
    *          limited to max_descriptor_memory_bytes; exhausting that budget returns descriptor_memory_limit_exceeded.
    *          Unrelated std::bad_alloc exceptions remain uncaught.
-   * @param memory_options Descriptor-memory limit and non-null upstream resource. The upstream resource must outlive
-   *                       the returned factory instance.
+   * @param memory_options Descriptor-memory limit and upstream resource. A null upstream returns
+   *                       invalid_descriptor_memory_options; otherwise the resource must outlive the returned factory.
    */
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
   create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb,

--- a/include/hpp_proto/dynamic_message/factory.hpp
+++ b/include/hpp_proto/dynamic_message/factory.hpp
@@ -56,10 +56,43 @@ private:
 
 public:
   using allocator_type = std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl>;
-  /// Maximum aggregate bytes accepted by serialized descriptor factory overloads.
+
+  /**
+   * @brief Default wire-size limit for serialized descriptor inputs: 16 MiB.
+   *
+   * This limit applies before decoding to the complete serialized `FileDescriptorSet`, or to the sum of all encoded
+   * `FileDescriptorProto` values passed through the distinct-descriptor overload. It bounds input retention and the
+   * parser work directly attributable to encoded bytes, but it does not bound decoded memory: very small protobuf
+   * submessages can expand into much larger C++ objects. The in-memory `FileDescriptorSet` overload has no encoded
+   * representation and therefore does not use this limit.
+   */
   static constexpr std::size_t max_serialized_descriptor_bytes = std::size_t{16} * 1024U * 1024U;
-  /// Maximum memory allocated for decoded descriptors and the resulting descriptor pool.
+
+  /**
+   * @brief Default live-memory limit for factory-owned descriptor state: 64 MiB.
+   *
+   * This limit applies to every factory entry point. It covers allocations made by binary decoding, persistent
+   * descriptor-pool containers and descriptor internals, plus temporary validation structures. Persistent state uses
+   * a monotonic arena, so its allocation remains live until the factory is destroyed; temporary scratch allocations
+   * restore budget when released. The budget counts bytes requested from the caller's upstream memory resource and
+   * can include allocator or arena growth overhead. It does not include the factory implementation object itself,
+   * caller-owned input buffers, or unrelated allocations outside descriptor construction.
+   */
   static constexpr std::size_t max_descriptor_memory_bytes = std::size_t{64} * 1024U * 1024U;
+
+  /**
+   * @brief Per-factory resource limits.
+   *
+   * Raising either limit permits larger schemas but increases the CPU or memory available to untrusted descriptors.
+   * `std::numeric_limits<std::size_t>::max()` can be used as an effectively unlimited value when input is trusted.
+   * Defaults preserve the 16 MiB encoded-input and 64 MiB live-memory limits above.
+   */
+  struct limits {
+    /// Maximum encoded bytes accepted by serialized factory overloads; ignored by the in-memory overload.
+    std::size_t max_serialized_bytes = max_serialized_descriptor_bytes;
+    /// Maximum live bytes allocated for decoding, descriptor storage, indexing, and validation scratch space.
+    std::size_t max_memory_bytes = max_descriptor_memory_bytes;
+  };
 
   /// enable to pass dynamic_message_factory as an option to read_json()/write_json()
   using option_type = std::reference_wrapper<dynamic_message_factory>;
@@ -75,13 +108,14 @@ private:
   explicit dynamic_message_factory(impl_ptr impl) noexcept;
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_fileset(file_descriptor_set_type &&fileset, allocator_type allocator);
+  create_from_fileset(file_descriptor_set_type &&fileset, limits resource_limits, allocator_type allocator);
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_descs(std::span<const file_descriptor_pb> descs, allocator_type allocator);
+  create_from_descs(std::span<const file_descriptor_pb> descs, limits resource_limits, allocator_type allocator);
 
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
-  create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, allocator_type allocator);
+  create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, limits resource_limits,
+                    allocator_type allocator);
 
 public:
   dynamic_message_factory(const dynamic_message_factory &) = delete;
@@ -101,7 +135,12 @@ public:
    */
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
   create(file_descriptor_set_type &&fileset, allocator_type allocator = {}) {
-    return create_from_fileset(std::move(fileset), allocator);
+    return create_from_fileset(std::move(fileset), limits{}, allocator);
+  }
+
+  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
+  create(file_descriptor_set_type &&fileset, limits resource_limits, allocator_type allocator = {}) {
+    return create_from_fileset(std::move(fileset), resource_limits, allocator);
   }
 
   /**
@@ -115,7 +154,15 @@ public:
   template <std::size_t N>
   [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
   create(const distinct_file_descriptor_pb_array<N> &descs, allocator_type allocator = {}) {
-    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), allocator);
+    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), limits{},
+                             allocator);
+  }
+
+  template <std::size_t N>
+  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
+  create(const distinct_file_descriptor_pb_array<N> &descs, limits resource_limits, allocator_type allocator = {}) {
+    return create_from_descs(std::span<const file_descriptor_pb>(std::data(descs), std::size(descs)), resource_limits,
+                             allocator);
   }
 
   /**
@@ -131,7 +178,15 @@ public:
   create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb, allocator_type allocator = {}) {
     return create_from_binpb(std::as_bytes(std::span{std::ranges::data(file_descriptor_set_binpb),
                                                      std::ranges::size(file_descriptor_set_binpb)}),
-                             allocator);
+                             limits{}, allocator);
+  }
+
+  [[nodiscard]] static std::expected<dynamic_message_factory, dynamic_message_errc>
+  create(concepts::contiguous_byte_range auto &&file_descriptor_set_binpb, limits resource_limits,
+         allocator_type allocator = {}) {
+    return create_from_binpb(std::as_bytes(std::span{std::ranges::data(file_descriptor_set_binpb),
+                                                     std::ranges::size(file_descriptor_set_binpb)}),
+                             resource_limits, allocator);
   }
 
   /**

--- a/include/hpp_proto/dynamic_message/factory_addons.hpp
+++ b/include/hpp_proto/dynamic_message/factory_addons.hpp
@@ -64,7 +64,8 @@ struct dynamic_message_factory_addons {
 #endif
 
   template <typename T>
-  static T parse_default_value(std::string_view value) {
+  static T parse_default_value(std::string_view value,
+                               std::pmr::memory_resource *resource = std::pmr::get_default_resource()) {
     T parsed{};
     if (value.empty()) {
       return parsed;
@@ -80,7 +81,7 @@ struct dynamic_message_factory_addons {
         ec = result.ec;
         consumed_entire_input = result.ptr == end;
       } else {
-        const std::string buffer(value);
+        const std::pmr::string buffer(value, resource);
         char *conv_end = nullptr;
         errno = 0;
         if constexpr (std::same_as<T, float>) {
@@ -135,36 +136,40 @@ struct dynamic_message_factory_addons {
     /// oneof fields use all bits; non-oneof fields use 0 and rely on active_oneof_index_bias
     /// to map present values to their own field index.
     uint32_t active_oneof_selection_mask = 0;
-    field_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options) { set_default_value(self.proto()); }
+    field_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options,
+                     [[maybe_unused]] std::pmr::memory_resource *resource) {
+      set_default_value(self.proto(), resource);
+    }
 
-    void set_default_value(const google::protobuf::FieldDescriptorProto<traits_type> &proto) {
+    void set_default_value(const google::protobuf::FieldDescriptorProto<traits_type> &proto,
+                           std::pmr::memory_resource *resource) {
       using enum google::protobuf::FieldDescriptorProto_::Type;
       switch (proto.type) {
       case TYPE_ENUM:
         break;
       case TYPE_DOUBLE:
-        default_value = parse_default_value<double>(proto.default_value);
+        default_value = parse_default_value<double>(proto.default_value, resource);
         break;
       case TYPE_FLOAT:
-        default_value = parse_default_value<float>(proto.default_value);
+        default_value = parse_default_value<float>(proto.default_value, resource);
         break;
       case TYPE_INT64:
       case TYPE_SFIXED64:
       case TYPE_SINT64:
-        default_value = parse_default_value<int64_t>(proto.default_value);
+        default_value = parse_default_value<int64_t>(proto.default_value, resource);
         break;
       case TYPE_UINT64:
       case TYPE_FIXED64:
-        default_value = parse_default_value<uint64_t>(proto.default_value);
+        default_value = parse_default_value<uint64_t>(proto.default_value, resource);
         break;
       case TYPE_INT32:
       case TYPE_SFIXED32:
       case TYPE_SINT32:
-        default_value = parse_default_value<int32_t>(proto.default_value);
+        default_value = parse_default_value<int32_t>(proto.default_value, resource);
         break;
       case TYPE_UINT32:
       case TYPE_FIXED32:
-        default_value = parse_default_value<uint32_t>(proto.default_value);
+        default_value = parse_default_value<uint32_t>(proto.default_value, resource);
         break;
       case TYPE_BOOL:
         default_value = proto.default_value == "true";
@@ -179,8 +184,9 @@ struct dynamic_message_factory_addons {
   struct enum_descriptor {
     bool is_null_value = false;
     map_t<std::string_view, const int32_t *> values_by_name;
-    explicit enum_descriptor(Derived &derived, [[maybe_unused]] const auto &inherited_options)
-        : is_null_value(derived.full_name() == "google.protobuf.NullValue") {
+    explicit enum_descriptor(Derived &derived, [[maybe_unused]] const auto &inherited_options,
+                             std::pmr::memory_resource *resource)
+        : is_null_value(derived.full_name() == "google.protobuf.NullValue"), values_by_name(resource) {
       values_by_name.reserve(derived.proto().value.size());
       for (const auto &value : derived.proto().value) {
         values_by_name.try_emplace(value.name, &value.number);
@@ -205,7 +211,8 @@ struct dynamic_message_factory_addons {
 
   template <typename Derived>
   struct oneof_descriptor {
-    explicit oneof_descriptor(Derived & /*derived*/, const auto & /*inherited_options*/) {}
+    explicit oneof_descriptor(Derived & /*derived*/, const auto & /*inherited_options*/,
+                              std::pmr::memory_resource * /*resource*/) {}
     [[nodiscard]] uint32_t storage_slot() const {
       assert(!static_cast<const Derived *>(this)->fields().empty());
       return static_cast<const Derived *>(this)->fields().front().storage_slot;
@@ -216,14 +223,16 @@ struct dynamic_message_factory_addons {
   struct message_descriptor {
     uint32_t num_slots = 0;
     wellknown_types_t wellknown = wellknown_types_t::NONE;
-    explicit message_descriptor(const Derived & /*derived*/, const auto & /*inherited_options*/) {}
+    explicit message_descriptor(const Derived & /*derived*/, const auto & /*inherited_options*/,
+                                std::pmr::memory_resource * /*resource*/) {}
   };
 
   template <typename Derived>
   struct file_descriptor {
     bool wellknown_validated_ = false;
     // NOLINTNEXTLINEß(bugprone-crtp-constructor-accessibility)// NOLINT(bugprone-crtp-constructor-accessibility)
-    explicit file_descriptor([[maybe_unused]] const Derived &derived) {
+    explicit file_descriptor([[maybe_unused]] const Derived &derived,
+                             [[maybe_unused]] std::pmr::memory_resource *resource) {
       // Validate embedded descriptors for supported well-known types against the
       // checked-in canonical descriptor bytes. This guarantees fixed field layout
       // assumptions used by dynamic Any/Struct/Value JSON serializers.
@@ -237,7 +246,7 @@ struct dynamic_message_factory_addons {
           {"google/protobuf/wrappers.proto", _desc_google_protobuf_wrappers_proto}};
 
       if (auto itr = wellknown_type_pbs.find(derived.proto().name); itr != wellknown_type_pbs.end()) {
-        std::vector<std::byte> pb;
+        std::pmr::vector<std::byte> pb{resource};
         hpp_proto::status status;
         if (derived.proto().source_code_info.has_value()) {
           auto proto_no_source_info = derived.proto();

--- a/include/hpp_proto/dynamic_message/factory_addons.hpp
+++ b/include/hpp_proto/dynamic_message/factory_addons.hpp
@@ -178,17 +178,18 @@ struct dynamic_message_factory_addons {
   template <typename Derived>
   struct enum_descriptor {
     bool is_null_value = false;
+    map_t<std::string_view, const int32_t *> values_by_name;
     explicit enum_descriptor(Derived &derived, [[maybe_unused]] const auto &inherited_options)
-        : is_null_value(derived.full_name() == "google.protobuf.NullValue") {}
+        : is_null_value(derived.full_name() == "google.protobuf.NullValue") {
+      values_by_name.reserve(derived.proto().value.size());
+      for (const auto &value : derived.proto().value) {
+        values_by_name.try_emplace(value.name, &value.number);
+      }
+    }
 
     [[nodiscard]] const int32_t *value_of(const std::string_view name) const {
-      const auto &proto = static_cast<const Derived *>(this)->proto();
-      for (const auto &ev : proto.value) {
-        if (ev.name == name) {
-          return &ev.number;
-        }
-      }
-      return nullptr;
+      const auto it = values_by_name.find(name);
+      return it == values_by_name.end() ? nullptr : it->second;
     }
 
     [[nodiscard]] std::string_view name_of(int32_t value) const {

--- a/include/hpp_proto/dynamic_message/types.hpp
+++ b/include/hpp_proto/dynamic_message/types.hpp
@@ -121,7 +121,8 @@ enum class dynamic_message_errc : uint8_t {
   wrong_message_type,
   unknown_message_name,
   descriptor_deserialization_error,
-  schema_validation_error
+  schema_validation_error,
+  descriptor_size_limit_exceeded
 };
 
 namespace concepts {

--- a/include/hpp_proto/dynamic_message/types.hpp
+++ b/include/hpp_proto/dynamic_message/types.hpp
@@ -122,7 +122,8 @@ enum class dynamic_message_errc : uint8_t {
   unknown_message_name,
   descriptor_deserialization_error,
   schema_validation_error,
-  descriptor_memory_limit_exceeded
+  descriptor_memory_limit_exceeded,
+  invalid_descriptor_memory_options
 };
 
 namespace concepts {

--- a/include/hpp_proto/dynamic_message/types.hpp
+++ b/include/hpp_proto/dynamic_message/types.hpp
@@ -122,7 +122,8 @@ enum class dynamic_message_errc : uint8_t {
   unknown_message_name,
   descriptor_deserialization_error,
   schema_validation_error,
-  descriptor_size_limit_exceeded
+  descriptor_size_limit_exceeded,
+  descriptor_memory_limit_exceeded
 };
 
 namespace concepts {

--- a/include/hpp_proto/dynamic_message/types.hpp
+++ b/include/hpp_proto/dynamic_message/types.hpp
@@ -122,7 +122,6 @@ enum class dynamic_message_errc : uint8_t {
   unknown_message_name,
   descriptor_deserialization_error,
   schema_validation_error,
-  descriptor_size_limit_exceeded,
   descriptor_memory_limit_exceeded
 };
 

--- a/include/hpp_proto/dynamic_message/types.hpp
+++ b/include/hpp_proto/dynamic_message/types.hpp
@@ -121,9 +121,7 @@ enum class dynamic_message_errc : uint8_t {
   wrong_message_type,
   unknown_message_name,
   descriptor_deserialization_error,
-  schema_validation_error,
-  descriptor_memory_limit_exceeded,
-  invalid_descriptor_memory_options
+  schema_validation_error
 };
 
 namespace concepts {

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -295,12 +295,16 @@ struct message_merger {
     requires((concepts::pb_unknown_fields<T> && concepts::pb_unknown_fields<U>) ||
              (concepts::pb_extensions<T> && concepts::pb_extensions<U>))
   constexpr void perform(T &dest, const U &source) {
-    if constexpr (!std::same_as<typename T::unknown_fields_range_t, typename U::unknown_fields_range_t> &&
+    if constexpr (concepts::pb_extensions<T> && concepts::pb_extensions<U> &&
                   requires { dest.fields.try_emplace(source.fields.begin()->first); }) {
       bind_empty_container_to_context(dest.fields);
       for (const auto &[number, data] : source.fields) {
         auto entry = dest.fields.try_emplace(number).first;
-        perform(entry->second, data);
+        bind_empty_container_to_context(entry->second);
+        decltype(auto) bytes = detail::as_modifiable(ctx, entry->second);
+        // Each map value stores every wire occurrence for one extension number.
+        // Protobuf merge semantics preserve those occurrences in parent-to-child order.
+        util::append_range(bytes, data);
       }
     } else {
       perform(dest.fields, source.fields);

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -258,6 +258,7 @@ struct message_merger {
     requires requires { typename T::mapped_type; }
   constexpr void insert_or_replace(T &dest, const U &source) {
     T tmp;
+    bind_empty_container_to_context(tmp);
     tmp.swap(dest);
     if constexpr (std::same_as<T, U>) {
       dest = source;
@@ -290,10 +291,20 @@ struct message_merger {
     }
   }
 
-  template <typename T>
-    requires(concepts::pb_unknown_fields<T> || concepts::pb_extensions<T>)
-  constexpr void perform(T &dest, const T &source) {
-    perform(dest.fields, source.fields);
+  template <typename T, typename U>
+    requires((concepts::pb_unknown_fields<T> && concepts::pb_unknown_fields<U>) ||
+             (concepts::pb_extensions<T> && concepts::pb_extensions<U>))
+  constexpr void perform(T &dest, const U &source) {
+    if constexpr (!std::same_as<typename T::unknown_fields_range_t, typename U::unknown_fields_range_t> &&
+                  requires { dest.fields.try_emplace(source.fields.begin()->first); }) {
+      bind_empty_container_to_context(dest.fields);
+      for (const auto &[number, data] : source.fields) {
+        auto entry = dest.fields.try_emplace(number).first;
+        perform(entry->second, data);
+      }
+    } else {
+      perform(dest.fields, source.fields);
+    }
   }
 
   template <typename T, typename U>

--- a/include/hpp_proto/merge.hpp
+++ b/include/hpp_proto/merge.hpp
@@ -25,6 +25,7 @@
 #include <concepts>
 #include <cstddef>
 #include <iterator>
+#include <memory>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -55,6 +56,22 @@ template <concepts::is_pb_context Context>
 struct message_merger {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   Context &ctx;
+
+  template <typename T>
+  constexpr void bind_empty_container_to_context(T &value) {
+    if constexpr (requires {
+                    value.get_allocator().resource();
+                    ctx.memory_resource();
+                    T{&ctx.memory_resource()};
+                    value.empty();
+                  }) {
+      auto *const resource = &ctx.memory_resource();
+      if (value.get_allocator().resource() != resource && value.empty()) {
+        std::destroy_at(&value);
+        std::construct_at(&value, resource);
+      }
+    }
+  }
 
   template <concepts::has_meta T, typename U>
     requires concepts::isomorphic_message<T, std::decay_t<U>>
@@ -153,6 +170,7 @@ struct message_merger {
     requires(std::convertible_to<typename U::value_type, std::remove_const_t<typename T::value_type>> &&
              !std::is_lvalue_reference_v<U>)
   constexpr void perform(T &dest, U &&source) {
+    bind_empty_container_to_context(dest);
     if constexpr (std::ranges::contiguous_range<U>) {
       if (dest.empty()) {
         if constexpr (requires { dest = std::forward<U>(source); }) {
@@ -180,6 +198,15 @@ struct message_merger {
   template <concepts::repeated T, typename U>
     requires std::convertible_to<typename U::value_type, std::remove_const_t<typename T::value_type>>
   constexpr void perform(T &dest, const U &source) {
+    bind_empty_container_to_context(dest);
+    if constexpr (concepts::has_meta<typename T::value_type>) {
+      auto original_size = dest.size();
+      dest.resize(original_size + source.size());
+      for (std::size_t i = 0; i < source.size(); ++i) {
+        perform(dest[original_size + i], source[i]);
+      }
+      return;
+    }
     if constexpr (std::ranges::contiguous_range<U>) {
       if (dest.empty()) {
         if constexpr (requires { dest = source; }) {
@@ -198,6 +225,7 @@ struct message_merger {
   template <concepts::repeated T, typename U>
     requires(!std::convertible_to<typename U::value_type, std::remove_const_t<typename T::value_type>>)
   constexpr void perform(T &dest, auto const &source) {
+    bind_empty_container_to_context(dest);
     decltype(auto) x = detail::as_modifiable(ctx, dest);
     auto orig_size = dest.size();
     x.resize(dest.size() + source.size());
@@ -214,6 +242,7 @@ struct message_merger {
 
   template <concepts::associative_container T, typename U>
   constexpr void perform(T &dest, U &&source) {
+    bind_empty_container_to_context(dest);
     if (!source.empty()) {
       if constexpr (std::same_as<T, std::decay_t<U>>) {
         if (dest.empty()) {
@@ -267,8 +296,18 @@ struct message_merger {
     perform(dest.fields, source.fields);
   }
 
+  template <typename T, typename U>
+    requires requires {
+      typename T::unknown_fields_range_t;
+      typename U::unknown_fields_range_t;
+      requires std::is_empty_v<T>;
+      requires std::is_empty_v<U>;
+    }
+  constexpr void perform(T & /*dest*/, const U & /*source*/) {}
+
   template <concepts::singular T, typename U>
   constexpr void perform(T &dest, U &&source) {
+    bind_empty_container_to_context(dest);
     if constexpr (requires { dest = std::forward<U>(source); }) {
       dest = std::forward<U>(source);
     } else if constexpr (requires { dest.assign_range(source); }) {

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -238,6 +238,13 @@ dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descr
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs, allocator_type allocator) {
+  std::size_t total_size = 0;
+  for (const auto &desc : descs) {
+    if (desc.value.size() > max_serialized_descriptor_bytes - total_size) {
+      return std::unexpected(dynamic_message_errc::descriptor_size_limit_exceeded);
+    }
+    total_size += desc.value.size();
+  }
   impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
   return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{}, alloc_from(impl->memory_resource()))
       .transform_error(detail::to_dynamic_message_errc)
@@ -248,6 +255,9 @@ dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> d
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb,
                                            allocator_type allocator) {
+  if (file_descriptor_set_binpb.size() > max_serialized_descriptor_bytes) {
+    return std::unexpected(dynamic_message_errc::descriptor_size_limit_exceeded);
+  }
   impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
   return impl->initialize(file_descriptor_set_binpb).transform([&] {
     return dynamic_message_factory{std::move(impl)};

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -280,9 +280,9 @@ dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descr
     return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
   }
   std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
-  impl_ptr impl{
-      allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
   try {
+    impl_ptr impl{
+        allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
     return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
   } catch (const detail::descriptor_memory_budget_exhausted &) {
     return std::unexpected(dynamic_message_errc::descriptor_memory_limit_exceeded);
@@ -296,9 +296,9 @@ dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> d
     return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
   }
   std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
-  impl_ptr impl{
-      allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
   try {
+    impl_ptr impl{
+        allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
     return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{},
                                                        alloc_from(impl->memory_resource()))
         .transform_error(detail::to_dynamic_message_errc)
@@ -316,9 +316,9 @@ dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descr
     return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
   }
   std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
-  impl_ptr impl{
-      allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
   try {
+    impl_ptr impl{
+        allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
     return impl->initialize(file_descriptor_set_binpb).transform([&] {
       return dynamic_message_factory{std::move(impl)};
     });

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -29,47 +29,12 @@
 #include <limits>
 #include <memory>
 #include <memory_resource>
-#include <new>
 #include <ranges>
 #include <utility>
 #include <vector>
 
 namespace hpp_proto {
 namespace detail {
-
-class descriptor_memory_budget_exhausted final : public std::bad_alloc {};
-
-class descriptor_memory_resource final : public std::pmr::memory_resource {
-public:
-  descriptor_memory_resource(std::pmr::memory_resource *upstream, std::size_t limit) noexcept
-      : upstream_(upstream), limit_(limit) {}
-
-  [[nodiscard]] std::pmr::memory_resource *upstream_resource() const noexcept { return upstream_; }
-
-private:
-  [[nodiscard]] void *do_allocate(std::size_t bytes, std::size_t alignment) override {
-    if (bytes > limit_ - allocated_) [[unlikely]] {
-      throw descriptor_memory_budget_exhausted{};
-    }
-    void *allocation = upstream_->allocate(bytes, alignment);
-    allocated_ += bytes;
-    return allocation;
-  }
-
-  void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
-    assert(bytes <= allocated_);
-    allocated_ -= bytes;
-    upstream_->deallocate(p, bytes, alignment);
-  }
-
-  [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
-    return this == &other;
-  }
-
-  std::pmr::memory_resource *upstream_;
-  std::size_t limit_;
-  std::size_t allocated_ = 0;
-};
 
 [[nodiscard]] constexpr dynamic_message_errc to_dynamic_message_errc(descriptor_pool_errc ec) noexcept {
   return (ec == descriptor_pool_errc::descriptor_deserialization_error)
@@ -134,9 +99,8 @@ class dynamic_message_factory_impl {
 public:
   using FileDescriptorSet = ::google::protobuf::FileDescriptorSet<dynamic_message_factory_addons::traits_type>;
 
-  dynamic_message_factory_impl(std::pmr::memory_resource *upstream_resource, std::size_t max_memory_bytes)
-      : descriptor_memory_resource_(upstream_resource, max_memory_bytes),
-        memory_resource_(&descriptor_memory_resource_), pool_(&memory_resource_, &descriptor_memory_resource_) {}
+  explicit dynamic_message_factory_impl(std::pmr::memory_resource *upstream_resource)
+      : memory_resource_(upstream_resource), pool_(&memory_resource_, upstream_resource) {}
 
   [[nodiscard]] std::expected<void, dynamic_message_errc> initialize(FileDescriptorSet &&fileset) {
     return pool_.init(std::move(fileset)).transform_error(to_dynamic_message_errc).and_then([this] {
@@ -159,20 +123,17 @@ public:
     }
     return expected_message_mref{std::unexpected(dynamic_message_errc::unknown_message_name)};
   }
-  [[nodiscard]] std::pmr::memory_resource *upstream_resource() const {
-    return descriptor_memory_resource_.upstream_resource();
-  }
+  [[nodiscard]] std::pmr::memory_resource *upstream_resource() const { return memory_resource_.upstream_resource(); }
   [[nodiscard]] std::pmr::monotonic_buffer_resource &memory_resource() { return memory_resource_; }
 
 private:
-  descriptor_memory_resource descriptor_memory_resource_;
   std::pmr::monotonic_buffer_resource memory_resource_;
   descriptor_pool_t pool_;
 
   [[nodiscard]] std::expected<void, dynamic_message_errc> setup_storage_slots() {
     for (auto &message : pool_.messages()) {
       const auto oneof_count = message.proto().oneof_decl.size();
-      storage_slot_state state{oneof_count, &descriptor_memory_resource_};
+      storage_slot_state state{oneof_count, upstream_resource()};
       std::size_t field_index = 0;
       for (auto &f : message.fields()) {
         const auto ec = f.proto().oneof_index.has_value() ? setup_oneof_field(f, state, field_index)
@@ -275,56 +236,27 @@ void dynamic_message_factory::impl_deleter::operator()(detail::dynamic_message_f
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descriptor_set_type &&fileset,
-                                             descriptor_memory_options memory_options) {
-  if (memory_options.upstream == nullptr) [[unlikely]] {
-    return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
-  }
-  std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
-  try {
-    impl_ptr impl{
-        allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
-    return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
-  } catch (const detail::descriptor_memory_budget_exhausted &) {
-    return std::unexpected(dynamic_message_errc::descriptor_memory_limit_exceeded);
-  }
+                                             allocator_type allocator) {
+  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
+  return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
-dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs,
-                                           descriptor_memory_options memory_options) {
-  if (memory_options.upstream == nullptr) [[unlikely]] {
-    return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
-  }
-  std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
-  try {
-    impl_ptr impl{
-        allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
-    return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{},
-                                                       alloc_from(impl->memory_resource()))
-        .transform_error(detail::to_dynamic_message_errc)
-        .and_then([&](auto &&fileset) { return impl->initialize(std::forward<decltype(fileset)>(fileset)); })
-        .transform([&] { return dynamic_message_factory{std::move(impl)}; });
-  } catch (const detail::descriptor_memory_budget_exhausted &) {
-    return std::unexpected(dynamic_message_errc::descriptor_memory_limit_exceeded);
-  }
+dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs, allocator_type allocator) {
+  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
+  return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{}, alloc_from(impl->memory_resource()))
+      .transform_error(detail::to_dynamic_message_errc)
+      .and_then([&](auto &&fileset) { return impl->initialize(std::forward<decltype(fileset)>(fileset)); })
+      .transform([&] { return dynamic_message_factory{std::move(impl)}; });
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb,
-                                           descriptor_memory_options memory_options) {
-  if (memory_options.upstream == nullptr) [[unlikely]] {
-    return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
-  }
-  std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
-  try {
-    impl_ptr impl{
-        allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
-    return impl->initialize(file_descriptor_set_binpb).transform([&] {
-      return dynamic_message_factory{std::move(impl)};
-    });
-  } catch (const detail::descriptor_memory_budget_exhausted &) {
-    return std::unexpected(dynamic_message_errc::descriptor_memory_limit_exceeded);
-  }
+                                           allocator_type allocator) {
+  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
+  return impl->initialize(file_descriptor_set_binpb).transform([&] {
+    return dynamic_message_factory{std::move(impl)};
+  });
 }
 
 expected_message_mref dynamic_message_factory::get_message(std::string_view name,

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -276,6 +276,9 @@ void dynamic_message_factory::impl_deleter::operator()(detail::dynamic_message_f
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descriptor_set_type &&fileset,
                                              descriptor_memory_options memory_options) {
+  if (memory_options.upstream == nullptr) [[unlikely]] {
+    return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
+  }
   std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
   impl_ptr impl{
       allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
@@ -289,6 +292,9 @@ dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descr
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs,
                                            descriptor_memory_options memory_options) {
+  if (memory_options.upstream == nullptr) [[unlikely]] {
+    return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
+  }
   std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
   impl_ptr impl{
       allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
@@ -306,6 +312,9 @@ dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> d
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb,
                                            descriptor_memory_options memory_options) {
+  if (memory_options.upstream == nullptr) [[unlikely]] {
+    return std::unexpected(dynamic_message_errc::invalid_descriptor_memory_options);
+  }
   std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
   impl_ptr impl{
       allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -29,11 +29,44 @@
 #include <limits>
 #include <memory>
 #include <memory_resource>
+#include <new>
 #include <utility>
 #include <vector>
 
 namespace hpp_proto {
 namespace detail {
+
+class descriptor_memory_budget_exhausted final : public std::bad_alloc {};
+
+class descriptor_memory_resource final : public std::pmr::memory_resource {
+public:
+  descriptor_memory_resource(std::pmr::memory_resource *upstream, std::size_t limit) noexcept
+      : upstream_(upstream), limit_(limit) {}
+
+  [[nodiscard]] std::pmr::memory_resource *upstream_resource() const noexcept { return upstream_; }
+
+private:
+  [[nodiscard]] void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+    if (bytes > limit_ - allocated_) [[unlikely]] {
+      throw descriptor_memory_budget_exhausted{};
+    }
+    void *allocation = upstream_->allocate(bytes, alignment);
+    allocated_ += bytes;
+    return allocation;
+  }
+
+  void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
+    upstream_->deallocate(p, bytes, alignment);
+  }
+
+  [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
+    return this == &other;
+  }
+
+  std::pmr::memory_resource *upstream_;
+  std::size_t limit_;
+  std::size_t allocated_ = 0;
+};
 
 [[nodiscard]] constexpr dynamic_message_errc to_dynamic_message_errc(descriptor_pool_errc ec) noexcept {
   return (ec == descriptor_pool_errc::descriptor_deserialization_error)
@@ -98,7 +131,8 @@ public:
   using FileDescriptorSet = ::google::protobuf::FileDescriptorSet<dynamic_message_factory_addons::traits_type>;
 
   explicit dynamic_message_factory_impl(std::pmr::memory_resource *upstream_resource)
-      : memory_resource_(upstream_resource) {}
+      : descriptor_memory_resource_(upstream_resource, dynamic_message_factory::max_descriptor_memory_bytes),
+        memory_resource_(&descriptor_memory_resource_) {}
 
   [[nodiscard]] std::expected<void, dynamic_message_errc> initialize(FileDescriptorSet &&fileset) {
     return pool_.init(std::move(fileset), memory_resource_).transform_error(to_dynamic_message_errc).and_then([this] {
@@ -121,10 +155,13 @@ public:
     }
     return expected_message_mref{std::unexpected(dynamic_message_errc::unknown_message_name)};
   }
-  [[nodiscard]] std::pmr::memory_resource *upstream_resource() const { return memory_resource_.upstream_resource(); }
+  [[nodiscard]] std::pmr::memory_resource *upstream_resource() const {
+    return descriptor_memory_resource_.upstream_resource();
+  }
   [[nodiscard]] std::pmr::monotonic_buffer_resource &memory_resource() { return memory_resource_; }
 
 private:
+  descriptor_memory_resource descriptor_memory_resource_;
   std::pmr::monotonic_buffer_resource memory_resource_;
   descriptor_pool_t pool_;
 
@@ -233,7 +270,11 @@ std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descriptor_set_type &&fileset,
                                              allocator_type allocator) {
   impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
-  return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
+  try {
+    return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
+  } catch (const detail::descriptor_memory_budget_exhausted &) {
+    return std::unexpected(dynamic_message_errc::descriptor_memory_limit_exceeded);
+  }
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
@@ -246,10 +287,15 @@ dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> d
     total_size += desc.value.size();
   }
   impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
-  return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{}, alloc_from(impl->memory_resource()))
-      .transform_error(detail::to_dynamic_message_errc)
-      .and_then([&](auto &&fileset) { return impl->initialize(std::forward<decltype(fileset)>(fileset)); })
-      .transform([&] { return dynamic_message_factory{std::move(impl)}; });
+  try {
+    return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{},
+                                                       alloc_from(impl->memory_resource()))
+        .transform_error(detail::to_dynamic_message_errc)
+        .and_then([&](auto &&fileset) { return impl->initialize(std::forward<decltype(fileset)>(fileset)); })
+        .transform([&] { return dynamic_message_factory{std::move(impl)}; });
+  } catch (const detail::descriptor_memory_budget_exhausted &) {
+    return std::unexpected(dynamic_message_errc::descriptor_memory_limit_exceeded);
+  }
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
@@ -259,9 +305,13 @@ dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descr
     return std::unexpected(dynamic_message_errc::descriptor_size_limit_exceeded);
   }
   impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
-  return impl->initialize(file_descriptor_set_binpb).transform([&] {
-    return dynamic_message_factory{std::move(impl)};
-  });
+  try {
+    return impl->initialize(file_descriptor_set_binpb).transform([&] {
+      return dynamic_message_factory{std::move(impl)};
+    });
+  } catch (const detail::descriptor_memory_budget_exhausted &) {
+    return std::unexpected(dynamic_message_errc::descriptor_memory_limit_exceeded);
+  }
 }
 
 expected_message_mref dynamic_message_factory::get_message(std::string_view name,

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -235,13 +235,6 @@ void dynamic_message_factory::impl_deleter::operator()(detail::dynamic_message_f
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
-dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descriptor_set_type &&fileset,
-                                             allocator_type allocator) {
-  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
-  return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
-}
-
-std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs, allocator_type allocator) {
   impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
   return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{}, alloc_from(impl->memory_resource()))

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -268,16 +268,17 @@ dynamic_message_factory::~dynamic_message_factory() = default;
 
 void dynamic_message_factory::impl_deleter::operator()(detail::dynamic_message_factory_impl *p) noexcept {
   if (p != nullptr) {
-    allocator_type allocator{p->upstream_resource()};
+    std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{p->upstream_resource()};
     allocator.delete_object(p);
   }
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descriptor_set_type &&fileset,
-                                             limits resource_limits, allocator_type allocator) {
-  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource(),
-                                                                           resource_limits.max_memory_bytes)};
+                                             descriptor_memory_options memory_options) {
+  std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
+  impl_ptr impl{
+      allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
   try {
     return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
   } catch (const detail::descriptor_memory_budget_exhausted &) {
@@ -286,17 +287,11 @@ dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descr
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
-dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs, limits resource_limits,
-                                           allocator_type allocator) {
-  std::size_t total_size = 0;
-  for (const auto &desc : descs) {
-    if (desc.value.size() > resource_limits.max_serialized_bytes - total_size) {
-      return std::unexpected(dynamic_message_errc::descriptor_size_limit_exceeded);
-    }
-    total_size += desc.value.size();
-  }
-  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource(),
-                                                                           resource_limits.max_memory_bytes)};
+dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs,
+                                           descriptor_memory_options memory_options) {
+  std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
+  impl_ptr impl{
+      allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
   try {
     return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{},
                                                        alloc_from(impl->memory_resource()))
@@ -309,13 +304,11 @@ dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> d
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
-dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, limits resource_limits,
-                                           allocator_type allocator) {
-  if (file_descriptor_set_binpb.size() > resource_limits.max_serialized_bytes) {
-    return std::unexpected(dynamic_message_errc::descriptor_size_limit_exceeded);
-  }
-  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource(),
-                                                                           resource_limits.max_memory_bytes)};
+dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb,
+                                           descriptor_memory_options memory_options) {
+  std::pmr::polymorphic_allocator<detail::dynamic_message_factory_impl> allocator{memory_options.upstream};
+  impl_ptr impl{
+      allocator.new_object<detail::dynamic_message_factory_impl>(memory_options.upstream, memory_options.limit)};
   try {
     return impl->initialize(file_descriptor_set_binpb).transform([&] {
       return dynamic_message_factory{std::move(impl)};

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -134,8 +134,8 @@ class dynamic_message_factory_impl {
 public:
   using FileDescriptorSet = ::google::protobuf::FileDescriptorSet<dynamic_message_factory_addons::traits_type>;
 
-  explicit dynamic_message_factory_impl(std::pmr::memory_resource *upstream_resource)
-      : descriptor_memory_resource_(upstream_resource, dynamic_message_factory::max_descriptor_memory_bytes),
+  dynamic_message_factory_impl(std::pmr::memory_resource *upstream_resource, std::size_t max_memory_bytes)
+      : descriptor_memory_resource_(upstream_resource, max_memory_bytes),
         memory_resource_(&descriptor_memory_resource_), pool_(&memory_resource_, &descriptor_memory_resource_) {}
 
   [[nodiscard]] std::expected<void, dynamic_message_errc> initialize(FileDescriptorSet &&fileset) {
@@ -275,8 +275,9 @@ void dynamic_message_factory::impl_deleter::operator()(detail::dynamic_message_f
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
 dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descriptor_set_type &&fileset,
-                                             allocator_type allocator) {
-  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
+                                             limits resource_limits, allocator_type allocator) {
+  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource(),
+                                                                           resource_limits.max_memory_bytes)};
   try {
     return impl->initialize(std::move(fileset)).transform([&] { return dynamic_message_factory{std::move(impl)}; });
   } catch (const detail::descriptor_memory_budget_exhausted &) {
@@ -285,15 +286,17 @@ dynamic_message_factory::create_from_fileset(dynamic_message_factory::file_descr
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
-dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs, allocator_type allocator) {
+dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> descs, limits resource_limits,
+                                           allocator_type allocator) {
   std::size_t total_size = 0;
   for (const auto &desc : descs) {
-    if (desc.value.size() > max_serialized_descriptor_bytes - total_size) {
+    if (desc.value.size() > resource_limits.max_serialized_bytes - total_size) {
       return std::unexpected(dynamic_message_errc::descriptor_size_limit_exceeded);
     }
     total_size += desc.value.size();
   }
-  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
+  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource(),
+                                                                           resource_limits.max_memory_bytes)};
   try {
     return descriptor_pool_t::make_file_descriptor_set(descs, distinct_file_tag_t{},
                                                        alloc_from(impl->memory_resource()))
@@ -306,12 +309,13 @@ dynamic_message_factory::create_from_descs(std::span<const file_descriptor_pb> d
 }
 
 std::expected<dynamic_message_factory, dynamic_message_errc>
-dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb,
+dynamic_message_factory::create_from_binpb(std::span<const std::byte> file_descriptor_set_binpb, limits resource_limits,
                                            allocator_type allocator) {
-  if (file_descriptor_set_binpb.size() > max_serialized_descriptor_bytes) {
+  if (file_descriptor_set_binpb.size() > resource_limits.max_serialized_bytes) {
     return std::unexpected(dynamic_message_errc::descriptor_size_limit_exceeded);
   }
-  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource())};
+  impl_ptr impl{allocator.new_object<detail::dynamic_message_factory_impl>(allocator.resource(),
+                                                                           resource_limits.max_memory_bytes)};
   try {
     return impl->initialize(file_descriptor_set_binpb).transform([&] {
       return dynamic_message_factory{std::move(impl)};

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -56,6 +56,8 @@ private:
   }
 
   void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
+    assert(bytes <= allocated_);
+    allocated_ -= bytes;
     upstream_->deallocate(p, bytes, alignment);
   }
 
@@ -77,11 +79,12 @@ private:
 struct storage_slot_state {
   uint32_t cur_slot = 0;
   std::size_t oneof_count = 0;
-  std::vector<bool> oneof_started;
+  std::pmr::vector<bool> oneof_started;
   std::size_t prev_oneof = 0;
   uint16_t oneof_next_ordinal = 1;
 
-  explicit storage_slot_state(std::size_t count) : oneof_count(count), oneof_started(count, false), prev_oneof(count) {}
+  storage_slot_state(std::size_t count, std::pmr::memory_resource *resource)
+      : oneof_count(count), oneof_started(count, false, resource), prev_oneof(count) {}
 };
 
 template <typename FieldT>
@@ -132,10 +135,10 @@ public:
 
   explicit dynamic_message_factory_impl(std::pmr::memory_resource *upstream_resource)
       : descriptor_memory_resource_(upstream_resource, dynamic_message_factory::max_descriptor_memory_bytes),
-        memory_resource_(&descriptor_memory_resource_) {}
+        memory_resource_(&descriptor_memory_resource_), pool_(&memory_resource_, &descriptor_memory_resource_) {}
 
   [[nodiscard]] std::expected<void, dynamic_message_errc> initialize(FileDescriptorSet &&fileset) {
-    return pool_.init(std::move(fileset), memory_resource_).transform_error(to_dynamic_message_errc).and_then([this] {
+    return pool_.init(std::move(fileset)).transform_error(to_dynamic_message_errc).and_then([this] {
       return finish_initialize();
     });
   }
@@ -168,7 +171,7 @@ private:
   [[nodiscard]] std::expected<void, dynamic_message_errc> setup_storage_slots() {
     for (auto &message : pool_.messages()) {
       const auto oneof_count = message.proto().oneof_decl.size();
-      storage_slot_state state{oneof_count};
+      storage_slot_state state{oneof_count, &descriptor_memory_resource_};
       std::size_t field_index = 0;
       for (auto &f : message.fields()) {
         const auto ec = f.proto().oneof_index.has_value() ? setup_oneof_field(f, state, field_index)

--- a/src/protoc-plugin/hpp_gen.cpp
+++ b/src/protoc-plugin/hpp_gen.cpp
@@ -303,7 +303,8 @@ struct hpp_addons {
     bool is_closed_enum = false;
     bool is_foreign = false;
 
-    field_descriptor(const Derived &self, [[maybe_unused]] const auto &inherited_options)
+    field_descriptor(const Derived &self, [[maybe_unused]] const auto &inherited_options,
+                     [[maybe_unused]] std::pmr::memory_resource *resource)
         : cpp_name(resolve_keyword(self.proto().name)) {
       set_cpp_type(self.proto());
       set_default_value(self.proto());
@@ -482,7 +483,8 @@ struct hpp_addons {
     std::string qualified_name;
     bool continuous = true;
 
-    explicit enum_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options)
+    explicit enum_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options,
+                             [[maybe_unused]] std::pmr::memory_resource *resource)
         : cpp_name(resolve_keyword(self.proto().name)) {
       sorted_values.resize(self.proto().value.size());
       std::ranges::transform(self.proto().value, sorted_values.begin(), [](auto &desc) { return desc.number; });
@@ -500,7 +502,8 @@ struct hpp_addons {
   struct oneof_descriptor {
     std::string cpp_name;
 
-    explicit oneof_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options)
+    explicit oneof_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options,
+                              [[maybe_unused]] std::pmr::memory_resource *resource)
         : cpp_name(resolve_keyword(self.proto().name)) {}
   };
 
@@ -516,7 +519,8 @@ struct hpp_addons {
     bool has_recursive_map_field = false;
     bool has_non_map_nested_message = false;
 
-    explicit message_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options)
+    explicit message_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options,
+                                [[maybe_unused]] std::pmr::memory_resource *resource)
         : pb_name(self.proto().name), cpp_name(resolve_keyword(self.proto().name)),
           has_non_map_nested_message(std::ranges::any_of(self.proto().nested_type, [](const DescriptorProto &submsg) {
             return !submsg.options.has_value() || !submsg.options->map_entry;
@@ -532,7 +536,8 @@ struct hpp_addons {
     std::string cpp_name;
     std::string namespace_prefix;
 
-    explicit file_descriptor(Derived &self) // NOLINT(bugprone-crtp-constructor-accessibility)
+    // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+    explicit file_descriptor(Derived &self, [[maybe_unused]] std::pmr::memory_resource *resource)
         : syntax(self.proto().syntax.empty() ? std::string{"proto2"} : self.proto().syntax),
           cpp_name(self.proto().name) {
       ::hpp_proto::hpp_file_opts opts;

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -60,6 +60,22 @@ struct test_feature_extension
                                                    hpp_proto::field_option::none, hpp_proto::vint64_t>>;
 };
 
+struct test_feature_message {
+  std::int32_t parent_value = 0;
+  std::int32_t child_value = 0;
+  using pb_meta = std::tuple<
+      hpp_proto::field_meta<1, &test_feature_message::parent_value, hpp_proto::field_option::none, hpp_proto::vint64_t>,
+      hpp_proto::field_meta<2, &test_feature_message::child_value, hpp_proto::field_option::none, hpp_proto::vint64_t>>;
+};
+
+template <typename Traits = hpp_proto::default_traits>
+struct test_message_feature_extension
+    : hpp_proto::extension_base<test_message_feature_extension<Traits>, google::protobuf::FeatureSet> {
+  static constexpr std::uint32_t field_number = 124;
+  test_feature_message value;
+  using pb_meta = std::tuple<hpp_proto::field_meta<field_number, &test_message_feature_extension::value>>;
+};
+
 class throwing_memory_resource final : public std::pmr::memory_resource {
 private:
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
@@ -1546,6 +1562,25 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     test_feature_extension extension;
     expect(message.descriptor().options().features->get_extension(extension).ok());
     expect(eq(extension.value, std::int32_t{2}));
+  };
+
+  "non_owning_message_feature_extension_merges_parent_and_child_subfields"_test = [&] {
+    constexpr auto field_number = test_message_feature_extension<>::field_number;
+    auto proto = make_two_oneofs_fileset();
+    proto.options.emplace().features.emplace().unknown_fields_.fields.emplace(
+        field_number,
+        std::vector<std::byte>{std::byte{0xe2}, std::byte{0x07}, std::byte{0x02}, std::byte{0x08}, std::byte{0x01}});
+    proto.message_type.front().options.emplace().features.emplace().unknown_fields_.fields.emplace(
+        field_number,
+        std::vector<std::byte>{std::byte{0xe2}, std::byte{0x07}, std::byte{0x02}, std::byte{0x10}, std::byte{0x02}});
+
+    auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(make_descriptor_set_binpb_one(proto)));
+    std::pmr::monotonic_buffer_resource message_resource;
+    auto message = expect_ok(factory.get_message("Root", message_resource));
+    test_message_feature_extension extension;
+    expect(message.descriptor().options().features->get_extension(extension).ok());
+    expect(eq(extension.value.parent_value, std::int32_t{1}));
+    expect(eq(extension.value.child_value, std::int32_t{2}));
   };
 
   "factory_create_succeeds_after_failed_create"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1230,6 +1230,25 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
   };
 
+  "factory_create_rejects_null_descriptor_upstream"_test = [&] {
+    auto proto = make_two_oneofs_fileset();
+    auto descriptor_set = make_descriptor_set_binpb_one(proto);
+    std::string file_descriptor;
+    expect(hpp_proto::write_binpb(proto, file_descriptor).ok());
+    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
+    std::pmr::monotonic_buffer_resource parse_resource;
+    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
+        descriptor_set, hpp_proto::alloc_from(parse_resource)));
+    const auto memory_options = hpp_proto::descriptor_memory_options{.upstream = nullptr};
+    auto expect_invalid_options = [](auto factory) {
+      expect(fatal(!factory.has_value()));
+      expect(eq(factory.error(), hpp_proto::dynamic_message_errc::invalid_descriptor_memory_options));
+    };
+    expect_invalid_options(hpp_proto::dynamic_message_factory::create(descriptor_set, memory_options));
+    expect_invalid_options(hpp_proto::dynamic_message_factory::create(descriptors, memory_options));
+    expect_invalid_options(hpp_proto::dynamic_message_factory::create(std::move(fileset), memory_options));
+  };
+
   "serialized_descriptor_decoded_memory_limit_is_enforced"_test = [] {
     // Each empty FileDescriptorProto needs only two wire bytes but occupies hundreds of decoded bytes.
     constexpr std::size_t empty_file_count = hpp_proto::dynamic_message_factory::max_descriptor_memory_bytes / 400U;

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1093,6 +1093,21 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
   };
 
+  "serialized_descriptor_decoded_memory_limit_is_enforced"_test = [] {
+    // Each empty FileDescriptorProto needs only two wire bytes but occupies hundreds of decoded bytes.
+    constexpr std::size_t empty_file_count = hpp_proto::dynamic_message_factory::max_descriptor_memory_bytes / 400U;
+    std::vector<std::byte> descriptor_set;
+    descriptor_set.reserve(empty_file_count * 2U);
+    for (std::size_t i = 0; i < empty_file_count; ++i) {
+      descriptor_set.push_back(std::byte{0x0a});
+      descriptor_set.push_back(std::byte{0x00});
+    }
+
+    auto factory = hpp_proto::dynamic_message_factory::create(descriptor_set);
+    expect(fatal(!factory.has_value()));
+    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
+  };
+
   "distinct_descriptor_aggregate_size_limit_is_enforced"_test = [] {
     std::string descriptor((hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes / 2) + 1, '\0');
     auto descriptors = hpp_proto::distinct_file_descriptor_pb_array{hpp_proto::file_descriptor_pb{descriptor},

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -26,24 +26,76 @@ struct owning_pmr_factory_addons {
 
   template <typename Derived>
   struct field_descriptor {
-    field_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+    field_descriptor([[maybe_unused]] Derived &derived, [[maybe_unused]] const auto &options,
+                     [[maybe_unused]] std::pmr::memory_resource *resource) {}
   };
   template <typename Derived>
   struct enum_descriptor {
-    enum_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+    enum_descriptor([[maybe_unused]] Derived &derived, [[maybe_unused]] const auto &options,
+                    [[maybe_unused]] std::pmr::memory_resource *resource) {}
   };
   template <typename Derived>
   struct oneof_descriptor {
-    oneof_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+    oneof_descriptor([[maybe_unused]] Derived &derived, [[maybe_unused]] const auto &options,
+                     [[maybe_unused]] std::pmr::memory_resource *resource) {}
   };
   template <typename Derived>
   struct message_descriptor {
-    message_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+    message_descriptor([[maybe_unused]] Derived &derived, [[maybe_unused]] const auto &options,
+                       [[maybe_unused]] std::pmr::memory_resource *resource) {}
   };
   template <typename Derived>
   struct file_descriptor {
-    file_descriptor(Derived &, std::pmr::memory_resource *) {}
+    // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+    file_descriptor([[maybe_unused]] Derived &derived, [[maybe_unused]] std::pmr::memory_resource *resource) {}
   };
+};
+
+class throwing_memory_resource final : public std::pmr::memory_resource {
+private:
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  void *do_allocate([[maybe_unused]] std::size_t bytes, [[maybe_unused]] std::size_t alignment) override {
+    throw std::bad_alloc{};
+  }
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  void do_deallocate([[maybe_unused]] void *pointer, [[maybe_unused]] std::size_t bytes,
+                     [[maybe_unused]] std::size_t alignment) override {}
+  [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
+    return this == &other;
+  }
+};
+
+class tracking_memory_resource final : public std::pmr::memory_resource {
+public:
+  [[nodiscard]] std::size_t allocations() const noexcept { return allocations_; }
+
+private:
+  void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+    ++allocations_;
+    return std::pmr::new_delete_resource()->allocate(bytes, alignment);
+  }
+  void do_deallocate(void *pointer, std::size_t bytes, std::size_t alignment) override {
+    std::pmr::new_delete_resource()->deallocate(pointer, bytes, alignment);
+  }
+  [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
+    return this == &other;
+  }
+
+  std::size_t allocations_ = 0;
+};
+
+class default_resource_scope {
+public:
+  explicit default_resource_scope(std::pmr::memory_resource *resource)
+      : previous_(std::pmr::set_default_resource(resource)) {}
+  ~default_resource_scope() { std::pmr::set_default_resource(previous_); }
+  default_resource_scope(const default_resource_scope &) = delete;
+  default_resource_scope(default_resource_scope &&) = delete;
+  default_resource_scope &operator=(const default_resource_scope &) = delete;
+  default_resource_scope &operator=(default_resource_scope &&) = delete;
+
+private:
+  std::pmr::memory_resource *previous_;
 };
 
 // Dynamic descriptor factory tests use protobuf boundary and validation fixture literals inline.
@@ -1162,12 +1214,27 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   };
 
   "descriptor_pool_construction_uses_decoded_memory_budget"_test = [&] {
-    auto descriptor_set = make_descriptor_set_binpb_one(make_large_field_message_fileset(150'000));
+    auto file = make_large_field_message_fileset(150'000);
+    auto descriptor_set = make_descriptor_set_binpb_one(file);
     expect(lt(descriptor_set.size(), hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes));
 
     auto factory = hpp_proto::dynamic_message_factory::create(descriptor_set);
     expect(fatal(!factory.has_value()));
     expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
+
+    std::string file_descriptor;
+    expect(hpp_proto::write_binpb(file, file_descriptor).ok());
+    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
+    auto distinct_factory = hpp_proto::dynamic_message_factory::create(descriptors);
+    expect(fatal(!distinct_factory.has_value()));
+    expect(eq(distinct_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
+
+    std::pmr::monotonic_buffer_resource parse_resource;
+    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
+        descriptor_set, hpp_proto::alloc_from(parse_resource)));
+    auto fileset_factory = hpp_proto::dynamic_message_factory::create(std::move(fileset));
+    expect(fatal(!fileset_factory.has_value()));
+    expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
   };
 
   "distinct_descriptor_aggregate_size_limit_is_enforced"_test = [] {
@@ -1349,19 +1416,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   };
 
   "factory_creation_does_not_use_global_default_resource"_test = [&] {
-    struct throwing_memory_resource final : std::pmr::memory_resource {
-      void *do_allocate(std::size_t, std::size_t) override { throw std::bad_alloc{}; }
-      void do_deallocate(void *, std::size_t, std::size_t) override {}
-      [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
-        return this == &other;
-      }
-    } throwing_resource;
-    struct default_resource_scope {
-      std::pmr::memory_resource *previous;
-      explicit default_resource_scope(std::pmr::memory_resource *resource)
-          : previous(std::pmr::set_default_resource(resource)) {}
-      ~default_resource_scope() { std::pmr::set_default_resource(previous); }
-    };
+    throwing_memory_resource throwing_resource;
 
     auto descriptor_set = make_descriptor_set_binpb_one(make_two_oneofs_fileset());
     std::pmr::monotonic_buffer_resource parse_resource;
@@ -1380,36 +1435,17 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   };
 
   "owning_pmr_descriptor_pool_does_not_use_global_default_resource"_test = [&] {
-    struct throwing_memory_resource final : std::pmr::memory_resource {
-      void *do_allocate(std::size_t, std::size_t) override { throw std::bad_alloc{}; }
-      void do_deallocate(void *, std::size_t, std::size_t) override {}
-      [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
-        return this == &other;
-      }
-    } throwing_resource;
-    struct default_resource_scope {
-      std::pmr::memory_resource *previous;
-      explicit default_resource_scope(std::pmr::memory_resource *resource)
-          : previous(std::pmr::set_default_resource(resource)) {}
-      ~default_resource_scope() { std::pmr::set_default_resource(previous); }
-    };
-
-    OwningFileDescriptorProto minimal_file;
-    minimal_file.name = "minimal.proto";
-    minimal_file.syntax = "proto3";
-    auto descriptor_set = make_descriptor_set_binpb_one(minimal_file);
+    auto descriptor_set = make_descriptor_set_binpb_one(OwningFileDescriptorProto{});
     std::pmr::monotonic_buffer_resource resource;
     using pool_type = hpp_proto::descriptor_pool<owning_pmr_factory_addons>;
-    auto warmup_fileset = expect_ok(
-        hpp_proto::read_binpb<typename pool_type::FileDescriptorSet>(descriptor_set, hpp_proto::alloc_from(resource)));
-    pool_type warmup_pool{&resource};
-    expect(warmup_pool.init(std::move(warmup_fileset)).has_value());
-    auto fileset = expect_ok(
-        hpp_proto::read_binpb<typename pool_type::FileDescriptorSet>(descriptor_set, hpp_proto::alloc_from(resource)));
+    auto fileset =
+        expect_ok(hpp_proto::read_binpb<pool_type::FileDescriptorSet>(descriptor_set, hpp_proto::alloc_from(resource)));
 
-    default_resource_scope guard{&throwing_resource};
+    tracking_memory_resource tracking_resource;
+    default_resource_scope guard{&tracking_resource};
     pool_type pool{&resource};
-    expect(pool.init(std::move(fileset)).has_value());
+    expect(!pool.init(std::move(fileset)).has_value());
+    expect(eq(tracking_resource.allocations(), std::size_t{0}));
   };
 
   "factory_create_succeeds_after_failed_create"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -496,9 +496,11 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     MessageProto root{.name = "Root"};
     root.field.reserve(field_count);
     for (std::size_t i = 0; i < field_count; ++i) {
+      const auto field_number = i + 1U;
+      const auto valid_field_number = field_number >= 19'000U ? field_number + 1'000U : field_number;
       root.field.push_back(FieldProto{
           .name = "field_" + std::to_string(i),
-          .number = static_cast<int32_t>(i + 1),
+          .number = static_cast<int32_t>(valid_field_number),
           .label = LABEL_OPTIONAL,
           .type = TYPE_INT32,
           .json_name = "customField" + std::to_string(i),
@@ -1559,7 +1561,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(make_descriptor_set_binpb_one(proto)));
     std::pmr::monotonic_buffer_resource message_resource;
     auto message = expect_ok(factory.get_message("Root", message_resource));
-    test_feature_extension extension;
+    test_feature_extension<> extension;
     expect(message.descriptor().options().features->get_extension(extension).ok());
     expect(eq(extension.value, std::int32_t{2}));
   };
@@ -1577,7 +1579,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(make_descriptor_set_binpb_one(proto)));
     std::pmr::monotonic_buffer_resource message_resource;
     auto message = expect_ok(factory.get_message("Root", message_resource));
-    test_message_feature_extension extension;
+    test_message_feature_extension<> extension;
     expect(message.descriptor().options().features->get_extension(extension).ok());
     expect(eq(extension.value.parent_value, std::int32_t{1}));
     expect(eq(extension.value.child_value, std::int32_t{2}));

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1236,85 +1236,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(hpp_proto::dynamic_message_factory::create(descriptor_set).has_value());
   };
 
-  "descriptor_factory_memory_limit_is_configurable"_test = [&] {
-    using factory_type = hpp_proto::dynamic_message_factory;
-    const hpp_proto::descriptor_memory_options defaults;
-    expect(eq(defaults.limit, factory_type::max_descriptor_memory_bytes));
-    expect(defaults.upstream == std::pmr::get_default_resource());
-
-    auto descriptor_set = make_descriptor_set_binpb_one(make_two_oneofs_fileset());
-    auto memory_limit = defaults;
-    memory_limit.limit = 1U;
-    auto memory_factory = factory_type::create(descriptor_set, memory_limit);
-    expect(fatal(!memory_factory.has_value()));
-    expect(eq(memory_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
-
-    std::pmr::monotonic_buffer_resource parse_resource;
-    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
-        descriptor_set, hpp_proto::alloc_from(parse_resource)));
-    auto fileset_factory = factory_type::create(std::move(fileset), memory_limit);
-    expect(fatal(!fileset_factory.has_value()));
-    expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
-  };
-
-  "factory_create_rejects_null_descriptor_upstream"_test = [&] {
-    auto proto = make_two_oneofs_fileset();
-    auto descriptor_set = make_descriptor_set_binpb_one(proto);
-    std::string file_descriptor;
-    expect(hpp_proto::write_binpb(proto, file_descriptor).ok());
-    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
-    std::pmr::monotonic_buffer_resource parse_resource;
-    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
-        descriptor_set, hpp_proto::alloc_from(parse_resource)));
-    const auto memory_options = hpp_proto::descriptor_memory_options{.upstream = nullptr};
-    auto expect_invalid_options = [](auto factory) {
-      expect(fatal(!factory.has_value()));
-      expect(eq(factory.error(), hpp_proto::dynamic_message_errc::invalid_descriptor_memory_options));
-    };
-    expect_invalid_options(hpp_proto::dynamic_message_factory::create(descriptor_set, memory_options));
-    expect_invalid_options(hpp_proto::dynamic_message_factory::create(descriptors, memory_options));
-    expect_invalid_options(hpp_proto::dynamic_message_factory::create(std::move(fileset), memory_options));
-  };
-
-  "serialized_descriptor_decoded_memory_limit_is_enforced"_test = [] {
-    // Each empty FileDescriptorProto needs only two wire bytes but occupies hundreds of decoded bytes.
-    constexpr std::size_t empty_file_count = hpp_proto::dynamic_message_factory::max_descriptor_memory_bytes / 400U;
-    std::vector<std::byte> descriptor_set;
-    descriptor_set.reserve(empty_file_count * 2U);
-    for (std::size_t i = 0; i < empty_file_count; ++i) {
-      descriptor_set.push_back(std::byte{0x0a});
-      descriptor_set.push_back(std::byte{0x00});
-    }
-
-    auto factory = hpp_proto::dynamic_message_factory::create(descriptor_set);
-    expect(fatal(!factory.has_value()));
-    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
-  };
-
-  "descriptor_pool_construction_uses_decoded_memory_budget"_test = [&] {
-    auto file = make_large_field_message_fileset(150'000);
-    auto descriptor_set = make_descriptor_set_binpb_one(file);
-
-    auto factory = hpp_proto::dynamic_message_factory::create(descriptor_set);
-    expect(fatal(!factory.has_value()));
-    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
-
-    std::string file_descriptor;
-    expect(hpp_proto::write_binpb(file, file_descriptor).ok());
-    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
-    auto distinct_factory = hpp_proto::dynamic_message_factory::create(descriptors);
-    expect(fatal(!distinct_factory.has_value()));
-    expect(eq(distinct_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
-
-    std::pmr::monotonic_buffer_resource parse_resource;
-    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
-        descriptor_set, hpp_proto::alloc_from(parse_resource)));
-    const auto pool_memory_limit = hpp_proto::descriptor_memory_options{.limit = std::size_t{1} * 1024U * 1024U};
-    auto fileset_factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), pool_memory_limit);
-    expect(fatal(!fileset_factory.has_value()));
-    expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
-  };
-
   "long_dependency_chain_factory_init_succeeds"_test = [&] {
     OwningFileDescriptorSet file_set;
     file_set.file = make_long_dependency_chain_fileset(8192);
@@ -1496,11 +1417,11 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
 
     std::pmr::unsynchronized_pool_resource upstream;
-    const auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &upstream};
+    const auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&upstream};
     default_resource_scope guard{&throwing_resource};
-    expect(hpp_proto::dynamic_message_factory::create(descriptor_set, memory_options).has_value());
-    expect(hpp_proto::dynamic_message_factory::create(descriptors, memory_options).has_value());
-    expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), memory_options).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(descriptor_set, allocator).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(descriptors, allocator).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator).has_value());
   };
 
   "owning_pmr_descriptor_pool_merges_feature_extensions_without_global_allocations"_test = [&] {
@@ -1721,7 +1642,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     tracking_memory_resource tracking_mr{};
     {
       auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(
-          read_file("unittest.desc.binpb"), hpp_proto::descriptor_memory_options{.upstream = &tracking_mr}));
+          read_file("unittest.desc.binpb"), hpp_proto::dynamic_message_factory::allocator_type{&tracking_mr}));
       expect(gt(tracking_mr.allocations, std::size_t{0}));
       std::pmr::monotonic_buffer_resource msg_mr;
       expect(factory.get_message("proto3_unittest.TestAllTypes", msg_mr).has_value());
@@ -1764,11 +1685,11 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
       return;
     }
     failpoint_memory_resource failpoint_mr{1};
-    const auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
+    const auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
     bool threw_bad_alloc = false;
     try {
       [[maybe_unused]] auto result =
-          hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb"), memory_options);
+          hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb"), allocator);
     } catch (const std::bad_alloc &) {
       threw_bad_alloc = true;
     } catch (...) {
@@ -1790,9 +1711,9 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
 
     auto throws_bad_alloc_for_index = [&](std::size_t fail_index) {
       failpoint_memory_resource failpoint_mr{fail_index};
-      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
+      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
       try {
-        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, memory_options);
+        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, allocator);
         return false;
       } catch (const std::bad_alloc &) {
         return true;
@@ -1831,13 +1752,13 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
 
     auto throws_bad_alloc_for_index = [&](std::size_t fail_index) {
       failpoint_memory_resource failpoint_mr{fail_index};
-      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
+      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
       try {
         std::pmr::monotonic_buffer_resource parse_mr;
         auto fileset =
             expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
                 descriptor_binpb, hpp_proto::alloc_from(parse_mr)));
-        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), memory_options);
+        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator);
         return false;
       } catch (const std::bad_alloc &) {
         return true;
@@ -1878,9 +1799,9 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     failing_indices.reserve(3);
     for (std::size_t index = 1; index <= 256 && failing_indices.size() < 3; ++index) {
       failpoint_memory_resource failpoint_mr{index};
-      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
+      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
       try {
-        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, memory_options);
+        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, allocator);
       } catch (const std::bad_alloc &) {
         failing_indices.push_back(index);
       }
@@ -1889,10 +1810,10 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(eq(failing_indices.size(), std::size_t{3}));
     for (const auto fail_index : failing_indices) {
       failpoint_memory_resource failpoint_mr{fail_index};
-      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
+      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
       bool threw_bad_alloc = false;
       try {
-        [[maybe_unused]] auto result = hpp_proto::dynamic_message_factory::create(descriptor_binpb, memory_options);
+        [[maybe_unused]] auto result = hpp_proto::dynamic_message_factory::create(descriptor_binpb, allocator);
       } catch (const std::bad_alloc &) {
         threw_bad_alloc = true;
       } catch (...) {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1456,24 +1456,25 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), memory_options).has_value());
   };
 
-  "owning_pmr_descriptor_pool_does_not_use_global_default_resource"_test = [&] {
+  "owning_pmr_descriptor_pool_merges_feature_extensions_without_global_allocations"_test = [&] {
     auto make_option = [] {
       return google::protobuf::UninterpretedOption<>{
           .name = {{.name_part = "allocator_sensitive_option_name", .is_extension = false}},
           .identifier_value = "allocator_sensitive_option_value",
       };
     };
-    auto make_extension = [] {
+    auto make_extension = [](std::byte payload) {
       std::vector<std::byte> result = {std::byte{0xda}, std::byte{0x07}, std::byte{0x40}};
-      result.resize(result.size() + 64U, std::byte{0x5a});
+      result.resize(result.size() + 64U, payload);
       return result;
     };
     auto proto = make_two_oneofs_fileset();
     proto.options.emplace().uninterpreted_option.push_back(make_option());
-    proto.options->unknown_fields_.fields.emplace(123U, make_extension());
-    proto.options->features.emplace().unknown_fields_.fields.emplace(123U, make_extension());
+    proto.options->unknown_fields_.fields.emplace(123U, make_extension(std::byte{0x5a}));
+    proto.options->features.emplace().unknown_fields_.fields.emplace(123U, make_extension(std::byte{0x5a}));
     auto &message = proto.message_type.front();
     message.options.emplace().uninterpreted_option.push_back(make_option());
+    message.options->features.emplace().unknown_fields_.fields.emplace(123U, make_extension(std::byte{0x6b}));
     message.field.front().options.emplace().uninterpreted_option.push_back(make_option());
     message.oneof_decl.front().options.emplace().uninterpreted_option.push_back(make_option());
     message.enum_type.push_back(EnumProto{
@@ -1494,6 +1495,13 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     const auto &feature_extensions = pool.files().front().options().features->unknown_fields_.fields;
     expect(eq(feature_extensions.size(), std::size_t{1}));
     expect(feature_extensions.contains(123U));
+    const auto &merged_feature_extensions = pool.messages().front().options().features->unknown_fields_.fields;
+    expect(eq(merged_feature_extensions.size(), std::size_t{1}));
+    expect(merged_feature_extensions.contains(123U));
+    const auto &merged_extension = merged_feature_extensions.at(123U);
+    expect(eq(merged_extension.size(), std::size_t{134}));
+    expect(eq(merged_extension[3], std::byte{0x5a}));
+    expect(eq(merged_extension[70], std::byte{0x6b}));
     expect(eq(tracking_resource.allocations(), std::size_t{0}));
   };
 

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1191,28 +1191,33 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
   };
 
-  "serialized_descriptor_size_limit_is_enforced"_test = [] {
-    std::vector<std::byte> oversized(hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes + 1);
-    auto factory = hpp_proto::dynamic_message_factory::create(oversized);
-    expect(fatal(!factory.has_value()));
-    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
+  "trusted_serialized_descriptors_are_not_size_limited"_test = [&] {
+    constexpr std::size_t previous_serialized_limit = std::size_t{16} * 1024U * 1024U;
+    auto file = OwningFileDescriptorProto{
+        .name = "large_trusted_descriptor.proto",
+        .package = std::string(previous_serialized_limit, 'a'),
+    };
+
+    std::string file_descriptor;
+    expect(hpp_proto::write_binpb(file, file_descriptor).ok());
+    expect(gt(file_descriptor.size(), previous_serialized_limit));
+    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
+    expect(hpp_proto::dynamic_message_factory::create(descriptors).has_value());
+
+    auto descriptor_set = make_descriptor_set_binpb_one(file);
+    expect(gt(descriptor_set.size(), previous_serialized_limit));
+    expect(hpp_proto::dynamic_message_factory::create(descriptor_set).has_value());
   };
 
-  "descriptor_factory_limits_are_configurable"_test = [&] {
+  "descriptor_factory_memory_limit_is_configurable"_test = [&] {
     using factory_type = hpp_proto::dynamic_message_factory;
-    constexpr factory_type::limits defaults;
-    expect(eq(defaults.max_serialized_bytes, factory_type::max_serialized_descriptor_bytes));
-    expect(eq(defaults.max_memory_bytes, factory_type::max_descriptor_memory_bytes));
+    const hpp_proto::descriptor_memory_options defaults;
+    expect(eq(defaults.limit, factory_type::max_descriptor_memory_bytes));
+    expect(defaults.upstream == std::pmr::get_default_resource());
 
     auto descriptor_set = make_descriptor_set_binpb_one(make_two_oneofs_fileset());
-    auto encoded_limit = defaults;
-    encoded_limit.max_serialized_bytes = descriptor_set.size() - 1U;
-    auto encoded_factory = factory_type::create(descriptor_set, encoded_limit);
-    expect(fatal(!encoded_factory.has_value()));
-    expect(eq(encoded_factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
-
     auto memory_limit = defaults;
-    memory_limit.max_memory_bytes = 1U;
+    memory_limit.limit = 1U;
     auto memory_factory = factory_type::create(descriptor_set, memory_limit);
     expect(fatal(!memory_factory.has_value()));
     expect(eq(memory_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
@@ -1220,15 +1225,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     std::pmr::monotonic_buffer_resource parse_resource;
     auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
         descriptor_set, hpp_proto::alloc_from(parse_resource)));
-    std::string file_descriptor;
-    expect(hpp_proto::write_binpb(fileset.file.front(), file_descriptor).ok());
-    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
-    auto distinct_limit = defaults;
-    distinct_limit.max_serialized_bytes = file_descriptor.size() - 1U;
-    auto distinct_factory = factory_type::create(descriptors, distinct_limit);
-    expect(fatal(!distinct_factory.has_value()));
-    expect(eq(distinct_factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
-
     auto fileset_factory = factory_type::create(std::move(fileset), memory_limit);
     expect(fatal(!fileset_factory.has_value()));
     expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
@@ -1252,7 +1248,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   "descriptor_pool_construction_uses_decoded_memory_budget"_test = [&] {
     auto file = make_large_field_message_fileset(150'000);
     auto descriptor_set = make_descriptor_set_binpb_one(file);
-    expect(lt(descriptor_set.size(), hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes));
 
     auto factory = hpp_proto::dynamic_message_factory::create(descriptor_set);
     expect(fatal(!factory.has_value()));
@@ -1271,15 +1266,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     auto fileset_factory = hpp_proto::dynamic_message_factory::create(std::move(fileset));
     expect(fatal(!fileset_factory.has_value()));
     expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
-  };
-
-  "distinct_descriptor_aggregate_size_limit_is_enforced"_test = [] {
-    std::string descriptor((hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes / 2) + 1, '\0');
-    auto descriptors = hpp_proto::distinct_file_descriptor_pb_array{hpp_proto::file_descriptor_pb{descriptor},
-                                                                    hpp_proto::file_descriptor_pb{descriptor}};
-    auto factory = hpp_proto::dynamic_message_factory::create(descriptors);
-    expect(fatal(!factory.has_value()));
-    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
   };
 
   "long_dependency_chain_factory_init_succeeds"_test = [&] {
@@ -1463,11 +1449,11 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
 
     std::pmr::unsynchronized_pool_resource upstream;
-    const auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&upstream};
+    const auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &upstream};
     default_resource_scope guard{&throwing_resource};
-    expect(hpp_proto::dynamic_message_factory::create(descriptor_set, allocator).has_value());
-    expect(hpp_proto::dynamic_message_factory::create(descriptors, allocator).has_value());
-    expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(descriptor_set, memory_options).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(descriptors, memory_options).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), memory_options).has_value());
   };
 
   "owning_pmr_descriptor_pool_does_not_use_global_default_resource"_test = [&] {
@@ -1639,7 +1625,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     tracking_memory_resource tracking_mr{};
     {
       auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(
-          read_file("unittest.desc.binpb"), hpp_proto::dynamic_message_factory::allocator_type{&tracking_mr}));
+          read_file("unittest.desc.binpb"), hpp_proto::descriptor_memory_options{.upstream = &tracking_mr}));
       expect(gt(tracking_mr.allocations, std::size_t{0}));
       std::pmr::monotonic_buffer_resource msg_mr;
       expect(factory.get_message("proto3_unittest.TestAllTypes", msg_mr).has_value());
@@ -1682,11 +1668,11 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
       return;
     }
     failpoint_memory_resource failpoint_mr{1};
-    const auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
+    const auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
     bool threw_bad_alloc = false;
     try {
       [[maybe_unused]] auto result =
-          hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb"), allocator);
+          hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb"), memory_options);
     } catch (const std::bad_alloc &) {
       threw_bad_alloc = true;
     } catch (...) {
@@ -1708,9 +1694,9 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
 
     auto throws_bad_alloc_for_index = [&](std::size_t fail_index) {
       failpoint_memory_resource failpoint_mr{fail_index};
-      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
+      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
       try {
-        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, allocator);
+        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, memory_options);
         return false;
       } catch (const std::bad_alloc &) {
         return true;
@@ -1749,13 +1735,13 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
 
     auto throws_bad_alloc_for_index = [&](std::size_t fail_index) {
       failpoint_memory_resource failpoint_mr{fail_index};
-      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
+      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
       try {
         std::pmr::monotonic_buffer_resource parse_mr;
         auto fileset =
             expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
                 descriptor_binpb, hpp_proto::alloc_from(parse_mr)));
-        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator);
+        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), memory_options);
         return false;
       } catch (const std::bad_alloc &) {
         return true;
@@ -1796,9 +1782,9 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     failing_indices.reserve(3);
     for (std::size_t index = 1; index <= 256 && failing_indices.size() < 3; ++index) {
       failpoint_memory_resource failpoint_mr{index};
-      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
+      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
       try {
-        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, allocator);
+        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(descriptor_binpb, memory_options);
       } catch (const std::bad_alloc &) {
         failing_indices.push_back(index);
       }
@@ -1807,10 +1793,10 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(eq(failing_indices.size(), std::size_t{3}));
     for (const auto fail_index : failing_indices) {
       failpoint_memory_resource failpoint_mr{fail_index};
-      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
+      auto memory_options = hpp_proto::descriptor_memory_options{.upstream = &failpoint_mr};
       bool threw_bad_alloc = false;
       try {
-        [[maybe_unused]] auto result = hpp_proto::dynamic_message_factory::create(descriptor_binpb, allocator);
+        [[maybe_unused]] auto result = hpp_proto::dynamic_message_factory::create(descriptor_binpb, memory_options);
       } catch (const std::bad_alloc &) {
         threw_bad_alloc = true;
       } catch (...) {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1198,6 +1198,42 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
   };
 
+  "descriptor_factory_limits_are_configurable"_test = [&] {
+    using factory_type = hpp_proto::dynamic_message_factory;
+    constexpr factory_type::limits defaults;
+    expect(eq(defaults.max_serialized_bytes, factory_type::max_serialized_descriptor_bytes));
+    expect(eq(defaults.max_memory_bytes, factory_type::max_descriptor_memory_bytes));
+
+    auto descriptor_set = make_descriptor_set_binpb_one(make_two_oneofs_fileset());
+    auto encoded_limit = defaults;
+    encoded_limit.max_serialized_bytes = descriptor_set.size() - 1U;
+    auto encoded_factory = factory_type::create(descriptor_set, encoded_limit);
+    expect(fatal(!encoded_factory.has_value()));
+    expect(eq(encoded_factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
+
+    auto memory_limit = defaults;
+    memory_limit.max_memory_bytes = 1U;
+    auto memory_factory = factory_type::create(descriptor_set, memory_limit);
+    expect(fatal(!memory_factory.has_value()));
+    expect(eq(memory_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
+
+    std::pmr::monotonic_buffer_resource parse_resource;
+    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
+        descriptor_set, hpp_proto::alloc_from(parse_resource)));
+    std::string file_descriptor;
+    expect(hpp_proto::write_binpb(fileset.file.front(), file_descriptor).ok());
+    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
+    auto distinct_limit = defaults;
+    distinct_limit.max_serialized_bytes = file_descriptor.size() - 1U;
+    auto distinct_factory = factory_type::create(descriptors, distinct_limit);
+    expect(fatal(!distinct_factory.has_value()));
+    expect(eq(distinct_factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
+
+    auto fileset_factory = factory_type::create(std::move(fileset), memory_limit);
+    expect(fatal(!fileset_factory.has_value()));
+    expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
+  };
+
   "serialized_descriptor_decoded_memory_limit_is_enforced"_test = [] {
     // Each empty FileDescriptorProto needs only two wire bytes but occupies hundreds of decoded bytes.
     constexpr std::size_t empty_file_count = hpp_proto::dynamic_message_factory::max_descriptor_memory_bytes / 400U;

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -384,6 +384,37 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     return files;
   };
 
+  auto make_large_field_message_fileset = [](std::size_t field_count) {
+    MessageProto root{.name = "Root"};
+    root.field.reserve(field_count);
+    for (std::size_t i = 0; i < field_count; ++i) {
+      root.field.push_back(FieldProto{
+          .name = "field_" + std::to_string(i),
+          .number = static_cast<int32_t>(i + 1),
+          .label = LABEL_OPTIONAL,
+          .type = TYPE_INT32,
+          .json_name = "customField" + std::to_string(i),
+      });
+    }
+    return OwningFileDescriptorProto{
+        .name = "large_field_message.proto",
+        .message_type = {std::move(root)},
+    };
+  };
+
+  auto make_long_dependency_chain_fileset = [](std::size_t file_count) {
+    std::vector<OwningFileDescriptorProto> files;
+    files.reserve(file_count);
+    for (std::size_t i = 0; i < file_count; ++i) {
+      OwningFileDescriptorProto file{.name = "chain_" + std::to_string(i) + ".proto"};
+      if (i != 0) {
+        file.dependency.push_back("chain_" + std::to_string(i - 1) + ".proto");
+      }
+      files.push_back(std::move(file));
+    }
+    return files;
+  };
+
   auto make_deep_name_and_dependency_pressure_fileset = [] {
     std::vector<OwningFileDescriptorProto> files;
     constexpr int dep_count = 96;
@@ -1012,6 +1043,19 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     auto files = make_large_descriptor_collection_fileset(256);
     OwningFileDescriptorSet file_set;
     file_set.file = std::move(files);
+    std::string desc_binpb;
+    expect(hpp_proto::write_binpb(file_set, desc_binpb).ok());
+    expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
+  };
+
+  "large_field_message_factory_init_succeeds"_test = [&] {
+    auto desc_binpb = make_descriptor_set_binpb_one(make_large_field_message_fileset(4096));
+    expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
+  };
+
+  "long_dependency_chain_factory_init_succeeds"_test = [&] {
+    OwningFileDescriptorSet file_set;
+    file_set.file = make_long_dependency_chain_fileset(8192);
     std::string desc_binpb;
     expect(hpp_proto::write_binpb(file_set, desc_binpb).ok());
     expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -62,12 +62,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   using OneofProto = google::protobuf::OneofDescriptorProto<>;
   using EnumProto = google::protobuf::EnumDescriptorProto<>;
   using EnumValueProto = google::protobuf::EnumValueDescriptorProto<>;
-  using BorrowedFileDescriptorProto = google::protobuf::FileDescriptorProto<hpp_proto::non_owning_traits>;
-  using BorrowedFileDescriptorSet = google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>;
-  using BorrowedMessageProto = google::protobuf::DescriptorProto<hpp_proto::non_owning_traits>;
-  using BorrowedFieldProto = google::protobuf::FieldDescriptorProto<hpp_proto::non_owning_traits>;
-  using BorrowedEnumProto = google::protobuf::EnumDescriptorProto<hpp_proto::non_owning_traits>;
-  using BorrowedEnumValueProto = google::protobuf::EnumValueDescriptorProto<hpp_proto::non_owning_traits>;
   using enum google::protobuf::FieldDescriptorProto_::Label;
   using enum google::protobuf::FieldDescriptorProto_::Type;
 
@@ -1092,63 +1086,20 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
   };
 
-  "in_memory_message_nesting_depth_is_bounded"_test = [] {
-    auto create_at_depth = [](std::size_t depth) {
-      std::vector<BorrowedMessageProto> messages(depth);
-      for (auto &message : messages) {
-        message.name = "Nested";
-      }
-      for (std::size_t i = 0; i + 1 < messages.size(); ++i) {
-        messages[i].nested_type = std::span{&messages[i + 1], 1};
-      }
-      BorrowedFileDescriptorProto file{
-          .name = "nested.proto",
-          .message_type = std::span{messages.data(), 1},
-      };
-      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
-      return hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value();
-    };
-
-    expect(create_at_depth(100));
-    expect(!create_at_depth(101));
+  "serialized_descriptor_size_limit_is_enforced"_test = [] {
+    std::vector<std::byte> oversized(hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes + 1);
+    auto factory = hpp_proto::dynamic_message_factory::create(oversized);
+    expect(fatal(!factory.has_value()));
+    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
   };
 
-  "in_memory_schema_resource_budgets_are_enforced"_test = [] {
-    {
-      std::vector<std::string_view> dependencies(65'537, "dependency.proto");
-      BorrowedFileDescriptorProto file{
-          .name = "dependency_budget.proto",
-          .dependency = dependencies,
-      };
-      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
-      expect(!hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value());
-    }
-    {
-      std::vector<BorrowedFieldProto> fields(65'537);
-      BorrowedMessageProto message{
-          .name = "Root",
-          .field = fields,
-      };
-      BorrowedFileDescriptorProto file{
-          .name = "field_budget.proto",
-          .message_type = std::span{&message, 1},
-      };
-      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
-      expect(!hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value());
-    }
-    {
-      std::vector<BorrowedEnumValueProto> values(131'073);
-      BorrowedEnumProto enumeration{
-          .name = "LargeEnum",
-          .value = values,
-      };
-      BorrowedFileDescriptorProto file{
-          .name = "enum_value_budget.proto",
-          .enum_type = std::span{&enumeration, 1},
-      };
-      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
-      expect(!hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value());
-    }
+  "distinct_descriptor_aggregate_size_limit_is_enforced"_test = [] {
+    std::string descriptor((hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes / 2) + 1, '\0');
+    auto descriptors = hpp_proto::distinct_file_descriptor_pb_array{hpp_proto::file_descriptor_pb{descriptor},
+                                                                    hpp_proto::file_descriptor_pb{descriptor}};
+    auto factory = hpp_proto::dynamic_message_factory::create(descriptors);
+    expect(fatal(!factory.has_value()));
+    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_size_limit_exceeded));
   };
 
   "long_dependency_chain_factory_init_succeeds"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -402,6 +402,34 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     };
   };
 
+  auto make_large_enum_default_fileset = [](std::size_t value_count, std::size_t field_count) {
+    EnumProto enumeration{.name = "LargeEnum"};
+    enumeration.value.reserve(value_count);
+    for (std::size_t i = 0; i < value_count; ++i) {
+      enumeration.value.push_back(EnumValueProto{
+          .name = "VALUE_" + std::to_string(i),
+          .number = static_cast<int32_t>(i),
+      });
+    }
+
+    MessageProto root{.name = "Root", .enum_type = {std::move(enumeration)}};
+    root.field.reserve(field_count);
+    for (std::size_t i = 0; i < field_count; ++i) {
+      root.field.push_back(FieldProto{
+          .name = "field_" + std::to_string(i),
+          .number = static_cast<int32_t>(i + 1),
+          .label = LABEL_OPTIONAL,
+          .type = TYPE_ENUM,
+          .type_name = ".Root.LargeEnum",
+          .default_value = "VALUE_" + std::to_string(value_count - 1),
+      });
+    }
+    return OwningFileDescriptorProto{
+        .name = "large_enum_default.proto",
+        .message_type = {std::move(root)},
+    };
+  };
+
   auto make_long_dependency_chain_fileset = [](std::size_t file_count) {
     std::vector<OwningFileDescriptorProto> files;
     files.reserve(file_count);
@@ -1051,6 +1079,36 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   "large_field_message_factory_init_succeeds"_test = [&] {
     auto desc_binpb = make_descriptor_set_binpb_one(make_large_field_message_fileset(4096));
     expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
+  };
+
+  "large_enum_defaults_factory_init_succeeds"_test = [&] {
+    auto desc_binpb = make_descriptor_set_binpb_one(make_large_enum_default_fileset(4096, 4096));
+    expect(hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
+  };
+
+  "in_memory_message_nesting_depth_is_bounded"_test = [] {
+    using BorrowedMessageProto = google::protobuf::DescriptorProto<hpp_proto::non_owning_traits>;
+    using BorrowedFileProto = google::protobuf::FileDescriptorProto<hpp_proto::non_owning_traits>;
+    using BorrowedFileSet = google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>;
+
+    auto create_at_depth = [](std::size_t depth) {
+      std::vector<BorrowedMessageProto> messages(depth);
+      for (auto &message : messages) {
+        message.name = "Nested";
+      }
+      for (std::size_t i = 0; i + 1 < messages.size(); ++i) {
+        messages[i].nested_type = std::span{&messages[i + 1], 1};
+      }
+      BorrowedFileProto file{
+          .name = "nested.proto",
+          .message_type = std::span{messages.data(), 1},
+      };
+      BorrowedFileSet file_set{.file = std::span{&file, 1}};
+      return hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value();
+    };
+
+    expect(create_at_depth(100));
+    expect(!create_at_depth(101));
   };
 
   "long_dependency_chain_factory_init_succeeds"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1309,7 +1309,9 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     std::pmr::monotonic_buffer_resource parse_resource;
     auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
         descriptor_set, hpp_proto::alloc_from(parse_resource)));
-    auto fileset_factory = hpp_proto::dynamic_message_factory::create(std::move(fileset));
+    const auto pool_memory_limit =
+        hpp_proto::descriptor_memory_options{.limit = std::size_t{1} * 1024U * 1024U};
+    auto fileset_factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), pool_memory_limit);
     expect(fatal(!fileset_factory.has_value()));
     expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
   };

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -62,6 +62,12 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   using OneofProto = google::protobuf::OneofDescriptorProto<>;
   using EnumProto = google::protobuf::EnumDescriptorProto<>;
   using EnumValueProto = google::protobuf::EnumValueDescriptorProto<>;
+  using BorrowedFileDescriptorProto = google::protobuf::FileDescriptorProto<hpp_proto::non_owning_traits>;
+  using BorrowedFileDescriptorSet = google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>;
+  using BorrowedMessageProto = google::protobuf::DescriptorProto<hpp_proto::non_owning_traits>;
+  using BorrowedFieldProto = google::protobuf::FieldDescriptorProto<hpp_proto::non_owning_traits>;
+  using BorrowedEnumProto = google::protobuf::EnumDescriptorProto<hpp_proto::non_owning_traits>;
+  using BorrowedEnumValueProto = google::protobuf::EnumValueDescriptorProto<hpp_proto::non_owning_traits>;
   using enum google::protobuf::FieldDescriptorProto_::Label;
   using enum google::protobuf::FieldDescriptorProto_::Type;
 
@@ -1087,10 +1093,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   };
 
   "in_memory_message_nesting_depth_is_bounded"_test = [] {
-    using BorrowedMessageProto = google::protobuf::DescriptorProto<hpp_proto::non_owning_traits>;
-    using BorrowedFileProto = google::protobuf::FileDescriptorProto<hpp_proto::non_owning_traits>;
-    using BorrowedFileSet = google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>;
-
     auto create_at_depth = [](std::size_t depth) {
       std::vector<BorrowedMessageProto> messages(depth);
       for (auto &message : messages) {
@@ -1099,16 +1101,54 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
       for (std::size_t i = 0; i + 1 < messages.size(); ++i) {
         messages[i].nested_type = std::span{&messages[i + 1], 1};
       }
-      BorrowedFileProto file{
+      BorrowedFileDescriptorProto file{
           .name = "nested.proto",
           .message_type = std::span{messages.data(), 1},
       };
-      BorrowedFileSet file_set{.file = std::span{&file, 1}};
+      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
       return hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value();
     };
 
     expect(create_at_depth(100));
     expect(!create_at_depth(101));
+  };
+
+  "in_memory_schema_resource_budgets_are_enforced"_test = [] {
+    {
+      std::vector<std::string_view> dependencies(65'537, "dependency.proto");
+      BorrowedFileDescriptorProto file{
+          .name = "dependency_budget.proto",
+          .dependency = dependencies,
+      };
+      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
+      expect(!hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value());
+    }
+    {
+      std::vector<BorrowedFieldProto> fields(65'537);
+      BorrowedMessageProto message{
+          .name = "Root",
+          .field = fields,
+      };
+      BorrowedFileDescriptorProto file{
+          .name = "field_budget.proto",
+          .message_type = std::span{&message, 1},
+      };
+      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
+      expect(!hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value());
+    }
+    {
+      std::vector<BorrowedEnumValueProto> values(131'073);
+      BorrowedEnumProto enumeration{
+          .name = "LargeEnum",
+          .value = values,
+      };
+      BorrowedFileDescriptorProto file{
+          .name = "enum_value_budget.proto",
+          .enum_type = std::span{&enumeration, 1},
+      };
+      BorrowedFileDescriptorSet file_set{.file = std::span{&file, 1}};
+      expect(!hpp_proto::dynamic_message_factory::create(std::move(file_set)).has_value());
+    }
   };
 
   "long_dependency_chain_factory_init_succeeds"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -76,6 +76,20 @@ struct test_message_feature_extension
   using pb_meta = std::tuple<hpp_proto::field_meta<field_number, &test_message_feature_extension::value>>;
 };
 
+struct test_repeated_feature_message {
+  std::vector<std::int32_t> values;
+  using pb_meta = std::tuple<hpp_proto::field_meta<1, &test_repeated_feature_message::values,
+                                                   hpp_proto::field_option::none, hpp_proto::vint64_t>>;
+};
+
+template <typename Traits = hpp_proto::default_traits>
+struct test_repeated_message_feature_extension
+    : hpp_proto::extension_base<test_repeated_message_feature_extension<Traits>, google::protobuf::FeatureSet> {
+  static constexpr std::uint32_t field_number = 125;
+  test_repeated_feature_message value;
+  using pb_meta = std::tuple<hpp_proto::field_meta<field_number, &test_repeated_message_feature_extension::value>>;
+};
+
 class throwing_memory_resource final : public std::pmr::memory_resource {
 private:
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
@@ -1132,6 +1146,24 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(!numbers->is_packed());
     expect(!scalar->explicit_presence());
     expect(child->is_delimited());
+  };
+
+  "edition_file_feature_extensions_are_merged_once"_test = [&] {
+    constexpr auto field_number = test_repeated_message_feature_extension<>::field_number;
+    auto proto = make_valid_edition_with_file_feature_overrides_fileset();
+    proto.options->features->unknown_fields_.fields.emplace(
+        field_number, std::vector<std::byte>{std::byte{0xea}, std::byte{0x07}, std::byte{0x04}, std::byte{0x08},
+                                             std::byte{0x07}, std::byte{0x08}, std::byte{0x0b}});
+
+    auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(make_descriptor_set_binpb_one(proto)));
+    std::pmr::monotonic_buffer_resource memory_resource;
+    auto message = expect_ok(factory.get_message("edition_features.Root", memory_resource));
+    test_repeated_message_feature_extension<> extension;
+
+    expect(message.descriptor().parent_file()->options().features->get_extension(extension).ok());
+    expect(fatal(eq(extension.value.values.size(), std::size_t{2})));
+    expect(eq(extension.value.values[0], std::int32_t{7}));
+    expect(eq(extension.value.values[1], std::int32_t{11}));
   };
 
   "missing_message_type_sets_error"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1,6 +1,7 @@
 #include "test_util.hpp"
 #include <array>
 #include <boost/ut.hpp>
+#include <concepts>
 #include <google/protobuf/descriptor.pb.hpp>
 #include <hpp_proto/dynamic_message/binpb.hpp>
 #include <hpp_proto/dynamic_message/factory_addons.hpp>
@@ -49,6 +50,32 @@ struct owning_pmr_factory_addons {
     // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
     file_descriptor([[maybe_unused]] Derived &derived, [[maybe_unused]] std::pmr::memory_resource *resource) {}
   };
+};
+
+template <typename T>
+concept factory_creatable_from =
+    requires(T &&value) { hpp_proto::dynamic_message_factory::create(std::forward<T>(value)); };
+
+using non_owning_file_descriptor_set = google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>;
+static_assert(!factory_creatable_from<non_owning_file_descriptor_set>);
+
+template <typename Pool>
+concept publicly_initializable_descriptor_pool =
+    requires(Pool &pool, Pool::FileDescriptorSet &&fileset) { pool.init(std::move(fileset)); };
+
+using owning_pmr_descriptor_pool = hpp_proto::descriptor_pool<owning_pmr_factory_addons>;
+static_assert(!publicly_initializable_descriptor_pool<owning_pmr_descriptor_pool>);
+
+template <typename AddOns>
+class internal_descriptor_pool : public hpp_proto::descriptor_pool<AddOns> {
+  using base_type = hpp_proto::descriptor_pool<AddOns>;
+
+public:
+  using base_type::base_type;
+
+  [[nodiscard]] std::expected<void, hpp_proto::descriptor_pool_errc> init(base_type::FileDescriptorSet &&fileset) {
+    return base_type::init(std::move(fileset));
+  }
 };
 
 template <typename Traits = hpp_proto::default_traits>
@@ -1453,7 +1480,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     default_resource_scope guard{&throwing_resource};
     expect(hpp_proto::dynamic_message_factory::create(descriptor_set, allocator).has_value());
     expect(hpp_proto::dynamic_message_factory::create(descriptors, allocator).has_value());
-    expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator).has_value());
   };
 
   "owning_pmr_descriptor_pool_merges_feature_extensions_without_global_allocations"_test = [&] {
@@ -1484,7 +1510,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     });
     auto descriptor_set = make_descriptor_set_binpb_one(proto);
     std::pmr::monotonic_buffer_resource resource;
-    using pool_type = hpp_proto::descriptor_pool<owning_pmr_factory_addons>;
+    using pool_type = internal_descriptor_pool<owning_pmr_factory_addons>;
     auto fileset =
         expect_ok(hpp_proto::read_binpb<pool_type::FileDescriptorSet>(descriptor_set, hpp_proto::alloc_from(resource)));
 
@@ -1575,32 +1601,11 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(!hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
   };
 
-  "factory_create_from_non_owning_fileset_overload_succeeds"_test = [&] {
-    auto desc_binpb = make_descriptor_set_binpb_one(make_two_oneofs_fileset());
-    std::pmr::monotonic_buffer_resource mr;
-    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
-        desc_binpb, hpp_proto::alloc_from(mr)));
-
-    auto factory = hpp_proto::dynamic_message_factory::create(std::move(fileset));
-    expect(factory.has_value());
-  };
-
   "factory_create_malformed_binpb_returns_descriptor_deserialization_error"_test = [&] {
     std::string malformed_binpb(1, static_cast<char>(0x80));
     auto factory = hpp_proto::dynamic_message_factory::create(malformed_binpb);
     expect(!factory.has_value());
     expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_deserialization_error));
-  };
-
-  "factory_create_invalid_fileset_returns_schema_validation_error"_test = [&] {
-    auto desc_binpb = make_descriptor_set_binpb_one(make_invalid_edition_fileset());
-    std::pmr::monotonic_buffer_resource mr;
-    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
-        desc_binpb, hpp_proto::alloc_from(mr)));
-
-    auto factory = hpp_proto::dynamic_message_factory::create(std::move(fileset));
-    expect(!factory.has_value());
-    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::schema_validation_error));
   };
 
   "factory_create_invalid_distinct_descs_returns_schema_validation_error"_test = [&] {
@@ -1765,51 +1770,6 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(gt(decode_fail_index, std::size_t{1}));
     expect(throws_bad_alloc_for_index(decode_fail_index));
     expect(throws_bad_alloc_for_index(decode_fail_index));
-
-    auto healthy_factory = expect_ok(hpp_proto::dynamic_message_factory::create(descriptor_binpb));
-    std::pmr::monotonic_buffer_resource msg_mr;
-    expect(healthy_factory.get_message("proto3_unittest.TestAllTypes", msg_mr).has_value());
-  };
-
-  // Verifies OOM contract on fileset-init path:
-  // 1) std::bad_alloc is propagated while building/linking/resolving pool state.
-  // 2) Repeating the same failpoint index yields the same failure.
-  // 3) A later healthy create still succeeds (no leaked invalid state).
-  "factory_create_failpoint_bad_alloc_during_pool_init_from_fileset_is_deterministic"_test = [&] {
-    if constexpr (msvc_asan_bad_alloc_failpoint_unstable) {
-      expect(true);
-      return;
-    }
-    auto descriptor_binpb = read_file("unittest.desc.binpb");
-
-    auto throws_bad_alloc_for_index = [&](std::size_t fail_index) {
-      failpoint_memory_resource failpoint_mr{fail_index};
-      auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&failpoint_mr};
-      try {
-        std::pmr::monotonic_buffer_resource parse_mr;
-        auto fileset =
-            expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
-                descriptor_binpb, hpp_proto::alloc_from(parse_mr)));
-        [[maybe_unused]] auto factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator);
-        return false;
-      } catch (const std::bad_alloc &) {
-        return true;
-      } catch (...) {
-        return false;
-      }
-    };
-
-    std::size_t pool_fail_index = 0;
-    for (std::size_t index = 2; index <= 128; ++index) {
-      if (throws_bad_alloc_for_index(index)) {
-        pool_fail_index = index;
-        break;
-      }
-    }
-
-    expect(gt(pool_fail_index, std::size_t{1}));
-    expect(throws_bad_alloc_for_index(pool_fail_index));
-    expect(throws_bad_alloc_for_index(pool_fail_index));
 
     auto healthy_factory = expect_ok(hpp_proto::dynamic_message_factory::create(descriptor_binpb));
     std::pmr::monotonic_buffer_resource msg_mr;

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -51,6 +51,15 @@ struct owning_pmr_factory_addons {
   };
 };
 
+template <typename Traits = hpp_proto::default_traits>
+struct test_feature_extension
+    : hpp_proto::extension_base<test_feature_extension<Traits>, google::protobuf::FeatureSet> {
+  static constexpr std::uint32_t field_number = 123;
+  std::int32_t value = 0;
+  using pb_meta = std::tuple<hpp_proto::field_meta<field_number, &test_feature_extension::value,
+                                                   hpp_proto::field_option::none, hpp_proto::vint64_t>>;
+};
+
 class throwing_memory_resource final : public std::pmr::memory_resource {
 private:
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
@@ -1522,6 +1531,21 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(eq(merged_extension[3], std::byte{0x5a}));
     expect(eq(merged_extension[70], std::byte{0x6b}));
     expect(eq(tracking_resource.allocations(), std::size_t{0}));
+  };
+
+  "non_owning_feature_extension_lookup_merges_parent_and_child"_test = [&] {
+    auto proto = make_two_oneofs_fileset();
+    proto.options.emplace().features.emplace().unknown_fields_.fields.emplace(
+        123U, std::vector<std::byte>{std::byte{0xd8}, std::byte{0x07}, std::byte{0x01}});
+    proto.message_type.front().options.emplace().features.emplace().unknown_fields_.fields.emplace(
+        123U, std::vector<std::byte>{std::byte{0xd8}, std::byte{0x07}, std::byte{0x02}});
+
+    auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(make_descriptor_set_binpb_one(proto)));
+    std::pmr::monotonic_buffer_resource message_resource;
+    auto message = expect_ok(factory.get_message("Root", message_resource));
+    test_feature_extension extension;
+    expect(message.descriptor().options().features->get_extension(extension).ok());
+    expect(eq(extension.value, std::int32_t{2}));
   };
 
   "factory_create_succeeds_after_failed_create"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1463,11 +1463,15 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
           .identifier_value = "allocator_sensitive_option_value",
       };
     };
+    auto make_extension = [] {
+      std::vector<std::byte> result = {std::byte{0xda}, std::byte{0x07}, std::byte{0x40}};
+      result.resize(result.size() + 64U, std::byte{0x5a});
+      return result;
+    };
     auto proto = make_two_oneofs_fileset();
     proto.options.emplace().uninterpreted_option.push_back(make_option());
-    std::vector<std::byte> extension_bytes = {std::byte{0xda}, std::byte{0x07}, std::byte{0x40}};
-    extension_bytes.resize(extension_bytes.size() + 64U, std::byte{0x5a});
-    proto.options->unknown_fields_.fields.emplace(123U, std::move(extension_bytes));
+    proto.options->unknown_fields_.fields.emplace(123U, make_extension());
+    proto.options->features.emplace().unknown_fields_.fields.emplace(123U, make_extension());
     auto &message = proto.message_type.front();
     message.options.emplace().uninterpreted_option.push_back(make_option());
     message.field.front().options.emplace().uninterpreted_option.push_back(make_option());
@@ -1487,6 +1491,9 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     default_resource_scope guard{&tracking_resource};
     pool_type pool{&resource};
     expect(pool.init(std::move(fileset)).has_value());
+    const auto &feature_extensions = pool.files().front().options().features->unknown_fields_.fields;
+    expect(eq(feature_extensions.size(), std::size_t{1}));
+    expect(feature_extensions.contains(123U));
     expect(eq(tracking_resource.allocations(), std::size_t{0}));
   };
 

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -11,9 +11,40 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 using namespace boost::ut;
+
+struct owning_pmr_factory_addons {
+  using traits_type = hpp_proto::pmr_traits;
+  using string_t = std::pmr::string;
+  template <typename T>
+  using vector_t = std::pmr::vector<T>;
+  template <typename K, typename V>
+  using map_t = std::pmr::unordered_map<K, V>;
+
+  template <typename Derived>
+  struct field_descriptor {
+    field_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+  };
+  template <typename Derived>
+  struct enum_descriptor {
+    enum_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+  };
+  template <typename Derived>
+  struct oneof_descriptor {
+    oneof_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+  };
+  template <typename Derived>
+  struct message_descriptor {
+    message_descriptor(Derived &, const auto &, std::pmr::memory_resource *) {}
+  };
+  template <typename Derived>
+  struct file_descriptor {
+    file_descriptor(Derived &, std::pmr::memory_resource *) {}
+  };
+};
 
 // Dynamic descriptor factory tests use protobuf boundary and validation fixture literals inline.
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,misc-const-correctness)
@@ -1311,6 +1342,39 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(hpp_proto::dynamic_message_factory::create(descriptor_set, allocator).has_value());
     expect(hpp_proto::dynamic_message_factory::create(descriptors, allocator).has_value());
     expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator).has_value());
+  };
+
+  "owning_pmr_descriptor_pool_does_not_use_global_default_resource"_test = [&] {
+    struct throwing_memory_resource final : std::pmr::memory_resource {
+      void *do_allocate(std::size_t, std::size_t) override { throw std::bad_alloc{}; }
+      void do_deallocate(void *, std::size_t, std::size_t) override {}
+      [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
+        return this == &other;
+      }
+    } throwing_resource;
+    struct default_resource_scope {
+      std::pmr::memory_resource *previous;
+      explicit default_resource_scope(std::pmr::memory_resource *resource)
+          : previous(std::pmr::set_default_resource(resource)) {}
+      ~default_resource_scope() { std::pmr::set_default_resource(previous); }
+    };
+
+    OwningFileDescriptorProto minimal_file;
+    minimal_file.name = "minimal.proto";
+    minimal_file.syntax = "proto3";
+    auto descriptor_set = make_descriptor_set_binpb_one(minimal_file);
+    std::pmr::monotonic_buffer_resource resource;
+    using pool_type = hpp_proto::descriptor_pool<owning_pmr_factory_addons>;
+    auto warmup_fileset = expect_ok(
+        hpp_proto::read_binpb<typename pool_type::FileDescriptorSet>(descriptor_set, hpp_proto::alloc_from(resource)));
+    pool_type warmup_pool{&resource};
+    expect(warmup_pool.init(std::move(warmup_fileset)).has_value());
+    auto fileset = expect_ok(
+        hpp_proto::read_binpb<typename pool_type::FileDescriptorSet>(descriptor_set, hpp_proto::alloc_from(resource)));
+
+    default_resource_scope guard{&throwing_resource};
+    pool_type pool{&resource};
+    expect(pool.init(std::move(fileset)).has_value());
   };
 
   "factory_create_succeeds_after_failed_create"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1309,8 +1309,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     std::pmr::monotonic_buffer_resource parse_resource;
     auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
         descriptor_set, hpp_proto::alloc_from(parse_resource)));
-    const auto pool_memory_limit =
-        hpp_proto::descriptor_memory_options{.limit = std::size_t{1} * 1024U * 1024U};
+    const auto pool_memory_limit = hpp_proto::descriptor_memory_options{.limit = std::size_t{1} * 1024U * 1024U};
     auto fileset_factory = hpp_proto::dynamic_message_factory::create(std::move(fileset), pool_memory_limit);
     expect(fatal(!fileset_factory.has_value()));
     expect(eq(fileset_factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1108,6 +1108,15 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
   };
 
+  "descriptor_pool_construction_uses_decoded_memory_budget"_test = [&] {
+    auto descriptor_set = make_descriptor_set_binpb_one(make_large_field_message_fileset(150'000));
+    expect(lt(descriptor_set.size(), hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes));
+
+    auto factory = hpp_proto::dynamic_message_factory::create(descriptor_set);
+    expect(fatal(!factory.has_value()));
+    expect(eq(factory.error(), hpp_proto::dynamic_message_errc::descriptor_memory_limit_exceeded));
+  };
+
   "distinct_descriptor_aggregate_size_limit_is_enforced"_test = [] {
     std::string descriptor((hpp_proto::dynamic_message_factory::max_serialized_descriptor_bytes / 2) + 1, '\0');
     auto descriptors = hpp_proto::distinct_file_descriptor_pb_array{hpp_proto::file_descriptor_pb{descriptor},
@@ -1271,6 +1280,37 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
       std::pmr::set_default_resource(old_resource);
     }
     expect(current_resource == old_resource);
+  };
+
+  "factory_creation_does_not_use_global_default_resource"_test = [&] {
+    struct throwing_memory_resource final : std::pmr::memory_resource {
+      void *do_allocate(std::size_t, std::size_t) override { throw std::bad_alloc{}; }
+      void do_deallocate(void *, std::size_t, std::size_t) override {}
+      [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
+        return this == &other;
+      }
+    } throwing_resource;
+    struct default_resource_scope {
+      std::pmr::memory_resource *previous;
+      explicit default_resource_scope(std::pmr::memory_resource *resource)
+          : previous(std::pmr::set_default_resource(resource)) {}
+      ~default_resource_scope() { std::pmr::set_default_resource(previous); }
+    };
+
+    auto descriptor_set = make_descriptor_set_binpb_one(make_two_oneofs_fileset());
+    std::pmr::monotonic_buffer_resource parse_resource;
+    auto fileset = expect_ok(hpp_proto::read_binpb<google::protobuf::FileDescriptorSet<hpp_proto::non_owning_traits>>(
+        descriptor_set, hpp_proto::alloc_from(parse_resource)));
+    std::string file_descriptor;
+    expect(hpp_proto::write_binpb(fileset.file.front(), file_descriptor).ok());
+    hpp_proto::distinct_file_descriptor_pb_array descriptors = {hpp_proto::file_descriptor_pb{file_descriptor}};
+
+    std::pmr::unsynchronized_pool_resource upstream;
+    const auto allocator = hpp_proto::dynamic_message_factory::allocator_type{&upstream};
+    default_resource_scope guard{&throwing_resource};
+    expect(hpp_proto::dynamic_message_factory::create(descriptor_set, allocator).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(descriptors, allocator).has_value());
+    expect(hpp_proto::dynamic_message_factory::create(std::move(fileset), allocator).has_value());
   };
 
   "factory_create_succeeds_after_failed_create"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -1471,7 +1471,27 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   };
 
   "owning_pmr_descriptor_pool_does_not_use_global_default_resource"_test = [&] {
-    auto descriptor_set = make_descriptor_set_binpb_one(OwningFileDescriptorProto{});
+    auto make_option = [] {
+      return google::protobuf::UninterpretedOption<>{
+          .name = {{.name_part = "allocator_sensitive_option_name", .is_extension = false}},
+          .identifier_value = "allocator_sensitive_option_value",
+      };
+    };
+    auto proto = make_two_oneofs_fileset();
+    proto.options.emplace().uninterpreted_option.push_back(make_option());
+    std::vector<std::byte> extension_bytes = {std::byte{0xda}, std::byte{0x07}, std::byte{0x40}};
+    extension_bytes.resize(extension_bytes.size() + 64U, std::byte{0x5a});
+    proto.options->unknown_fields_.fields.emplace(123U, std::move(extension_bytes));
+    auto &message = proto.message_type.front();
+    message.options.emplace().uninterpreted_option.push_back(make_option());
+    message.field.front().options.emplace().uninterpreted_option.push_back(make_option());
+    message.oneof_decl.front().options.emplace().uninterpreted_option.push_back(make_option());
+    message.enum_type.push_back(EnumProto{
+        .name = "AllocatorSensitiveEnum",
+        .value = {{.name = "ZERO", .number = 0}},
+        .options = google::protobuf::EnumOptions<>{.uninterpreted_option = {make_option()}},
+    });
+    auto descriptor_set = make_descriptor_set_binpb_one(proto);
     std::pmr::monotonic_buffer_resource resource;
     using pool_type = hpp_proto::descriptor_pool<owning_pmr_factory_addons>;
     auto fileset =
@@ -1480,7 +1500,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     tracking_memory_resource tracking_resource;
     default_resource_scope guard{&tracking_resource};
     pool_type pool{&resource};
-    expect(!pool.init(std::move(fileset)).has_value());
+    expect(pool.init(std::move(fileset)).has_value());
     expect(eq(tracking_resource.allocations(), std::size_t{0}));
   };
 


### PR DESCRIPTION
## Summary

Harden dynamic descriptor construction against recursive schema depth and quadratic validation work while preserving the library's trusted-input and no-explicit-exceptions design.

## Resource contract

- Every `dynamic_message_factory::create(...)` overload accepts trusted, prevalidated descriptor input. The factory deliberately does not impose a serialized byte-size or decoded-memory limit; callers accepting untrusted serialized data must enforce suitable bounds before calling it, consistent with `read_binpb()`.
- Serialized `FileDescriptorSet` parsing retains the binary parser's default recursion limit of 100.
- The optional PMR allocator creates the factory implementation and supplies the upstream resource for descriptor decoding, persistent descriptor storage, indexes, addon state, and temporary validation structures. Its resource must outlive the returned factory.
- Factory creation contains no explicit `throw`, `try`, or `catch`. Allocation failure follows the configured toolchain and memory resource behavior, as elsewhere in the library.

## What changed

- Make `descriptor_pool` allocator-aware and propagate the configured resource explicitly through top-level containers, parser storage, descriptor constructors, nested PMR members, copied options, addon maps, and FeatureSet extension storage.
- Remove factory-time changes to the process-wide PMR default resource, making concurrent factory construction with different resources independent.
- Replace recursive dependency-cycle validation with iterative Kahn topological validation and build nested message descriptors iteratively.
- Replace pairwise JSON-name conflict scans with hash-set lookups and index enum values once so explicit defaults use constant-time lookup.
- Preserve protobuf FeatureSet inheritance for same-number extensions. Owning PMR storage coalesces parent and child wire payloads; non-owning storage lookup deserializes every matching entry in order.
- Add non-owning regressions for scalar last-wins behavior and message-valued extensions whose parent and child set different nested subfields.
- Add stress and allocator-isolation coverage for validation scratch storage, concurrent factories, deep nesting, long dependency chains, large messages, and large enums.

## Why

Deep or adversarially shaped trusted schemas should not overflow the stack or trigger quadratic validation work. Explicit allocator propagation makes resource ownership auditable and concurrency-safe without adding a second recoverable error mechanism. Correct extension coalescing also preserves protobuf's parent-to-child FeatureSet merge semantics for both owning and non-owning traits.

## Testing

- `cmake --build build/release --target dynamic_message_test -j4`
- `ctest --test-dir build/release --output-on-failure` (34/34 passed)
- `clangd --check` on the modified factory and dynamic-message test sources (no diagnostics)
- Targeted `clang-tidy` check for the modified sources
- `clang-format --dry-run --Werror` and `git diff --check`
- Full GitHub Actions matrix on the preceding allocator-fix head, including MSVC, MinGW, Linux, macOS, clang-tidy, Conan, Vcpkg, and ClusterFuzzLite (26/26 passed)

An exploratory full `-fno-exceptions` build confirms the factory budget mechanism is no longer a blocker. The target still encounters six pre-existing explicit throws in dynamic-message field accessors that are outside this PR's factory changes.
