### PR TITLE
Reject malformed descriptor defaults without exceptions

### DIFF
--- a/include/hpp_proto/dynamic_message/factory_addons.hpp
+++ b/include/hpp_proto/dynamic_message/factory_addons.hpp
@@ -26,6 +26,7 @@
 #include <cerrno>
 #include <charconv>
 #include <cstdlib>
+#include <expected>
 #include <memory_resource>
 #include <span>
 #include <string>
@@ -64,7 +65,7 @@ struct dynamic_message_factory_addons {
 #endif
 
   template <typename T>
-  static T parse_default_value(std::string_view value) {
+  static std::expected<T, std::errc> parse_default_value(std::string_view value) {
     T parsed{};
     if (value.empty()) {
       return parsed;
@@ -108,11 +109,8 @@ struct dynamic_message_factory_addons {
       consumed_entire_input = result.ptr == end;
     }
 
-    if (ec == std::errc::result_out_of_range) {
-      throw std::out_of_range("default value out of range");
-    }
     if (ec != std::errc{} || !consumed_entire_input) {
-      throw std::invalid_argument("invalid default value");
+      return std::unexpected(ec == std::errc{} ? std::errc::invalid_argument : ec);
     }
     return parsed;
   }
@@ -121,6 +119,7 @@ struct dynamic_message_factory_addons {
   struct field_descriptor {
     using type = void;
     std::variant<bool, int32_t, uint32_t, int64_t, uint64_t, double, float> default_value;
+    bool default_value_valid = true;
     /// @brief slot represents the index to the field memory storage of a message; all non-oneof fields use different
     /// slot, fields of the same oneof type share the same slot.
     uint32_t storage_slot = 0;
@@ -137,34 +136,44 @@ struct dynamic_message_factory_addons {
     uint32_t active_oneof_selection_mask = 0;
     field_descriptor(Derived &self, [[maybe_unused]] const auto &inherited_options) { set_default_value(self.proto()); }
 
+    template <typename T>
+    void set_numeric_default_value(std::string_view value) {
+      auto parsed = parse_default_value<T>(value);
+      if (parsed.has_value()) {
+        default_value = *parsed;
+      } else {
+        default_value_valid = false;
+      }
+    }
+
     void set_default_value(const google::protobuf::FieldDescriptorProto<traits_type> &proto) {
       using enum google::protobuf::FieldDescriptorProto_::Type;
       switch (proto.type) {
       case TYPE_ENUM:
         break;
       case TYPE_DOUBLE:
-        default_value = parse_default_value<double>(proto.default_value);
+        set_numeric_default_value<double>(proto.default_value);
         break;
       case TYPE_FLOAT:
-        default_value = parse_default_value<float>(proto.default_value);
+        set_numeric_default_value<float>(proto.default_value);
         break;
       case TYPE_INT64:
       case TYPE_SFIXED64:
       case TYPE_SINT64:
-        default_value = parse_default_value<int64_t>(proto.default_value);
+        set_numeric_default_value<int64_t>(proto.default_value);
         break;
       case TYPE_UINT64:
       case TYPE_FIXED64:
-        default_value = parse_default_value<uint64_t>(proto.default_value);
+        set_numeric_default_value<uint64_t>(proto.default_value);
         break;
       case TYPE_INT32:
       case TYPE_SFIXED32:
       case TYPE_SINT32:
-        default_value = parse_default_value<int32_t>(proto.default_value);
+        set_numeric_default_value<int32_t>(proto.default_value);
         break;
       case TYPE_UINT32:
       case TYPE_FIXED32:
-        default_value = parse_default_value<uint32_t>(proto.default_value);
+        set_numeric_default_value<uint32_t>(proto.default_value);
         break;
       case TYPE_BOOL:
         default_value = proto.default_value == "true";

--- a/src/dynamic_message/factory.cpp
+++ b/src/dynamic_message/factory.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 #include <memory>
 #include <memory_resource>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -205,6 +206,9 @@ private:
   }
 
   [[nodiscard]] std::expected<void, dynamic_message_errc> finish_initialize() {
+    if (std::ranges::any_of(pool_.fields(), [](const auto &field) { return !field.default_value_valid; })) {
+      return std::unexpected(dynamic_message_errc::schema_validation_error);
+    }
     return setup_storage_slots().and_then([this] {
       setup_wellknown_types_impl(pool_);
       return setup_enum_field_default_value();

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -32,23 +32,23 @@ constexpr bool msvc_asan_bad_alloc_failpoint_unstable = false;
 
 const boost::ut::suite parse_default_value_tests = [] {
   "parse_default_value_success"_test = [] {
-    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>("123"), 123));
-    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<uint64_t>(
+    expect(eq(*hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>("123"), 123));
+    expect(eq(*hpp_proto::dynamic_message_factory_addons::parse_default_value<uint64_t>(
                   std::to_string(std::numeric_limits<uint64_t>::max())),
               std::numeric_limits<uint64_t>::max()));
-    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<float>("1.5"), 1.5F));
-    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<double>("-2.5"), -2.5));
-    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>(""),
+    expect(eq(*hpp_proto::dynamic_message_factory_addons::parse_default_value<float>("1.5"), 1.5F));
+    expect(eq(*hpp_proto::dynamic_message_factory_addons::parse_default_value<double>("-2.5"), -2.5));
+    expect(eq(*hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>(""),
               0)); // empty defaults to zero-initialized
   };
 
   "parse_default_value_errors"_test = [] {
-    expect(throws<std::invalid_argument>(
-        [] { (void)hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>("abc"); }));
-    expect(throws<std::out_of_range>(
-        [] { (void)hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>("999999999999"); }));
-    expect(throws<std::out_of_range>(
-        [] { (void)hpp_proto::dynamic_message_factory_addons::parse_default_value<double>("1e400"); }));
+    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>("abc").error(),
+              std::errc::invalid_argument));
+    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<int32_t>("999999999999").error(),
+              std::errc::result_out_of_range));
+    expect(eq(hpp_proto::dynamic_message_factory_addons::parse_default_value<double>("1e400").error(),
+              std::errc::result_out_of_range));
   };
 };
 
@@ -708,6 +708,28 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     };
   };
 
