### PR TITLE
Centralize protobuf recursion limit handling

### DIFF
--- a/fuzz/fuzz_json.cpp
+++ b/fuzz/fuzz_json.cpp
@@ -67,7 +67,10 @@ extern "C" __attribute__((visibility("default"))) int LLVMFuzzerTestOneInput(con
 
           const bool all_status_same = (non_owning_read_status.ok() == owning_read_status.ok() &&
                                         owning_read_status.ok() == dyn_read_status.ok());
-          if (!all_status_same) {
+          const bool expected_dynamic_recursion_rejection =
+              non_owning_read_status.ok() && owning_read_status.ok() &&
+              dyn_read_status.ctx.ec == glz::error_code::exceeded_max_recursive_depth;
+          if (!all_status_same && !expected_dynamic_recursion_rejection) {
             auto print_error = [&input](std::string_view name, auto status) {
               if (!status.ok()) {
                 std::cerr << name << " failed:" << status.message(input) << "\n";
@@ -77,7 +80,7 @@ extern "C" __attribute__((visibility("default"))) int LLVMFuzzerTestOneInput(con
             print_error("owning", owning_read_status);
             print_error("dyn", dyn_read_status);
           }
-          assert(all_status_same);
+          assert(all_status_same || expected_dynamic_recursion_rejection);
           if (dyn_read_status.ok()) {
             round_trip_test(non_owning_message, non_owning_message_t{});
             round_trip_test(owning_message, owning_message_t{});

--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -21,7 +21,9 @@
 // SOFTWARE.
 
 #pragma once
+#include <cstdint>
 #include <expected>
+#include <limits>
 
 #include <hpp_proto/binpb/deserialize.hpp>
 #include <hpp_proto/binpb/serialize.hpp>
@@ -91,8 +93,12 @@ constexpr auto adaptive_mode = serialization_option_t<serialization_mode::adapti
 ///   incur a CPU performance penalty compared to contiguous serialization.
 constexpr auto chunked_mode = serialization_option_t<serialization_mode::chunked>{};
 
+/// Limit nested message recursion for binary protobuf and dynamic-message JSON operations.
+/// The root message does not consume the recursion budget.
+/// UINT32_MAX is reserved so the internal recursion counter cannot wrap.
 template <uint32_t N>
 struct recursion_limit_t {
+  static_assert(N < std::numeric_limits<uint32_t>::max(), "recursion limit must be less than UINT32_MAX");
   using option_type = recursion_limit_t<N>;
   static constexpr uint32_t max_recursion_depth = N;
 };

--- a/include/hpp_proto/binpb.hpp
+++ b/include/hpp_proto/binpb.hpp
@@ -23,10 +23,10 @@
 #pragma once
 #include <cstdint>
 #include <expected>
-#include <limits>
 
 #include <hpp_proto/binpb/deserialize.hpp>
 #include <hpp_proto/binpb/serialize.hpp>
+#include <hpp_proto/recursion.hpp>
 
 namespace hpp_proto {
 using std::expected;
@@ -93,19 +93,6 @@ constexpr auto adaptive_mode = serialization_option_t<serialization_mode::adapti
 ///   incur a CPU performance penalty compared to contiguous serialization.
 constexpr auto chunked_mode = serialization_option_t<serialization_mode::chunked>{};
 
-/// Limit nested message recursion for binary protobuf and dynamic-message JSON operations.
-/// The root message does not consume the recursion budget.
-/// UINT32_MAX is reserved so the internal recursion counter cannot wrap.
-template <uint32_t N>
-struct recursion_limit_t {
-  static_assert(N < std::numeric_limits<uint32_t>::max(), "recursion limit must be less than UINT32_MAX");
-  using option_type = recursion_limit_t<N>;
-  static constexpr uint32_t max_recursion_depth = N;
-};
-
-template <uint32_t N>
-constexpr auto recursion_limit = recursion_limit_t<N>{};
-
 struct padded_input_t {
   using option_type = padded_input_t;
   using padded_input = void;
@@ -121,16 +108,26 @@ template <typename F>
   requires std::regular_invocable<F>
 consteval auto write_binpb(F make_object) {
   constexpr auto obj = make_object();
-  constexpr auto sz = pb_serializer::message_size_calculator<decltype(obj)>::message_size(obj);
-  if constexpr (sz == 0) {
-    return std::span<std::byte>{};
-  } else {
+  constexpr bool recursion_limit_exceeded = [&obj] {
     pb_context<> ctx;
-    std::array<std::byte, sz> buffer = {};
-    if (auto result = pb_serializer::serialize(obj, buffer, ctx); !result.ok()) {
-      throw std::system_error(std::make_error_code(result.ec));
+    bool exceeded = false;
+    (void)pb_serializer::size_cache_counter<decltype(obj)>::count(obj, ctx, exceeded);
+    return exceeded;
+  }();
+  if constexpr (recursion_limit_exceeded) {
+    throw std::system_error(std::make_error_code(std::errc::bad_message));
+  } else {
+    constexpr auto sz = pb_serializer::message_size_calculator<decltype(obj)>::message_size(obj);
+    if constexpr (sz == 0) {
+      return std::span<std::byte>{};
+    } else {
+      pb_context<> ctx;
+      std::array<std::byte, sz> buffer = {};
+      if (auto result = pb_serializer::serialize(obj, buffer, ctx); !result.ok()) {
+        throw std::system_error(std::make_error_code(result.ec));
+      }
+      return buffer;
     }
-    return buffer;
   }
 }
 

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -29,6 +29,7 @@
 #include <hpp_proto/binpb/utf8.hpp>
 #include <hpp_proto/binpb/util.hpp>
 #include <hpp_proto/binpb/varint.hpp>
+#include <hpp_proto/recursion.hpp>
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 namespace hpp_proto {
@@ -711,8 +712,9 @@ constexpr status skip_fields_match_tag(uint32_t tag, concepts::is_basic_in auto 
 }
 
 constexpr status do_skip_group(uint32_t field_num, concepts::is_basic_in auto &archive) {
-  const util::recursion_guard guard{archive.context};
-  if (!guard.ok()) {
+  const detail::recursion_scope recursion_scope{archive.context.recursion_depth,
+                                                archive.context.get_max_recursion_depth()};
+  if (!recursion_scope.ok()) {
     return std::errc::value_too_large; // maximum recursion reached
   }
 
@@ -1301,8 +1303,9 @@ constexpr auto &get_unknown_fields(auto &item)
 constexpr std::monostate get_unknown_fields(auto & /*item*/) { return {}; }
 
 constexpr status deserialize_group(uint32_t field_num, auto &&item, concepts::is_basic_in auto &archive) {
-  const util::recursion_guard guard{archive.context};
-  if (!guard.ok()) {
+  const detail::recursion_scope recursion_scope{archive.context.recursion_depth,
+                                                archive.context.get_max_recursion_depth()};
+  if (!recursion_scope.ok()) {
     return std::errc::value_too_large; // maximum recursion reached
   }
 
@@ -1323,6 +1326,12 @@ constexpr status deserialize_group(uint32_t field_num, auto &&item, concepts::is
 }
 
 constexpr status deserialize(auto &&item, concepts::is_basic_in auto &archive) {
+  const detail::recursion_scope recursion_scope{archive.context.recursion_depth,
+                                                archive.context.get_max_recursion_depth()};
+  if (!recursion_scope.ok()) [[unlikely]] {
+    return std::errc::value_too_large;
+  }
+
   if constexpr (requires { item.is_map_entry(); }) {
     if (item.is_map_entry() && archive.in_avail() > 0) {
       // Map entries must start with field number 1 (the key), matching protobuf validation.
@@ -1350,18 +1359,10 @@ constexpr status deserialize_sized(auto &&item, concepts::is_basic_in auto &arch
   if (auto result = archive(len); !result.ok()) [[unlikely]] {
     return result;
   }
-  if (len == 0) [[unlikely]] {
-    if constexpr (requires { item.is_map_entry(); }) {
-      if (item.is_map_entry()) {
-        return std::errc::bad_message;
-      }
+  if constexpr (requires { item.is_map_entry(); }) {
+    if (len == 0 && item.is_map_entry()) [[unlikely]] {
+      return std::errc::bad_message;
     }
-    return {};
-  }
-
-  const util::recursion_guard guard{archive.context};
-  if (!guard.ok()) {
-    return std::errc::value_too_large; // maximum recursion reached
   }
 
   if (len < archive.in_avail()) [[likely]] {

--- a/include/hpp_proto/binpb/serialize.hpp
+++ b/include/hpp_proto/binpb/serialize.hpp
@@ -27,6 +27,7 @@
 #include <hpp_proto/binpb/utf8.hpp>
 #include <hpp_proto/binpb/util.hpp>
 #include <hpp_proto/binpb/varint.hpp>
+#include <hpp_proto/recursion.hpp>
 
 #include <limits>
 
@@ -211,36 +212,56 @@ struct size_cache_counter;
 
 template <concepts::has_meta T>
 struct size_cache_counter<T> {
-  constexpr static std::size_t count(concepts::has_meta auto const &item) {
+  constexpr static std::size_t count(concepts::has_meta auto const &item, concepts::is_pb_context auto &context,
+                                     bool &recursion_limit_exceeded) {
+    const detail::recursion_scope recursion_scope{context.recursion_depth, context.get_max_recursion_depth()};
+    if (!recursion_scope.ok()) [[unlikely]] {
+      recursion_limit_exceeded = true;
+      return 0;
+    }
+
     using type = std::remove_cvref_t<decltype(item)>;
     using meta_type = util::meta_of<type>::type;
     if constexpr (std::tuple_size_v<meta_type> == 0) {
       return 0;
     } else {
-      return std::apply(
-          [&item](auto &&...meta) constexpr {
-            return ((meta.omit_value(meta.get(item)) ? 0 : count(meta.get(item), meta)) + ...);
-          },
-          meta_type{});
+      return [&item, &context, &recursion_limit_exceeded]<std::size_t... I>(std::index_sequence<I...>) constexpr {
+        std::size_t result = 0;
+        ((result += std::tuple_element_t<I, meta_type>{}.omit_value(std::tuple_element_t<I, meta_type>{}.get(item))
+                        ? 0
+                        : count(std::tuple_element_t<I, meta_type>{}.get(item), std::tuple_element_t<I, meta_type>{},
+                                context, recursion_limit_exceeded)),
+         ...);
+        return result;
+      }(std::make_index_sequence<std::tuple_size_v<meta_type>>{});
     }
   }
 
   template <typename Meta>
-  constexpr static std::size_t count(concepts::oneof_type auto const &item, Meta /*meta*/) {
-    return count_oneof<0, typename Meta::alternatives_meta>(item);
+  constexpr static std::size_t count(concepts::oneof_type auto const &item, Meta /*meta*/,
+                                     concepts::is_pb_context auto &context, bool &recursion_limit_exceeded) {
+    return count_oneof<0, typename Meta::alternatives_meta>(item, context, recursion_limit_exceeded);
   }
 
-  constexpr static std::size_t count(concepts::dereferenceable auto const &item, auto meta) {
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    return count(*item, meta);
+  constexpr static std::size_t count(concepts::dereferenceable auto const &item, auto meta,
+                                     concepts::is_pb_context auto &context, bool &recursion_limit_exceeded) {
+    if constexpr (concepts::has_meta<std::remove_cvref_t<decltype(*item)>>) {
+      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+      return count(*item, context, recursion_limit_exceeded) + (!meta.is_delimited());
+    } else {
+      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+      return count(*item, meta, context, recursion_limit_exceeded);
+    }
   }
 
-  constexpr static std::size_t count(concepts::has_meta auto const &item, auto meta) {
-    return count(item) + (!meta.is_delimited());
+  constexpr static std::size_t count(concepts::has_meta auto const &item, auto meta,
+                                     concepts::is_pb_context auto &context, bool &recursion_limit_exceeded) {
+    return count(item, context, recursion_limit_exceeded) + (!meta.is_delimited());
   }
 
   template <typename Meta>
-  constexpr static std::size_t count(std::ranges::input_range auto const &item, Meta meta)
+  constexpr static std::size_t count(std::ranges::input_range auto const &item, Meta meta,
+                                     concepts::is_pb_context auto &context, bool &recursion_limit_exceeded)
     requires(!concepts::optional<std::remove_cvref_t<decltype(item)>>)
   {
     using type = std::remove_cvref_t<decltype(item)>;
@@ -249,7 +270,8 @@ struct size_cache_counter<T> {
     }
     using value_type = std::ranges::range_value_t<type>;
     if constexpr (concepts::has_meta<value_type> || !meta.is_packed() || meta.is_delimited()) {
-      return util::transform_accumulate(item, [](const auto &elem) constexpr { return count(elem, Meta{}); });
+      return util::transform_accumulate(
+          item, [&](const auto &elem) constexpr { return count(elem, Meta{}, context, recursion_limit_exceeded); });
     } else {
       using element_type =
           std::conditional_t<std::same_as<typename Meta::type, void> || concepts::contiguous_byte_range<type>,
@@ -264,30 +286,42 @@ struct size_cache_counter<T> {
   }
 
   template <typename Meta>
-  constexpr static std::size_t count(concepts::is_pair auto const &item, Meta /*meta*/) {
+  constexpr static std::size_t count(concepts::is_pair auto const &item, Meta /*meta*/,
+                                     concepts::is_pb_context auto &context, bool &recursion_limit_exceeded) {
+    const detail::recursion_scope recursion_scope{context.recursion_depth, context.get_max_recursion_depth()};
+    if (!recursion_scope.ok()) [[unlikely]] {
+      recursion_limit_exceeded = true;
+      return 0;
+    }
+
     using type = std::remove_cvref_t<decltype(item)>;
     using serialize_type = util::get_serialize_type<Meta, type>::type;
 
     static_assert(concepts::is_map_entry<serialize_type>);
     using mapped_type = serialize_type::mapped_type;
     if constexpr (requires { *item.second; }) {
-      return count(*item.second) + 2;
+      return count(*item.second, context, recursion_limit_exceeded) + 2;
     } else if constexpr (concepts::has_meta<mapped_type>) {
-      return count(item.second) + 2;
+      return count(item.second, context, recursion_limit_exceeded) + 2;
     } else {
       return 1;
     }
   }
 
-  constexpr static std::size_t count(concepts::no_cached_size auto const & /*item*/, auto /*meta*/) { return 0; }
+  constexpr static std::size_t count(concepts::no_cached_size auto const & /*item*/, auto /*meta*/,
+                                     concepts::is_pb_context auto & /*context*/, bool & /*recursion_limit_exceeded*/) {
+    return 0;
+  }
 
   template <std::size_t I, typename Meta>
-  constexpr static std::size_t count_oneof(auto const &item) {
+  constexpr static std::size_t count_oneof(auto const &item, concepts::is_pb_context auto &context,
+                                           bool &recursion_limit_exceeded) {
     if constexpr (I < std::tuple_size_v<Meta>) {
       if (I == item.index() - 1) {
-        return count(std::get<I + 1>(item), typename std::tuple_element_t<I, Meta>{});
+        return count(std::get<I + 1>(item), typename std::tuple_element_t<I, Meta>{}, context,
+                     recursion_limit_exceeded);
       }
-      return count_oneof<I + 1, Meta>(item);
+      return count_oneof<I + 1, Meta>(item, context, recursion_limit_exceeded);
     } else {
       return 0;
     }
@@ -546,7 +580,11 @@ template <bool overwrite_buffer = true, typename T, concepts::contiguous_byte_ra
 
 template <bool overwrite_buffer = true, typename T, concepts::contiguous_byte_range Buffer>
 constexpr status serialize(const T &item, Buffer &buffer, [[maybe_unused]] concepts::is_pb_context auto &context) {
-  const std::size_t n = size_cache_counter<T>::count(item);
+  bool recursion_limit_exceeded = false;
+  const std::size_t n = size_cache_counter<T>::count(item, context, recursion_limit_exceeded);
+  if (recursion_limit_exceeded) [[unlikely]] {
+    return std::errc::bad_message;
+  }
 
   if (std::is_constant_evaluated()) {
     std::vector<uint32_t> cache(n);
@@ -598,7 +636,11 @@ template <typename T, concepts::out_sink Sink, concepts::is_pb_context Context>
 
 template <typename T, concepts::out_sink Sink, concepts::is_pb_context Context>
 status serialize(const T &item, Sink &sink, Context &context) {
-  const std::size_t n = size_cache_counter<T>::count(item);
+  bool recursion_limit_exceeded = false;
+  const std::size_t n = size_cache_counter<T>::count(item, context, recursion_limit_exceeded);
+  if (recursion_limit_exceeded) [[unlikely]] {
+    return std::errc::bad_message;
+  }
 
   auto serialize_with_cache_resource = [&](std::pmr::memory_resource &cache_mr) -> status {
     std::pmr::vector<uint32_t> cache(n, &cache_mr);
@@ -632,6 +674,12 @@ status serialize(const T &item, Sink &sink, Context &context) {
 
 template <concepts::has_meta T>
 [[nodiscard]] constexpr bool serialize(const T &item, concepts::is_size_cache_iterator auto &cache_itr, auto &archive) {
+  const detail::recursion_scope recursion_scope{archive.context_.recursion_depth,
+                                                archive.context_.get_max_recursion_depth()};
+  if (!recursion_scope.ok()) [[unlikely]] {
+    return false;
+  }
+
   using type = std::remove_cvref_t<decltype(item)>;
   using metas = util::meta_of<type>::type;
   auto serialize_field_if_not_empty = [&](auto meta) {
@@ -692,17 +740,8 @@ template <typename Meta>
 template <concepts::dereferenceable T>
 [[nodiscard]] constexpr bool serialize_field(const T &item, auto meta, concepts::is_size_cache_iterator auto &cache_itr,
                                              auto &archive) {
-  if constexpr (concepts::optional_indirect_view<T> || concepts::indirect_view<T>) {
-    const util::recursion_guard guard{archive.context_};
-    if (!guard.ok()) {
-      return false; // recursion limit reached
-    }
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    return serialize_field(*item, meta, cache_itr, archive);
-  } else {
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    return serialize_field(*item, meta, cache_itr, archive);
-  }
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  return serialize_field(*item, meta, cache_itr, archive);
 }
 
 [[nodiscard]] constexpr bool serialize_field(concepts::has_meta auto const &item, auto meta,

--- a/include/hpp_proto/binpb/util.hpp
+++ b/include/hpp_proto/binpb/util.hpp
@@ -45,32 +45,4 @@ void append_range(T &v, const Range &range) {
   }
 }
 
-template <concepts::is_pb_context Context>
-class recursion_guard {
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  Context &ctx;
-  bool allowed = false;
-
-public:
-  explicit constexpr recursion_guard(Context &context) : ctx(context) {
-    if (ctx.recursion_depth < ctx.get_max_recursion_depth()) {
-      ctx.recursion_depth++;
-      allowed = true;
-    }
-  }
-
-  recursion_guard(const recursion_guard &) = delete;
-  recursion_guard &operator=(const recursion_guard &) = delete;
-  recursion_guard(recursion_guard &&) = delete;
-  recursion_guard &operator=(recursion_guard &&) = delete;
-
-  constexpr ~recursion_guard() {
-    if (allowed) {
-      ctx.recursion_depth--;
-    }
-  }
-
-  [[nodiscard]] constexpr bool ok() const { return allowed; }
-};
-
 } // namespace hpp_proto::util

--- a/include/hpp_proto/dynamic_message/binpb.hpp
+++ b/include/hpp_proto/dynamic_message/binpb.hpp
@@ -24,9 +24,9 @@ namespace hpp_proto {
 
 /// @brief Deserializes binary protobuf data into a dynamic message.
 /// @details The message is reset before parsing. The previous contents of @p msg are not preserved on parse failure.
-[[nodiscard]] status read_binpb(message_value_mref msg, auto &&buffer) {
+[[nodiscard]] status read_binpb(message_value_mref msg, auto &&buffer, concepts::is_option_type auto &&...option) {
   msg.reset();
-  auto context = pb_context{alloc_from(msg.memory_resource())};
+  auto context = pb_context{alloc_from(msg.memory_resource()), std::forward<decltype(option)>(option)...};
   return pb_serializer::deserialize(msg, std::forward<decltype(buffer)>(buffer), context);
 }
 
@@ -34,11 +34,12 @@ template <std::size_t N>
 /// @brief Deserializes binary protobuf data from a character array into a dynamic message.
 /// @details The previous contents of @p msg are not preserved on parse failure.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
-[[nodiscard]] status read_binpb(message_value_mref msg, const char (&buffer)[N]) {
+[[nodiscard]] status read_binpb(message_value_mref msg, const char (&buffer)[N],
+                                concepts::is_option_type auto &&...option) {
   constexpr auto span_size = N == 0 ? 0 : N - 1;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay,-warnings-as-errors)
   auto span = std::span<const char>{buffer, span_size};
-  return read_binpb(msg, span);
+  return read_binpb(msg, span, std::forward<decltype(option)>(option)...);
 }
 
 [[nodiscard]] status write_binpb(const message_value_cref &msg, concepts::contiguous_byte_range auto &buffer,

--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -9,59 +9,51 @@
 #include <hpp_proto/dynamic_message/factory.hpp>
 #include <hpp_proto/dynamic_message/field_visit.hpp>
 #include <hpp_proto/json.hpp>
+#include <hpp_proto/recursion.hpp>
 #include <iterator>
-#include <limits>
 
 namespace hpp_proto::detail {
 
-inline std::uint32_t &dynamic_json_recursion_depth() {
+inline std::uint32_t &direct_glaze_recursion_depth() {
   static thread_local std::uint32_t depth = 0;
   return depth;
 }
 
-class dynamic_json_recursion_guard {
-  std::uint32_t *depth_ = nullptr;
-  bool entered_ = false;
+template <typename Context>
+static std::uint32_t &dynamic_json_recursion_depth(Context &ctx) {
+  if constexpr (requires {
+                  { ctx.recursion_depth } -> std::same_as<std::uint32_t &>;
+                }) {
+    return ctx.recursion_depth;
+  } else {
+    return direct_glaze_recursion_depth();
+  }
+}
+
+template <typename Context>
+static std::uint32_t dynamic_json_max_recursion_depth(Context &ctx) {
+  if constexpr (requires {
+                  { ctx.get_max_recursion_depth() } -> std::same_as<std::uint32_t>;
+                }) {
+    return ctx.get_max_recursion_depth();
+  } else {
+    return default_max_recursion_depth;
+  }
+}
+
+class dynamic_json_recursion_scope {
+  recursion_scope scope_;
 
 public:
   template <typename Context>
-  explicit dynamic_json_recursion_guard(Context &ctx) {
-    std::uint32_t max_recursion_depth = default_max_recursion_depth;
-    if constexpr (requires {
-                    { ctx.get_max_recursion_depth() } -> std::same_as<std::uint32_t>;
-                  }) {
-      max_recursion_depth = ctx.get_max_recursion_depth();
-    }
-    if constexpr (requires {
-                    { ctx.recursion_depth } -> std::same_as<std::uint32_t &>;
-                  }) {
-      depth_ = &ctx.recursion_depth;
-    } else {
-      depth_ = &dynamic_json_recursion_depth();
-    }
-    // Match binary protobuf recursion semantics: the root message does not consume the budget.
-    // The saturation check also protects direct Glaze callers with a custom context that bypasses
-    // recursion_limit_t's compile-time validation.
-    if (*depth_ > max_recursion_depth || *depth_ == std::numeric_limits<std::uint32_t>::max()) [[unlikely]] {
+  explicit dynamic_json_recursion_scope(Context &ctx)
+      : scope_{dynamic_json_recursion_depth(ctx), dynamic_json_max_recursion_depth(ctx)} {
+    if (!scope_.ok()) [[unlikely]] {
       ctx.error = glz::error_code::exceeded_max_recursive_depth;
-      return;
-    }
-    ++*depth_;
-    entered_ = true;
-  }
-
-  dynamic_json_recursion_guard(const dynamic_json_recursion_guard &) = delete;
-  dynamic_json_recursion_guard &operator=(const dynamic_json_recursion_guard &) = delete;
-  dynamic_json_recursion_guard(dynamic_json_recursion_guard &&) = delete;
-  dynamic_json_recursion_guard &operator=(dynamic_json_recursion_guard &&) = delete;
-
-  ~dynamic_json_recursion_guard() {
-    if (entered_) {
-      --*depth_;
     }
   }
 
-  [[nodiscard]] bool ok() const { return entered_; }
+  [[nodiscard]] bool ok() const { return scope_.ok(); }
 };
 
 } // namespace hpp_proto::detail
@@ -684,8 +676,8 @@ struct to<JSON, hpp_proto::message_value_cref> {
   template <auto Opts>
   GLZ_ALWAYS_INLINE static void op(const hpp_proto::message_value_cref &value, is_context auto &ctx, auto &b,
                                    auto &ix) {
-    const ::hpp_proto::detail::dynamic_json_recursion_guard recursion_guard{ctx};
-    if (!recursion_guard.ok()) [[unlikely]] {
+    const ::hpp_proto::detail::dynamic_json_recursion_scope recursion_scope{ctx};
+    if (!recursion_scope.ok()) [[unlikely]] {
       return;
     }
     using enum hpp_proto::wellknown_types_t;
@@ -915,8 +907,8 @@ struct from<JSON, hpp_proto::message_value_mref> {
   template <auto Opts>
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   GLZ_ALWAYS_INLINE static void op(auto &&value, is_context auto &ctx, auto &it, auto &end) {
-    const ::hpp_proto::detail::dynamic_json_recursion_guard recursion_guard{ctx};
-    if (!recursion_guard.ok()) [[unlikely]] {
+    const ::hpp_proto::detail::dynamic_json_recursion_scope recursion_scope{ctx};
+    if (!recursion_scope.ok()) [[unlikely]] {
       return;
     }
     if (value.descriptor().is_map_entry()) {
@@ -979,7 +971,9 @@ struct from<JSON, T> {
 template <auto Opts>
 static std::expected<bool, const char *> message_to_json(::hpp_proto::message_value_mref message, const auto &any_value,
                                                          is_context auto &ctx, auto &b, auto &ix) {
-  if (hpp_proto::read_binpb(message, any_value).ok()) {
+  const auto recursion_limit =
+      ::hpp_proto::detail::runtime_recursion_limit{::hpp_proto::detail::dynamic_json_max_recursion_depth(ctx)};
+  if (hpp_proto::read_binpb(message, any_value, recursion_limit).ok()) {
     const auto pre_ix = ix;
     to<JSON, hpp_proto::message_value_cref>::template op<Opts>(message, ctx, b, ix);
     if (bool(ctx.error)) [[unlikely]] {
@@ -1122,11 +1116,13 @@ void any_message_json_serializer::from_json_impl(auto &&build_message, auto &&an
           if (message.descriptor().wellknown != ::hpp_proto::wellknown_types_t::NONE) {
             return parse_wellknown_any_value<Opts>(message, ctx, it, end);
           }
-          const ::hpp_proto::detail::dynamic_json_recursion_guard recursion_guard{ctx};
-          return recursion_guard.ok() && parse_generic_any_value<opening_handled<Opts>()>(message, ctx, it, end);
+          const ::hpp_proto::detail::dynamic_json_recursion_scope recursion_scope{ctx};
+          return recursion_scope.ok() && parse_generic_any_value<opening_handled<Opts>()>(message, ctx, it, end);
         }();
 
-        if (ok && !hpp_proto::write_binpb(message, any_value).ok()) {
+        const auto recursion_limit =
+            ::hpp_proto::detail::runtime_recursion_limit{::hpp_proto::detail::dynamic_json_max_recursion_depth(ctx)};
+        if (ok && !hpp_proto::write_binpb(message, any_value, recursion_limit).ok()) {
           return std::unexpected("unable to serialize the value for google.protobuf.Any message");
         }
         return {};

--- a/include/hpp_proto/dynamic_message/json.hpp
+++ b/include/hpp_proto/dynamic_message/json.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <google/protobuf/duration.glz.hpp>
 #include <google/protobuf/field_mask.glz.hpp>
 #include <google/protobuf/struct.msg.hpp>
@@ -9,6 +10,61 @@
 #include <hpp_proto/dynamic_message/field_visit.hpp>
 #include <hpp_proto/json.hpp>
 #include <iterator>
+#include <limits>
+
+namespace hpp_proto::detail {
+
+inline std::uint32_t &dynamic_json_recursion_depth() {
+  static thread_local std::uint32_t depth = 0;
+  return depth;
+}
+
+class dynamic_json_recursion_guard {
+  std::uint32_t *depth_ = nullptr;
+  bool entered_ = false;
+
+public:
+  template <typename Context>
+  explicit dynamic_json_recursion_guard(Context &ctx) {
+    std::uint32_t max_recursion_depth = default_max_recursion_depth;
+    if constexpr (requires {
+                    { ctx.get_max_recursion_depth() } -> std::same_as<std::uint32_t>;
+                  }) {
+      max_recursion_depth = ctx.get_max_recursion_depth();
+    }
+    if constexpr (requires {
+                    { ctx.recursion_depth } -> std::same_as<std::uint32_t &>;
+                  }) {
+      depth_ = &ctx.recursion_depth;
+    } else {
+      depth_ = &dynamic_json_recursion_depth();
+    }
+    // Match binary protobuf recursion semantics: the root message does not consume the budget.
+    // The saturation check also protects direct Glaze callers with a custom context that bypasses
+    // recursion_limit_t's compile-time validation.
+    if (*depth_ > max_recursion_depth || *depth_ == std::numeric_limits<std::uint32_t>::max()) [[unlikely]] {
+      ctx.error = glz::error_code::exceeded_max_recursive_depth;
+      return;
+    }
+    ++*depth_;
+    entered_ = true;
+  }
+
+  dynamic_json_recursion_guard(const dynamic_json_recursion_guard &) = delete;
+  dynamic_json_recursion_guard &operator=(const dynamic_json_recursion_guard &) = delete;
+  dynamic_json_recursion_guard(dynamic_json_recursion_guard &&) = delete;
+  dynamic_json_recursion_guard &operator=(dynamic_json_recursion_guard &&) = delete;
+
+  ~dynamic_json_recursion_guard() {
+    if (entered_) {
+      --*depth_;
+    }
+  }
+
+  [[nodiscard]] bool ok() const { return entered_; }
+};
+
+} // namespace hpp_proto::detail
 
 namespace glz {
 namespace concepts {
@@ -628,6 +684,10 @@ struct to<JSON, hpp_proto::message_value_cref> {
   template <auto Opts>
   GLZ_ALWAYS_INLINE static void op(const hpp_proto::message_value_cref &value, is_context auto &ctx, auto &b,
                                    auto &ix) {
+    const ::hpp_proto::detail::dynamic_json_recursion_guard recursion_guard{ctx};
+    if (!recursion_guard.ok()) [[unlikely]] {
+      return;
+    }
     using enum hpp_proto::wellknown_types_t;
     switch (value.descriptor().wellknown) {
     case ANY:
@@ -855,6 +915,10 @@ struct from<JSON, hpp_proto::message_value_mref> {
   template <auto Opts>
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   GLZ_ALWAYS_INLINE static void op(auto &&value, is_context auto &ctx, auto &it, auto &end) {
+    const ::hpp_proto::detail::dynamic_json_recursion_guard recursion_guard{ctx};
+    if (!recursion_guard.ok()) [[unlikely]] {
+      return;
+    }
     if (value.descriptor().is_map_entry()) {
       value.fields()[0].visit([&](auto key_mref) {
         using key_mref_type = decltype(key_mref);
@@ -1054,9 +1118,13 @@ void any_message_json_serializer::from_json_impl(auto &&build_message, auto &&an
   (void)get_type_url<Opts>(any_type_url, ctx, it, end)
       .and_then([&](std::string_view type_url) { return to_message_name(type_url).and_then(build_message); })
       .and_then([&](auto message) -> std::expected<void, const char *> {
-        const bool ok = message.descriptor().wellknown != ::hpp_proto::wellknown_types_t::NONE
-                            ? parse_wellknown_any_value<Opts>(message, ctx, it, end)
-                            : parse_generic_any_value<opening_handled<Opts>()>(message, ctx, it, end);
+        const bool ok = [&] {
+          if (message.descriptor().wellknown != ::hpp_proto::wellknown_types_t::NONE) {
+            return parse_wellknown_any_value<Opts>(message, ctx, it, end);
+          }
+          const ::hpp_proto::detail::dynamic_json_recursion_guard recursion_guard{ctx};
+          return recursion_guard.ok() && parse_generic_any_value<opening_handled<Opts>()>(message, ctx, it, end);
+        }();
 
         if (ok && !hpp_proto::write_binpb(message, any_value).ok()) {
           return std::unexpected("unable to serialize the value for google.protobuf.Any message");

--- a/include/hpp_proto/dynamic_message/pb_serializer_ext.hpp
+++ b/include/hpp_proto/dynamic_message/pb_serializer_ext.hpp
@@ -352,33 +352,53 @@ status deserialize_field_by_tag(uint32_t tag, message_value_mref item, concepts:
 
 template <>
 struct size_cache_counter<message_value_cref> {
-  constexpr std::size_t operator()(auto /*f*/) const { return 0; }
+  template <concepts::is_pb_context Context>
+  struct field_visitor {
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+    Context &context;
+    bool &recursion_limit_exceeded;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
-  template <concepts::varint T, field_kind_t Kind>
-  std::size_t operator()(repeated_scalar_field_cref<T, Kind> f) const {
-    return static_cast<std::size_t>(f.descriptor().is_packed());
-  }
+    constexpr std::size_t operator()(auto /*f*/) const { return 0; }
 
-  template <typename T, field_kind_t Kind>
-  std::size_t operator()(repeated_scalar_field_cref<T, Kind> /*f*/) const {
-    return 0;
-  }
+    template <concepts::varint T, field_kind_t Kind>
+    std::size_t operator()(repeated_scalar_field_cref<T, Kind> f) const {
+      return static_cast<std::size_t>(f.descriptor().is_packed());
+    }
 
-  std::size_t operator()(repeated_enum_field_cref f) const { return f.descriptor().is_packed() ? 1 : 0; }
+    template <typename T, field_kind_t Kind>
+    std::size_t operator()(repeated_scalar_field_cref<T, Kind> /*f*/) const {
+      return 0;
+    }
 
-  static std::size_t count(message_value_cref f) {
+    std::size_t operator()(repeated_enum_field_cref f) const { return f.descriptor().is_packed() ? 1 : 0; }
+
+    std::size_t operator()(message_field_cref f) const {
+      return count(*f, context, recursion_limit_exceeded) + (f.descriptor().is_delimited() ? 0 : 1);
+    }
+
+    std::size_t operator()(repeated_message_field_cref f) const {
+      return util::transform_accumulate(
+                 f, [&](message_value_cref element) { return count(element, context, recursion_limit_exceeded); }) +
+             (f.descriptor().is_delimited() ? 0 : f.size());
+    }
+  };
+
+  static std::size_t count(message_value_cref f, concepts::is_pb_context auto &context,
+                           bool &recursion_limit_exceeded) {
+    const detail::recursion_scope recursion_scope{context.recursion_depth, context.get_max_recursion_depth()};
+    if (!recursion_scope.ok()) [[unlikely]] {
+      recursion_limit_exceeded = true;
+      return 0;
+    }
+
     auto fields = f.fields();
-    return util::transform_accumulate(fields, [](field_cref nested_field) {
-      return is_present_or_explicit_default(nested_field) ? nested_field.visit(size_cache_counter<message_value_cref>{})
-                                                          : 0;
+    return util::transform_accumulate(fields, [&](field_cref nested_field) {
+      return is_present_or_explicit_default(nested_field)
+                 ? nested_field.visit(
+                       field_visitor<std::remove_reference_t<decltype(context)>>{context, recursion_limit_exceeded})
+                 : 0;
     });
-  }
-
-  std::size_t operator()(message_field_cref f) const { return count(*f) + (f.descriptor().is_delimited() ? 0 : 1); }
-
-  std::size_t operator()(repeated_message_field_cref f) const {
-    return util::transform_accumulate(f, [](message_value_cref element) { return count(element); }) +
-           (f.descriptor().is_delimited() ? 0 : f.size());
   }
 };
 
@@ -609,6 +629,11 @@ struct field_serializer {
   }
 
   bool operator()(message_value_cref item) {
+    const detail::recursion_scope recursion_scope{archive.context_.recursion_depth,
+                                                  archive.context_.get_max_recursion_depth()};
+    if (!recursion_scope.ok()) [[unlikely]] {
+      return false;
+    }
     return std::ranges::all_of(item.fields(),
                                [&](field_cref f) { return !is_present_or_explicit_default(f) || f.visit(*this); });
   }

--- a/include/hpp_proto/memory_resource_utils.hpp
+++ b/include/hpp_proto/memory_resource_utils.hpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <functional>
 #include <hpp_proto/field_types.hpp>
+#include <hpp_proto/recursion.hpp>
 #include <memory_resource>
 #include <ranges>
 #include <span>
@@ -108,7 +109,6 @@ public:
 };
 
 inline constexpr std::size_t default_stack_buffer_size = 1024;
-inline constexpr uint32_t default_max_recursion_depth = 100;
 
 template <std::size_t StackBufferSize = default_stack_buffer_size>
 class default_cache_memory_resource {

--- a/include/hpp_proto/recursion.hpp
+++ b/include/hpp_proto/recursion.hpp
@@ -1,0 +1,84 @@
+// MIT License
+//
+// Copyright (c) Huang-Ming Huang
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace hpp_proto {
+
+inline constexpr std::uint32_t default_max_recursion_depth = 100;
+
+/// Limit nested message recursion for binary protobuf and dynamic-message JSON operations.
+/// The root message does not consume the recursion budget.
+/// UINT32_MAX is reserved so the internal recursion counter cannot wrap.
+template <std::uint32_t N>
+struct recursion_limit_t {
+  // Parentheses protect against Windows headers defining max as a function-like macro.
+  // NOLINTNEXTLINE(readability-redundant-parentheses)
+  static_assert(N < (std::numeric_limits<std::uint32_t>::max)(), "recursion limit must be less than UINT32_MAX");
+  using option_type = recursion_limit_t<N>;
+  static constexpr std::uint32_t max_recursion_depth = N;
+};
+
+template <std::uint32_t N>
+constexpr auto recursion_limit = recursion_limit_t<N>{};
+
+namespace detail {
+
+struct runtime_recursion_limit {
+  using option_type = runtime_recursion_limit;
+  std::uint32_t max_recursion_depth;
+};
+
+/// Tracks one active recursive message/group scope. active_depth includes the root scope;
+/// max_nested_depth controls how many additional scopes may be entered below it.
+class recursion_scope {
+  std::uint32_t *active_depth_ = nullptr;
+
+public:
+  explicit constexpr recursion_scope(std::uint32_t &active_depth, std::uint32_t max_nested_depth) noexcept {
+    // Parentheses protect against Windows headers defining max as a function-like macro.
+    // NOLINTNEXTLINE(readability-redundant-parentheses)
+    if (active_depth <= max_nested_depth && active_depth != (std::numeric_limits<std::uint32_t>::max)()) [[likely]] {
+      ++active_depth;
+      active_depth_ = &active_depth;
+    }
+  }
+
+  recursion_scope(const recursion_scope &) = delete;
+  recursion_scope &operator=(const recursion_scope &) = delete;
+  recursion_scope(recursion_scope &&) = delete;
+  recursion_scope &operator=(recursion_scope &&) = delete;
+
+  constexpr ~recursion_scope() {
+    if (active_depth_ != nullptr) {
+      --*active_depth_;
+    }
+  }
+
+  [[nodiscard]] constexpr bool ok() const noexcept { return active_depth_ != nullptr; }
+};
+
+} // namespace detail
+} // namespace hpp_proto

--- a/tests/any_test.cpp
+++ b/tests/any_test.cpp
@@ -149,6 +149,47 @@ const suite test_dynamic_message_any = [] {
     expect(hpp_proto::write_json(accepted.cref(), output, hpp_proto::recursion_limit<2>).ok());
   };
 
+  "any_binary_conversion_uses_json_recursion_limit"_test = [&] {
+    constexpr auto nested_messages = hpp_proto::default_max_recursion_depth + 1;
+    std::string recursive_json;
+    for (std::uint32_t i = 0; i < nested_messages; ++i) {
+      recursive_json += R"({"child":)";
+    }
+    recursive_json += "{}";
+    recursive_json.append(nested_messages, '}');
+
+    std::pmr::monotonic_buffer_resource recursive_mr;
+    auto recursive = expect_ok(message_factory.get_message("proto3_unittest.NestedTestAllTypes", recursive_mr));
+    auto dynamic_read = hpp_proto::read_json(recursive, recursive_json, hpp_proto::recursion_limit<nested_messages>);
+    expect(dynamic_read.ok()) << "build recursive dynamic message";
+
+    std::vector<std::byte> payload;
+    auto dynamic_write = hpp_proto::write_binpb(recursive.cref(), payload, hpp_proto::recursion_limit<nested_messages>);
+    expect(dynamic_write.ok()) << "encode recursive Any payload";
+
+    ::protobuf_unittest::TestAny<> source;
+    source.any_value.emplace().type_url = "type.googleapis.com/proto3_unittest.NestedTestAllTypes";
+    source.any_value->value = payload;
+
+    std::string output;
+    auto any_write = hpp_proto::write_json(source, output, hpp_proto::use_factory{message_factory},
+                                           hpp_proto::recursion_limit<nested_messages>);
+    expect(any_write.ok()) << "decode recursive binary payload while writing Any JSON";
+
+    // Build canonical generic-Any JSON directly so the reverse direction independently exercises
+    // the JSON-to-binary adapter with the same non-default recursion policy.
+    std::string json = R"({"anyValue":{"@type":"type.googleapis.com/proto3_unittest.NestedTestAllTypes",)";
+    json += std::string_view{recursive_json}.substr(1);
+    json += '}';
+
+    ::protobuf_unittest::TestAny<> parsed;
+    auto any_read = hpp_proto::read_json(parsed, json, hpp_proto::use_factory{message_factory},
+                                         hpp_proto::recursion_limit<nested_messages>);
+    expect(any_read.ok()) << "encode recursive binary payload while reading Any JSON: "
+                          << glz::format_error(any_read.ctx, json);
+    expect(parsed == source);
+  };
+
   "any_json_edge_cases"_test = [&] {
     auto expect_read_fail = [&](std::string_view json) {
       ::protobuf_unittest::TestAny<> message;

--- a/tests/any_test.cpp
+++ b/tests/any_test.cpp
@@ -126,6 +126,29 @@ const suite test_dynamic_message_any = [] {
 
   auto message_factory = expect_ok(::hpp_proto::dynamic_message_factory::create(protos));
 
+  "dynamic_any_respects_recursion_limit"_test = [&] {
+    constexpr std::string_view json =
+        R"({"anyValue":{"@type":"type.googleapis.com/protobuf_unittest.TestAny","int32Value":1}})";
+
+    std::pmr::monotonic_buffer_resource accepted_mr;
+    auto accepted = expect_ok(message_factory.get_message("protobuf_unittest.TestAny", accepted_mr));
+    expect(hpp_proto::read_json(accepted, json, hpp_proto::recursion_limit<2>).ok());
+
+    std::pmr::monotonic_buffer_resource rejected_mr;
+    auto rejected = expect_ok(message_factory.get_message("protobuf_unittest.TestAny", rejected_mr));
+    auto read_status = hpp_proto::read_json(rejected, json, hpp_proto::recursion_limit<1>);
+    expect(!read_status.ok());
+    expect(read_status.ctx.ec == glz::error_code::exceeded_max_recursive_depth);
+
+    std::string output;
+    auto write_status = hpp_proto::write_json(accepted.cref(), output, hpp_proto::recursion_limit<1>);
+    expect(!write_status.ok());
+    expect(write_status.ctx.ec == glz::error_code::exceeded_max_recursive_depth);
+
+    output.clear();
+    expect(hpp_proto::write_json(accepted.cref(), output, hpp_proto::recursion_limit<2>).ok());
+  };
+
   "any_json_edge_cases"_test = [&] {
     auto expect_read_fail = [&](std::string_view json) {
       ::protobuf_unittest::TestAny<> message;

--- a/tests/dynamic_message_test.cpp
+++ b/tests/dynamic_message_test.cpp
@@ -24,6 +24,85 @@ decltype(auto) expect_ok(Exp &&exp) {
   return std::forward<Exp>(exp).value(); // NOLINT(bugprone-unchecked-optional-access)
 }
 
+std::string make_recursive_message_json(std::size_t nested_messages) {
+  std::string json;
+  for (std::size_t i = 0; i < nested_messages; ++i) {
+    json += R"({"a":)";
+  }
+  json += R"({"i":1})";
+  json.append(nested_messages, '}');
+  return json;
+}
+
+const boost::ut::suite dynamic_message_json_recursion_limit_tests = [] {
+  "read_respects_recursion_limit"_test = [] {
+    auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb")));
+
+    std::pmr::monotonic_buffer_resource flat_mr;
+    auto flat = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", flat_mr));
+    expect(hpp_proto::read_json(flat, make_recursive_message_json(0), hpp_proto::recursion_limit<0>).ok());
+
+    std::pmr::monotonic_buffer_resource shallow_mr;
+    auto shallow = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", shallow_mr));
+    expect(hpp_proto::read_json(shallow, make_recursive_message_json(1), hpp_proto::recursion_limit<1>).ok());
+
+    std::pmr::monotonic_buffer_resource deep_mr;
+    auto deep = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", deep_mr));
+    auto status = hpp_proto::read_json(deep, make_recursive_message_json(2), hpp_proto::recursion_limit<1>);
+    expect(!status.ok());
+    expect(status.ctx.ec == glz::error_code::exceeded_max_recursive_depth);
+  };
+
+  "write_respects_recursion_limit"_test = [] {
+    auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb")));
+    std::pmr::monotonic_buffer_resource mr;
+    auto message = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", mr));
+    expect(hpp_proto::read_json(message, make_recursive_message_json(2), hpp_proto::recursion_limit<2>).ok());
+
+    std::string json;
+    auto status = hpp_proto::write_json(message.cref(), json, hpp_proto::recursion_limit<1>);
+    expect(!status.ok());
+    expect(status.ctx.ec == glz::error_code::exceeded_max_recursive_depth);
+
+    json.clear();
+    expect(hpp_proto::write_json(message.cref(), json, hpp_proto::recursion_limit<2>).ok());
+  };
+
+  "direct_glaze_entry_points_use_default_recursion_limit"_test = [] {
+    auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb")));
+    const auto at_limit_json = make_recursive_message_json(hpp_proto::default_max_recursion_depth);
+    const auto over_limit_json = make_recursive_message_json(hpp_proto::default_max_recursion_depth + 1);
+
+    std::pmr::monotonic_buffer_resource accepted_mr;
+    auto accepted = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", accepted_mr));
+    expect(!glz::read_json(accepted, at_limit_json));
+
+    std::pmr::monotonic_buffer_resource rejected_mr;
+    auto rejected = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", rejected_mr));
+    auto read_error = glz::read_json(rejected, over_limit_json);
+    expect(read_error.ec == glz::error_code::exceeded_max_recursive_depth);
+
+    std::pmr::monotonic_buffer_resource recovered_mr;
+    auto recovered = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", recovered_mr));
+    expect(!glz::read_json(recovered, at_limit_json));
+
+    std::string output;
+    expect(!glz::write_json(accepted.cref(), output));
+
+    std::pmr::monotonic_buffer_resource write_rejected_mr;
+    auto write_rejected = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", write_rejected_mr));
+    expect(hpp_proto::read_json(write_rejected, over_limit_json,
+                                hpp_proto::recursion_limit<hpp_proto::default_max_recursion_depth + 1>)
+               .ok());
+    output.clear();
+    auto write_error = glz::write_json(write_rejected.cref(), output);
+    expect(write_error.ec == glz::error_code::exceeded_max_recursive_depth);
+
+    output.clear();
+    expect(!glz::write_json(accepted.cref(), output));
+  };
+};
+
 const boost::ut::suite dynamic_message_json_iterator_safety_tests = [] {
   "value_from_json_ws_handled_end_iterator_regression"_test = [] {
     auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb")));

--- a/tests/dynamic_message_test.cpp
+++ b/tests/dynamic_message_test.cpp
@@ -103,6 +103,31 @@ const boost::ut::suite dynamic_message_json_recursion_limit_tests = [] {
   };
 };
 
+const boost::ut::suite dynamic_message_binary_recursion_limit_tests = [] {
+  "write_uses_shared_recursion_counter"_test = [] {
+    auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb")));
+    std::pmr::monotonic_buffer_resource mr;
+    auto message = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", mr));
+    expect(hpp_proto::read_json(message, make_recursive_message_json(2), hpp_proto::recursion_limit<2>).ok());
+
+    std::vector<std::byte> output;
+    auto status = hpp_proto::write_binpb(message.cref(), output, hpp_proto::recursion_limit<1>);
+    expect(!status.ok());
+    expect(status.ec == std::errc::bad_message);
+    expect(hpp_proto::write_binpb(message.cref(), output, hpp_proto::recursion_limit<2>).ok());
+
+    std::pmr::monotonic_buffer_resource rejected_mr;
+    auto rejected = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", rejected_mr));
+    auto read_status = hpp_proto::read_binpb(rejected, output, hpp_proto::recursion_limit<1>);
+    expect(!read_status.ok());
+    expect(read_status.ec == std::errc::value_too_large);
+
+    std::pmr::monotonic_buffer_resource accepted_mr;
+    auto accepted = expect_ok(factory.get_message("protobuf_unittest.TestRecursiveMessage", accepted_mr));
+    expect(hpp_proto::read_binpb(accepted, output, hpp_proto::recursion_limit<2>).ok());
+  };
+};
+
 const boost::ut::suite dynamic_message_json_iterator_safety_tests = [] {
   "value_from_json_ws_handled_end_iterator_regression"_test = [] {
     auto factory = expect_ok(hpp_proto::dynamic_message_factory::create(read_file("unittest.desc.binpb")));

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1687,6 +1687,15 @@ auto pb_meta(const recursive_type1<Traits> &)
     -> std::tuple<hpp_proto::field_meta<1, &recursive_type1<Traits>::child>,
                   hpp_proto::field_meta<2, &recursive_type1<Traits>::payload, field_option::none, hpp_proto::vint64_t>>;
 
+inline constexpr recursive_type1<hpp_proto::non_owning_traits> constexpr_recursive_cycle{&constexpr_recursive_cycle, 1};
+static_assert([] {
+  hpp_proto::pb_context<> context;
+  bool recursion_limit_exceeded = false;
+  (void)hpp_proto::pb_serializer::size_cache_counter<decltype(constexpr_recursive_cycle)>::count(
+      constexpr_recursive_cycle, context, recursion_limit_exceeded);
+  return recursion_limit_exceeded;
+}());
+
 template <typename Traits>
 struct recursive_type2 {
   Traits::template repeated_t<recursive_type2<Traits>> children;
@@ -1759,6 +1768,62 @@ recursive_type1<Traits> make_recursive_chain(uint32_t depth) {
 
 const ut::suite recursion_limit_tests = [] {
   using namespace boost::ut;
+
+  "shared_recursion_counter_owns_root_and_nested_depth"_test = [] {
+    std::uint32_t active_depth = 0;
+    ut::expect(active_depth == 0U);
+
+    {
+      const hpp_proto::detail::recursion_scope root{active_depth, 1};
+      ut::expect(root.ok());
+      ut::expect(active_depth == 1U);
+
+      const hpp_proto::detail::recursion_scope nested{active_depth, 1};
+      ut::expect(nested.ok());
+      ut::expect(active_depth == 2U);
+
+      const hpp_proto::detail::recursion_scope rejected{active_depth, 1};
+      ut::expect(!rejected.ok());
+      ut::expect(active_depth == 2U);
+    }
+
+    ut::expect(active_depth == 0U);
+    const hpp_proto::detail::recursion_scope recovered_root{active_depth, 0};
+    ut::expect(recovered_root.ok());
+  };
+
+  "custom_pb_context_keeps_recursion_depth_adapter_contract"_test = [] {
+    struct custom_context {
+      using is_pb_context = void;
+      std::uint32_t recursion_depth = 0;
+      [[nodiscard]] constexpr std::uint32_t get_max_recursion_depth() const { return 0; }
+    } context;
+
+    std::vector<std::byte> buffer;
+    ut::expect(hpp_proto::write_binpb(empty{}, buffer, context).ok());
+
+    empty value;
+    ut::expect(hpp_proto::read_binpb(value, buffer, context).ok());
+  };
+
+  "binary_root_is_free_and_empty_nested_messages_consume_depth"_test = [] {
+    std::vector<std::byte> buffer;
+    ut::expect(hpp_proto::write_binpb(empty{}, buffer, hpp_proto::recursion_limit<0>).ok());
+
+    empty flat;
+    ut::expect(hpp_proto::read_binpb(flat, buffer, hpp_proto::recursion_limit<0>).ok());
+
+    nested_example nested{.nested = example{}};
+    auto write_status = hpp_proto::write_binpb(nested, buffer, hpp_proto::recursion_limit<0>);
+    ut::expect(!write_status.ok());
+    ut::expect(write_status.ec == std::errc::bad_message);
+
+    constexpr auto empty_nested = "\x0a\x00"sv;
+    auto read_status = hpp_proto::read_binpb(nested, empty_nested, hpp_proto::recursion_limit<0>);
+    ut::expect(!read_status.ok());
+    ut::expect(read_status.ec == std::errc::value_too_large);
+  };
+
   "serialize_respects_recursion_limit"_test = [] {
     std::array<recursive_type1<hpp_proto::non_owning_traits>, 3> nodes{};
     nodes[0].payload = 3;
@@ -1772,6 +1837,32 @@ const ut::suite recursion_limit_tests = [] {
     auto status = hpp_proto::write_binpb(nodes[0], buffer, hpp_proto::recursion_limit<1>);
     ut::expect(!status.ok());
     ut::expect(status.ec == std::errc::bad_message);
+  };
+
+  "serialize_rejects_cycles_before_sizing_or_allocation"_test = [] {
+    recursive_type1<hpp_proto::non_owning_traits> value;
+    value.child = &value;
+    value.payload = 1;
+    std::vector<std::byte> buffer(3);
+
+    auto status = hpp_proto::write_binpb(value, buffer, hpp_proto::recursion_limit<1>);
+    ut::expect(!status.ok());
+    ut::expect(status.ec == std::errc::bad_message);
+    ut::expect(buffer.size() == 3U);
+  };
+
+  "serialize_repeated_messages_respects_recursion_limit"_test = [] {
+    using message_type = recursive_type2<hpp_proto::non_owning_traits>;
+    std::array<message_type, 1> grandchildren{};
+    std::array<message_type, 1> children{};
+    children[0].children = grandchildren;
+    message_type root{.children = children};
+    std::vector<std::byte> buffer;
+
+    auto status = hpp_proto::write_binpb(root, buffer, hpp_proto::recursion_limit<1>);
+    ut::expect(!status.ok());
+    ut::expect(status.ec == std::errc::bad_message);
+    ut::expect(hpp_proto::write_binpb(root, buffer, hpp_proto::recursion_limit<2>).ok());
   };
 
   "deserialize_respects_recursion_limit"_test = [] {
@@ -1793,6 +1884,16 @@ const ut::suite recursion_limit_tests = [] {
     ut::expect(!status.ok());
     ut::expect(status.ec == std::errc::value_too_large);
     ut::expect(hpp_proto::read_binpb(out, buffer, hpp_proto::recursion_limit<2>).ok());
+  };
+
+  "serialize_groups_respects_recursion_limit"_test = [] {
+    doubly_nested_group value;
+    std::vector<std::byte> buffer;
+
+    auto status = hpp_proto::write_binpb(value, buffer, hpp_proto::recursion_limit<1>);
+    ut::expect(!status.ok());
+    ut::expect(status.ec == std::errc::bad_message);
+    ut::expect(hpp_proto::write_binpb(value, buffer, hpp_proto::recursion_limit<2>).ok());
   };
 
   "skipped_groups_respect_recursion_limit"_test = [] {


### PR DESCRIPTION
## Summary

Centralize protobuf recursion-counter semantics and enforce the same nesting policy across binary protobuf, dynamic-message JSON, direct Glaze entry points, group parsing, and `google.protobuf.Any` conversions.

## What changed

- Add a small shared recursion Module that owns the default limit, validated `recursion_limit<N>` option, runtime limit propagation, and overflow-safe RAII scope semantics.
- Adapt binary reads, binary writes, known and skipped groups, dynamic JSON, and direct Glaze traversal to translate recursion rejection into their format-specific errors.
- Make binary serialization reject excessive depth and cyclic non-owning graphs during its existing size-cache pass, before message sizing or output allocation, without adding another object traversal.
- Make compile-time serialization run a constexpr-safe recursion preflight before recursive size calculation.
- Propagate configured limits through dynamic binary reads/writes used by generic `google.protobuf.Any` JSON conversion.
- Preserve the public `pb_context::recursion_depth` contract for programmatically supplied contexts.
- Update the JSON fuzz status oracle to recognize the dynamic parser's intentional recursion-limit rejection.
- Add coverage for boundary semantics, recovery after rejection, empty nested messages, repeated messages, groups, skipped groups, cycles, custom contexts, dynamic binary options, configured `Any` limits, and constexpr cycles.

## Why

Recursion depth was previously owned by separate binary and dynamic-JSON implementations, leaving inconsistent coverage and error behavior. Some write paths could recurse during sizing before reaching a guard, while nested dynamic binary conversions inside `Any` could lose the caller's configured limit. A single policy Module keeps the nesting semantics consistent while leaving wire/JSON error translation in each Adapter.
