### PR TITLE
Enforce recursion limits for protobuf groups

### DIFF
--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -711,6 +711,11 @@ constexpr status skip_fields_match_tag(uint32_t tag, concepts::is_basic_in auto 
 }
 
 constexpr status do_skip_group(uint32_t field_num, concepts::is_basic_in auto &archive) {
+  const util::recursion_guard guard{archive.context};
+  if (!guard.ok()) {
+    return std::errc::value_too_large; // maximum recursion reached
+  }
+
   while (archive.in_avail() > 0) {
     auto tag = archive.read_tag();
 
@@ -1296,6 +1301,11 @@ constexpr auto &get_unknown_fields(auto &item)
 constexpr std::monostate get_unknown_fields(auto & /*item*/) { return {}; }
 
 constexpr status deserialize_group(uint32_t field_num, auto &&item, concepts::is_basic_in auto &archive) {
+  const util::recursion_guard guard{archive.context};
+  if (!guard.ok()) {
+    return std::errc::value_too_large; // maximum recursion reached
+  }
+
   decltype(auto) unknown_fields = get_unknown_fields(item);
   decltype(auto) modifiable_unknown_fields = detail::as_modifiable(archive.context, unknown_fields);
   while (archive.in_avail() > 0) {

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -694,6 +694,14 @@ struct nested_group {
 
 auto pb_meta(const nested_group &) -> std::tuple<hpp_proto::field_meta<1, &nested_group::nested, field_option::group>>;
 
+struct doubly_nested_group {
+  nested_group nested;
+  bool operator==(const doubly_nested_group &) const = default;
+};
+
+auto pb_meta(const doubly_nested_group &)
+    -> std::tuple<hpp_proto::field_meta<1, &doubly_nested_group::nested, field_option::group>>;
+
 const ut::suite test_nested_group = [] {
   "nested_group_case"_test = [] { expect_roundtrip_ok("\x0b\x08\x01\x0c"sv, nested_group{.nested = {.i = 1}}); };
   nested_group value;
@@ -1753,6 +1761,26 @@ const ut::suite recursion_limit_tests = [] {
     auto status = hpp_proto::read_binpb(out, buffer, hpp_proto::recursion_limit<1>);
     ut::expect(!status.ok());
     ut::expect(status.ec == std::errc::value_too_large);
+  };
+
+  "known_groups_respect_recursion_limit"_test = [] {
+    constexpr auto buffer = "\x0b\x0b\x0c\x0c"sv;
+    doubly_nested_group out;
+
+    auto status = hpp_proto::read_binpb(out, buffer, hpp_proto::recursion_limit<1>);
+    ut::expect(!status.ok());
+    ut::expect(status.ec == std::errc::value_too_large);
+    ut::expect(hpp_proto::read_binpb(out, buffer, hpp_proto::recursion_limit<2>).ok());
+  };
+
+  "skipped_groups_respect_recursion_limit"_test = [] {
+    constexpr auto buffer = "\x0b\x0b\x0c\x0c"sv;
+    empty out;
+
+    auto status = hpp_proto::read_binpb(out, buffer, hpp_proto::recursion_limit<1>);
+    ut::expect(!status.ok());
+    ut::expect(status.ec == std::errc::value_too_large);
+    ut::expect(hpp_proto::read_binpb(out, buffer, hpp_proto::recursion_limit<2>).ok());
   };
 };
 


### PR DESCRIPTION
## Summary

Make binary deserialization enforce the configured recursion limit while parsing protobuf group wire values, preventing deeply nested known or unknown groups from bypassing stack-exhaustion protection.

## What changed

- Added a recursion guard when skipping unknown protobuf groups.
- Added the same recursion guard when deserializing schema-known groups.
- Added boundary tests proving two nested groups fail with a limit of 1 and succeed with a limit of 2 for both paths.

## Why

Group wire values recurse independently of length-delimited messages. Without guards at the group entry points, attacker-controlled input could exceed the advertised binary recursion limit and exhaust the process stack.