+  auto make_invalid_numeric_default_fileset = [](auto type, std::string default_value) {
+    return OwningFileDescriptorProto{
+        .name = "invalid_numeric_default.proto",
+        .message_type =
+            {
+                MessageProto{
+                    .name = "Root",
+                    .field =
+                        {
+                            FieldProto{
+                                .name = "value",
+                                .number = 1,
+                                .label = LABEL_OPTIONAL,
+                                .type = type,
+                                .default_value = std::move(default_value),
+                            },
+                        },
+                },
+            },
+    };
+  };
+
   auto make_empty_enum_fileset = [] {
     return OwningFileDescriptorProto{
         .name = "empty_enum.proto",
@@ -1146,6 +1168,19 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   "invalid_enum_default_name_factory_init_fails"_test = [&] {
     auto desc_binpb = make_descriptor_set_binpb_one(make_invalid_enum_default_name_fileset());
     expect(!hpp_proto::dynamic_message_factory::create(desc_binpb).has_value());
+  };
+
+  "invalid_numeric_defaults_return_schema_validation_error"_test = [&] {
+    auto expect_schema_error = [&](auto type, std::string default_value) {
+      auto desc_binpb = make_descriptor_set_binpb_one(make_invalid_numeric_default_fileset(type, default_value));
+      auto factory = hpp_proto::dynamic_message_factory::create(desc_binpb);
+      expect(fatal(!factory.has_value()));
+      expect(eq(factory.error(), hpp_proto::dynamic_message_errc::schema_validation_error));
+    };
+
+    expect_schema_error(TYPE_INT32, "not-an-integer");
+    expect_schema_error(TYPE_INT32, "999999999999");
+    expect_schema_error(TYPE_DOUBLE, "1e400");
   };
 
   "empty_enum_factory_init_fails"_test = [&] {

--- a/tests/dynamic_message_factory_test.cpp
+++ b/tests/dynamic_message_factory_test.cpp
@@ -708,7 +708,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
     };
   };
 
-  auto make_invalid_numeric_default_fileset = [](auto type, std::string default_value) {
+  auto make_invalid_numeric_default_fileset = [](auto type, std::string_view default_value) {
     return OwningFileDescriptorProto{
         .name = "invalid_numeric_default.proto",
         .message_type =
@@ -722,7 +722,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
                                 .number = 1,
                                 .label = LABEL_OPTIONAL,
                                 .type = type,
-                                .default_value = std::move(default_value),
+                                .default_value = std::string{default_value},
                             },
                         },
                 },
@@ -1171,7 +1171,7 @@ const boost::ut::suite descriptor_pool_gap_tests = [] {
   };
 
   "invalid_numeric_defaults_return_schema_validation_error"_test = [&] {
-    auto expect_schema_error = [&](auto type, std::string default_value) {
+    auto expect_schema_error = [&](auto type, std::string_view default_value) {
       auto desc_binpb = make_descriptor_set_binpb_one(make_invalid_numeric_default_fileset(type, default_value));
       auto factory = hpp_proto::dynamic_message_factory::create(desc_binpb);
       expect(fatal(!factory.has_value()));


### PR DESCRIPTION
## Summary

Keep malformed numeric descriptor defaults inside the dynamic factory's `std::expected` error contract.

## What changed

- Return `std::expected<T, std::errc>` from numeric default parsing instead of throwing.
- Record invalid numeric defaults on field descriptors during pool construction.
- Return `schema_validation_error` from factory initialization when a field default is invalid.
- Add coverage for malformed integers and out-of-range integer and floating-point defaults.

## Why

Uploaded descriptor sets can contain invalid numeric defaults. Previously these values raised `std::invalid_argument` or `std::out_of_range`, escaping the public factory API's error-return contract and potentially terminating callers that only handle `std::expected` failures.
