### PR TITLE
Harden CI trust paths

### DIFF
--- a/.clusterfuzzlite/migrate-storage.sh
+++ b/.clusterfuzzlite/migrate-storage.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly source_repository="${CFL_STORAGE_SOURCE_REPOSITORY:-huangminghuang/hpp-proto-storage}"
+readonly destination_repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+readonly github_token="${GITHUB_TOKEN:?GITHUB_TOKEN must be set}"
+readonly destination_url="https://x-access-token:${github_token}@github.com/${destination_repository}.git"
+
+migrate_branch() {
+    local source_branch="$1"
+    local destination_branch="$2"
+
+    if git ls-remote --exit-code --heads "${destination_url}" "refs/heads/${destination_branch}" >/dev/null; then
+        return
+    fi
+
+    local migration_directory
+    migration_directory="$(mktemp -d)"
+    git clone --quiet --single-branch --branch "${source_branch}" \
+        "https://github.com/${source_repository}.git" "${migration_directory}"
+    git -C "${migration_directory}" remote set-url origin "${destination_url}"
+    git -C "${migration_directory}" push origin "HEAD:refs/heads/${destination_branch}"
+    rm -rf "${migration_directory}"
+}
+
+migrate_branch main cflite-corpus
+migrate_branch gh-pages cflite-coverage

--- a/.github/actions/cflite-build-fuzzers/action.yml
+++ b/.github/actions/cflite-build-fuzzers/action.yml
@@ -1,0 +1,68 @@
+# Vendored from google/clusterfuzzlite commit
+# 884713a6c30a92e5e8544c39945cd7cb630abcd1. Keep the runtime image digest
+# immutable when updating this action contract.
+name: ClusterFuzzLite build fuzzers
+description: Builds the project's fuzzers with an immutable runtime image.
+
+inputs:
+  language:
+    description: Language the project is written in.
+    required: false
+    default: c++
+  dry-run:
+    description: Run without reporting a failure.
+    required: false
+    default: 'false'
+  allowed-broken-targets-percentage:
+    description: Percentage of broken targets allowed by the bad-build check.
+    required: false
+  sanitizer:
+    description: Sanitizer used to build the fuzzers.
+    required: false
+    default: address
+  project-src-path:
+    description: Path to the project source checkout.
+    required: false
+  bad-build-check:
+    description: Run OSS-Fuzz's bad-build check.
+    required: false
+    default: 'true'
+  keep-unaffected-fuzz-targets:
+    description: Keep fuzz targets unaffected by the change.
+    required: false
+    default: 'false'
+  storage-repo:
+    description: Git repository used to store fuzzing artifacts.
+    required: false
+  storage-repo-branch:
+    description: Branch used to store fuzzing artifacts.
+    required: false
+  storage-repo-branch-coverage:
+    description: Branch used to store coverage reports.
+    required: false
+  upload-build:
+    description: Upload the fuzzer build.
+    required: false
+    default: 'false'
+  github-token:
+    description: Token used by the GitHub API.
+    required: false
+
+runs:
+  using: docker
+  image: docker://gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers@sha256:58caf06f6a40d6079eaaa11ce4adcb406ff8db02a537badb7a1a13ab3d2e9f94
+  env:
+    ALLOWED_BROKEN_TARGETS_PERCENTAGE: ${{ inputs.allowed-broken-targets-percentage }}
+    BAD_BUILD_CHECK: ${{ inputs.bad-build-check }}
+    UPLOAD_BUILD: ${{ inputs.upload-build }}
+    LANGUAGE: ${{ inputs.language }}
+    DRY_RUN: ${{ inputs.dry-run }}
+    SANITIZER: ${{ inputs.sanitizer }}
+    PROJECT_SRC_PATH: ${{ inputs.project-src-path }}
+    GITHUB_TOKEN: ${{ inputs.github-token }}
+    GIT_STORE_REPO: ${{ inputs.storage-repo }}
+    GIT_STORE_BRANCH: ${{ inputs.storage-repo-branch }}
+    GIT_STORE_BRANCH_COVERAGE: ${{ inputs.storage-repo-branch-coverage }}
+    CFL_PLATFORM: github
+    LOW_DISK_SPACE: 'True'
+    KEEP_UNAFFECTED_FUZZ_TARGETS: ${{ inputs.keep-unaffected-fuzz-targets }}

--- a/.github/actions/cflite-run-fuzzers/action.yml
+++ b/.github/actions/cflite-run-fuzzers/action.yml
@@ -1,0 +1,77 @@
+# Vendored from google/clusterfuzzlite commit
+# 884713a6c30a92e5e8544c39945cd7cb630abcd1. Keep the runtime image digest
+# immutable when updating this action contract.
+name: ClusterFuzzLite run fuzzers
+description: Runs fuzz targets with an immutable runtime image.
+
+inputs:
+  language:
+    description: Language the project is written in.
+    required: false
+    default: c++
+  fuzz-seconds:
+    description: Total time allotted for fuzzing.
+    required: true
+    default: '600'
+  dry-run:
+    description: Run without reporting a failure.
+    required: false
+    default: 'false'
+  sanitizer:
+    description: Sanitizer used to run the fuzzers.
+    required: false
+    default: address
+  mode:
+    description: Fuzzing mode (code-change, batch, coverage, or prune).
+    required: false
+    default: code-change
+  github-token:
+    description: Token used by the GitHub API.
+    required: true
+  storage-repo:
+    description: Git repository used to store fuzzing artifacts.
+    required: false
+  storage-repo-branch:
+    description: Branch used to store fuzzing artifacts.
+    required: false
+    default: main
+  storage-repo-branch-coverage:
+    description: Branch used to store coverage reports.
+    required: false
+    default: gh-pages
+  report-unreproducible-crashes:
+    description: Report crashes that cannot be reproduced.
+    required: false
+    default: 'False'
+  minimize-crashes:
+    description: Minimize reportable crashes.
+    required: false
+    default: 'False'
+  parallel-fuzzing:
+    description: Use all available cores for fuzzing.
+    required: false
+    default: 'false'
+  output-sarif:
+    description: Write fuzzing results as SARIF.
+    required: false
+    default: 'false'
+
+runs:
+  using: docker
+  image: docker://gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers@sha256:8f2bf4947fb44d2b111ecc08e2cec2473b798dbcf018fd0a663e1b3e3473145d
+  env:
+    FUZZ_SECONDS: ${{ inputs.fuzz-seconds }}
+    MODE: ${{ inputs.mode }}
+    LANGUAGE: ${{ inputs.language }}
+    DRY_RUN: ${{ inputs.dry-run }}
+    SANITIZER: ${{ inputs.sanitizer }}
+    GITHUB_TOKEN: ${{ inputs.github-token }}
+    LOW_DISK_SPACE: 'True'
+    GIT_STORE_REPO: ${{ inputs.storage-repo }}
+    GIT_STORE_BRANCH: ${{ inputs.storage-repo-branch }}
+    GIT_STORE_BRANCH_COVERAGE: ${{ inputs.storage-repo-branch-coverage }}
+    REPORT_UNREPRODUCIBLE_CRASHES: ${{ inputs.report-unreproducible-crashes }}
+    OUTPUT_SARIF: ${{ inputs.output-sarif }}
+    MINIMIZE_CRASHES: ${{ inputs.minimize-crashes }}
+    CFL_PLATFORM: github
+    PARALLEL_FUZZING: ${{ inputs.parallel-fuzzing }}

--- a/.github/workflows/auto-clang-format.yml
+++ b/.github/workflows/auto-clang-format.yml
@@ -1,26 +1,46 @@
-name: auto-clang-format
-on: [push]
+name: clang-format
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.h'
+      - '**.hpp'
+      - '**.cpp'
+      - '.clang-format'
+      - '.github/workflows/auto-clang-format.yml'
+  pull_request:
+    paths:
+      - '**.h'
+      - '**.hpp'
+      - '**.cpp'
+      - '.clang-format'
+      - '.github/workflows/auto-clang-format.yml'
+
+permissions:
+  contents: read
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Check clang-format version
-      run: docker run --rm xianpengshen/clang-tools:22 clang-format --version
-    - name: Run clang-format
-      run: |
-        find . \
-          -path './.git' -prune -o \
-          -path './third_party' -prune -o \
-          -path './external' -prune -o \
-          \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \) \
-          -print0 |
-          xargs -0 docker run --rm -i -v "$PWD:/src" -w /src xianpengshen/clang-tools:22 clang-format -i
-    - uses: EndBug/add-and-commit@v10
-      with:
-        author_name: Clang Robot
-        author_email: huangming.huang@gmail.com
-        message: ':art: Committing clang-format changes'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install clang-format
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
+        with:
+          compiler: llvm-22
+
+      - name: Check formatting
+        shell: bash
+        run: |
+          clang-format --version
+          find . \
+            -path './.git' -prune -o \
+            -path './third_party' -prune -o \
+            -path './external' -prune -o \
+            \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \) \
+            -print0 |
+            xargs -0 clang-format --dry-run --Werror

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -7,9 +7,8 @@ on:
   schedule:
     - cron: '0 3 * * *'
 permissions:
-  contents: read
+  contents: write
   actions: read
-  security-events: write
 jobs:
   BatchFuzzing:
     runs-on: ubuntu-latest
@@ -18,45 +17,33 @@ jobs:
       matrix:
         sanitizer: [address, undefined]  # Override this with the sanitizers you want.
     steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup C++ tools
       uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-build-fuzzers
       with:
         sanitizer: ${{ matrix.sanitizer }}
 
-    - name: Create short-lived storage token
-      id: storage-token
-      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
-      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-      with:
-        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
-        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
-        owner: huangminghuang
-        repositories: hpp-proto-storage
+    - name: Migrate persistent storage to short-lived workflow credentials
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: .clusterfuzzlite/migrate-storage.sh
 
-    - name: Run Fuzzers (${{ matrix.sanitizer }}) with storage repo
-      if: steps.storage-token.outcome == 'success'
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-run-fuzzers
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600
         mode: 'batch'
         sanitizer: ${{ matrix.sanitizer }}
-        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
-        storage-repo-branch: main   # Optional. Defaults to "main"
-        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
-
-    - name: Run Fuzzers (${{ matrix.sanitizer }}) without storage repo
-      if: steps.storage-token.outcome != 'success'
-      id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-      with:
-        github-token: ${{ github.token }}
-        fuzz-seconds: 600
-        mode: 'batch'
-        sanitizer: ${{ matrix.sanitizer }}
+        storage-repo: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+        storage-repo-branch: cflite-corpus
+        storage-repo-branch-coverage: cflite-coverage

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -19,44 +19,42 @@ jobs:
         sanitizer: [address, undefined]  # Override this with the sanitizers you want.
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.1
+      uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         sanitizer: ${{ matrix.sanitizer }}
 
-    - name: Detect storage PAT
-      id: storage
-      shell: bash
-      env:
-        PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      run: |
-        if [[ -n "${PERSONAL_ACCESS_TOKEN}" ]]; then
-          echo "has_pat=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has_pat=false" >> "$GITHUB_OUTPUT"
-        fi
+    - name: Create short-lived storage token
+      id: storage-token
+      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+      with:
+        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
+        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
+        owner: huangminghuang
+        repositories: hpp-proto-storage
 
     - name: Run Fuzzers (${{ matrix.sanitizer }}) with storage repo
-      if: steps.storage.outputs.has_pat == 'true'
+      if: steps.storage-token.outcome == 'success'
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600
         mode: 'batch'
         sanitizer: ${{ matrix.sanitizer }}
-        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/huangminghuang/hpp-proto-storage.git
+        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
         storage-repo-branch: main   # Optional. Defaults to "main"
         storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
 
     - name: Run Fuzzers (${{ matrix.sanitizer }}) without storage repo
-      if: steps.storage.outputs.has_pat != 'true'
+      if: steps.storage-token.outcome != 'success'
       id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -7,10 +7,13 @@ on:
   schedule:
     - cron: '0 3 * * *'
 permissions:
-  contents: write
+  contents: read
   actions: read
 jobs:
   BatchFuzzing:
+    permissions:
+      contents: write
+      actions: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -16,12 +16,12 @@ jobs:
         sanitizer: [address, undefined]
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.1
+      uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         sanitizer: ${{ matrix.sanitizer }}
         upload-build: true

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -15,13 +15,16 @@ jobs:
       matrix:
         sanitizer: [address, undefined]
     steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup C++ tools
       uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-build-fuzzers
       with:
         sanitizer: ${{ matrix.sanitizer }}
         upload-build: true

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -12,43 +12,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.1
+      uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         sanitizer: coverage
-    - name: Detect storage PAT
-      id: storage
-      shell: bash
-      env:
-        PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      run: |
-        if [[ -n "${PERSONAL_ACCESS_TOKEN}" ]]; then
-          echo "has_pat=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has_pat=false" >> "$GITHUB_OUTPUT"
-        fi
+    - name: Create short-lived storage token
+      id: storage-token
+      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+      with:
+        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
+        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
+        owner: huangminghuang
+        repositories: hpp-proto-storage
 
     - name: Run Fuzzers with storage repo
-      if: steps.storage.outputs.has_pat == 'true'
+      if: steps.storage-token.outcome == 'success'
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       env:
         COVERAGE_EXTRA_ARGS: -ignore-filename-regex=build/* -ignore-filename-regex=fuzz/* -ignore-filename-regex=include/google/*
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600
         mode: 'coverage'
-        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/huangminghuang/hpp-proto-storage.git
+        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
         storage-repo-branch: main   # Optional. Defaults to "main"
         storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
     - name: Run Fuzzers without storage repo
-      if: steps.storage.outputs.has_pat != 'true'
+      if: steps.storage-token.outcome != 'success'
       id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       env:
         COVERAGE_EXTRA_ARGS: -ignore-filename-regex=build/* -ignore-filename-regex=fuzz/* -ignore-filename-regex=include/google/*
       with:
@@ -59,39 +57,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.1
+      uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
-    - name: Detect storage PAT
-      id: storage
-      shell: bash
-      env:
-        PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      run: |
-        if [[ -n "${PERSONAL_ACCESS_TOKEN}" ]]; then
-          echo "has_pat=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has_pat=false" >> "$GITHUB_OUTPUT"
-        fi
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+    - name: Create short-lived storage token
+      id: storage-token
+      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+      with:
+        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
+        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
+        owner: huangminghuang
+        repositories: hpp-proto-storage
 
     - name: Run Fuzzers with storage repo
-      if: steps.storage.outputs.has_pat == 'true'
+      if: steps.storage-token.outcome == 'success'
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600
         mode: 'prune'
-        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/huangminghuang/hpp-proto-storage.git
+        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
         storage-repo-branch: main   # Optional. Defaults to "main"
         storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
     - name: Run Fuzzers without storage repo
-      if: steps.storage.outputs.has_pat != 'true'
+      if: steps.storage-token.outcome != 'success'
       id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -4,10 +4,13 @@ on:
   schedule:
     - cron: '0 5 * * *'  # Once a day.
 permissions:
-  contents: write
+  contents: read
   actions: read
 jobs:
   Coverage:
+    permissions:
+      contents: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -41,6 +44,9 @@ jobs:
         storage-repo-branch: cflite-corpus
         storage-repo-branch-coverage: cflite-coverage
   Pruning:
+    permissions:
+      contents: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -4,91 +4,68 @@ on:
   schedule:
     - cron: '0 5 * * *'  # Once a day.
 permissions:
-  contents: read
+  contents: write
   actions: read
-  security-events: write
 jobs:
   Coverage:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup C++ tools
       uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-build-fuzzers
       with:
         sanitizer: coverage
-    - name: Create short-lived storage token
-      id: storage-token
-      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
-      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-      with:
-        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
-        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
-        owner: huangminghuang
-        repositories: hpp-proto-storage
+    - name: Migrate persistent storage to short-lived workflow credentials
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: .clusterfuzzlite/migrate-storage.sh
 
     - name: Run Fuzzers with storage repo
-      if: steps.storage-token.outcome == 'success'
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-run-fuzzers
       env:
         COVERAGE_EXTRA_ARGS: -ignore-filename-regex=build/* -ignore-filename-regex=fuzz/* -ignore-filename-regex=include/google/*
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600
         mode: 'coverage'
-        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
-        storage-repo-branch: main   # Optional. Defaults to "main"
-        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
-    - name: Run Fuzzers without storage repo
-      if: steps.storage-token.outcome != 'success'
-      id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-      env:
-        COVERAGE_EXTRA_ARGS: -ignore-filename-regex=build/* -ignore-filename-regex=fuzz/* -ignore-filename-regex=include/google/*
-      with:
-        github-token: ${{ github.token }}
-        fuzz-seconds: 600
-        mode: 'coverage'
+        storage-repo: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+        storage-repo-branch: cflite-corpus
+        storage-repo-branch-coverage: cflite-coverage
   Pruning:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup C++ tools
       uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-    - name: Create short-lived storage token
-      id: storage-token
-      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
-      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-      with:
-        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
-        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
-        owner: huangminghuang
-        repositories: hpp-proto-storage
+      uses: ./.github/actions/cflite-build-fuzzers
+    - name: Migrate persistent storage to short-lived workflow credentials
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: .clusterfuzzlite/migrate-storage.sh
 
     - name: Run Fuzzers with storage repo
-      if: steps.storage-token.outcome == 'success'
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-run-fuzzers
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 600
         mode: 'prune'
-        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
-        storage-repo-branch: main   # Optional. Defaults to "main"
-        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
-    - name: Run Fuzzers without storage repo
-      if: steps.storage-token.outcome != 'success'
-      id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-      with:
-        github-token: ${{ github.token }}
-        fuzz-seconds: 600
-        mode: 'prune'
+        storage-repo: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+        storage-repo-branch: cflite-corpus
+        storage-repo-branch-coverage: cflite-coverage

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -40,7 +40,9 @@ jobs:
         mode: 'code-change'
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
-        # Code-change mode only reads the corpus, so fork PRs need no secret.
-        storage-repo: https://github.com/huangminghuang/hpp-proto-storage.git
-        storage-repo-branch: main   # Optional. Defaults to "main"
-        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        # Code-change mode only reads the public corpus, so fork PRs need no
+        # secret. Before the first post-merge migration this branch is absent
+        # and ClusterFuzzLite starts with an empty corpus.
+        storage-repo: https://github.com/${{ github.repository }}.git
+        storage-repo-branch: cflite-corpus
+        storage-repo-branch-coverage: cflite-coverage

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -16,49 +16,31 @@ jobs:
       matrix:
         sanitizer: [address, undefined]  
     steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Setup C++ tools
       uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-build-fuzzers
       with:
         language: c++ 
         github-token: ${{ github.token }}
         sanitizer: ${{ matrix.sanitizer }}
 
-    - name: Create short-lived storage token
-      id: storage-token
-      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
-      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-      with:
-        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
-        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
-        owner: huangminghuang
-        repositories: hpp-proto-storage
-
-    - name: Run Fuzzers (${{ matrix.sanitizer }}) with storage repo
-      if: steps.storage-token.outcome == 'success'
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+      uses: ./.github/actions/cflite-run-fuzzers
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 300
         mode: 'code-change'
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
-        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
+        # Code-change mode only reads the corpus, so fork PRs need no secret.
+        storage-repo: https://github.com/huangminghuang/hpp-proto-storage.git
         storage-repo-branch: main   # Optional. Defaults to "main"
         storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
-
-    - name: Run Fuzzers (${{ matrix.sanitizer }}) without storage repo
-      if: steps.storage-token.outcome != 'success'
-      id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-      with:
-        github-token: ${{ github.token }}
-        fuzz-seconds: 300
-        mode: 'code-change'
-        sanitizer: ${{ matrix.sanitizer }}
-        output-sarif: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -17,47 +17,45 @@ jobs:
         sanitizer: [address, undefined]  
     steps:
     - name: Setup C++ tools
-      uses: aminya/setup-cpp@v1.8.1
+      uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
       with:
         ccache: true
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         language: c++ 
         github-token: ${{ github.token }}
         sanitizer: ${{ matrix.sanitizer }}
 
-    - name: Detect storage PAT
-      id: storage
-      shell: bash
-      env:
-        PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      run: |
-        if [[ -n "${PERSONAL_ACCESS_TOKEN}" ]]; then
-          echo "has_pat=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has_pat=false" >> "$GITHUB_OUTPUT"
-        fi
+    - name: Create short-lived storage token
+      id: storage-token
+      if: vars.CFL_STORAGE_APP_ENABLED == 'true'
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+      with:
+        app-id: ${{ secrets.CFL_STORAGE_APP_ID }}
+        private-key: ${{ secrets.CFL_STORAGE_APP_PRIVATE_KEY }}
+        owner: huangminghuang
+        repositories: hpp-proto-storage
 
     - name: Run Fuzzers (${{ matrix.sanitizer }}) with storage repo
-      if: steps.storage.outputs.has_pat == 'true'
+      if: steps.storage-token.outcome == 'success'
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 300
         mode: 'code-change'
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
-        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/huangminghuang/hpp-proto-storage.git
+        storage-repo: https://x-access-token:${{ steps.storage-token.outputs.token }}@github.com/huangminghuang/hpp-proto-storage.git
         storage-repo-branch: main   # Optional. Defaults to "main"
         storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
 
     - name: Run Fuzzers (${{ matrix.sanitizer }}) without storage repo
-      if: steps.storage.outputs.has_pat != 'true'
+      if: steps.storage-token.outcome != 'success'
       id: run-no-storage
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ github.token }}
         fuzz-seconds: 300

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -22,12 +22,16 @@ env:
   CTCACHE_DIR: ${{ github.workspace }}/.ctcache
   CTCACHE_LOCAL: "1"
 
+permissions:
+  contents: read
+
 jobs:
   clang-tidy:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Prepare cache directories
@@ -36,13 +40,13 @@ jobs:
           mkdir -p "${CCACHE_DIR}"
           mkdir -p "${CTCACHE_DIR}"
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CPM_SOURCE_CACHE }}
           key: clang-tidy-${{ runner.os }}-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: clang-tidy-${{ runner.os }}-ccache-${{ github.sha }}
@@ -50,7 +54,7 @@ jobs:
             clang-tidy-${{ runner.os }}-ccache-
 
       - name: Cache ctcache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CTCACHE_DIR }}
           key: clang-tidy-${{ runner.os }}-ctcache-${{ hashFiles('.clang-tidy', '.github/workflows/clang-tidy.yml') }}-${{ github.sha }}
@@ -59,7 +63,7 @@ jobs:
             clang-tidy-${{ runner.os }}-ctcache-
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           compiler: llvm-22
           cmake: "4.4.0"
@@ -71,7 +75,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --user --break-system-packages --upgrade \
-            "git+https://github.com/matus-chochlik/ctcache.git"
+            "git+https://github.com/matus-chochlik/ctcache.git@0c7fee26e09ae8a393ed7d56164102da118ab23a"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
           REAL_CLANG_TIDY="$(command -v clang-tidy)"

--- a/.github/workflows/conan-windows.yml
+++ b/.github/workflows/conan-windows.yml
@@ -23,6 +23,9 @@ env:
   PROTOC_SHA256: d1cede9e308cc3eb072392af1c02ccae4bdd3d2f374ec2970dbd8cdfdaa91363
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -43,12 +46,14 @@ jobs:
     name: ${{ matrix.name }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
-      - uses: ilammy/msvc-dev-cmd@v1.13.0
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: setup cpp tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           cmake: "4.4.0"
           ninja: true
@@ -56,7 +61,7 @@ jobs:
           conan: "2.30.0"
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.name }}-ccache-${{ github.sha }}

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -24,6 +24,9 @@ env:
   PROTOC_SHA256: a45cda0989c17dd950db55f6fbe1e5814c50fda08e87aa422980ac1f89dddbbc
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -47,10 +50,12 @@ jobs:
       CXX: g++-13
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: setup cpp tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           compiler: gcc-13
           cmake: "4.4.0"
@@ -59,7 +64,7 @@ jobs:
           conan: "2.30.0"
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.name }}-ccache-${{ github.sha }}

--- a/.github/workflows/fetch_content.yml
+++ b/.github/workflows/fetch_content.yml
@@ -21,6 +21,9 @@ env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,23 +33,25 @@ jobs:
         gcc: [13]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           compiler: gcc-${{ matrix.gcc }}
           cmake: "4.4.0"
           ninja: true
           ccache: true
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-ccache-${{ github.sha }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -22,6 +22,9 @@ env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,23 +36,25 @@ jobs:
         cpm-local-packages-only: ["OFF", "ON"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           compiler: gcc-${{ matrix.gcc }}
           cmake: "4.4.0"
           ninja: true
           ccache: true
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ matrix.cpm-local-packages-only }}-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-gcc-${{ matrix.gcc }}-${{ matrix.cpm-local-packages-only }}-ccache-${{ github.sha }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,6 +22,9 @@
     CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
     CCACHE_DIR: ${{ github.workspace }}/.ccache
   
+  permissions:
+    contents: read
+
   jobs:
     build:
       strategy:
@@ -63,23 +66,25 @@
           if: matrix.cmake_preset != 'ci-linux-asan-ubsan'
           run: |
             sudo apt-get install -y libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
-        - uses: actions/checkout@v7
+        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+          with:
+            persist-credentials: false
 
         - name: Setup required C++ tools
-          uses: aminya/setup-cpp@v1.8.1
+          uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
           with:
             compiler: ${{ matrix.compiler }}
             cmake: "4.4.0"
             ninja: true
             ccache: true
 
-        - uses: actions/cache@v6
+        - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
           with:
             path: "**/cpm_modules"
             key: ${{ runner.os }}-${{ matrix.compiler }}-cxx${{ matrix.cpp_standard }}-${{ matrix.cmake_preset }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
         - name: Cache ccache
-          uses: actions/cache@v6
+          uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
           with:
             path: ${{ env.CCACHE_DIR }}
             key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.compiler }}-cxx${{ matrix.cpp_standard }}-${{ matrix.cmake_preset }}-ccache-${{ github.sha }}
@@ -108,7 +113,7 @@
             cmake --build build --target coverage_filtered_info
 
         - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@v7
+          uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
           if: matrix.cmake_preset == 'ci-linux-coverage'
           with:
             token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,6 +22,9 @@ env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest
@@ -32,15 +35,17 @@ jobs:
           - cmake_preset: ci-macos-coverage
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-ccache-${{ github.sha }}
@@ -48,7 +53,7 @@ jobs:
             ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-ccache-
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           cmake: "4.4.0"
           ninja: true
@@ -99,7 +104,7 @@ jobs:
           cmake --build build --target coverage_filtered_info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         if: matrix.cmake_preset == 'ci-macos-coverage'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ubuntu-two-stage-host-protoc-gen-hpp.yml
+++ b/.github/workflows/ubuntu-two-stage-host-protoc-gen-hpp.yml
@@ -19,6 +19,9 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test_with_host_plugin:
     runs-on: ubuntu-latest
@@ -27,10 +30,12 @@ jobs:
       matrix:
         cmake: ["4.4.0"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           compiler: gcc-13
           cmake: ${{ matrix.cmake }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -24,12 +24,17 @@ env:
   PROTOC_ZIP: protoc-35.0-linux-x86_64.zip
   PROTOC_SHA256: a45cda0989c17dd950db55f6fbe1e5814c50fda08e87aa422980ac1f89dddbbc
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: install build tools
         run: |
@@ -52,7 +57,7 @@ jobs:
           echo "PROTOC_BIN=$PROTOC_DIR/bin" >> "$GITHUB_ENV"
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           cmake: "4.4.0"
           ninja: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,9 @@ env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -34,14 +37,16 @@ jobs:
             compiler_env: mingw
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
-      - uses: ilammy/msvc-dev-cmd@v1.13.0
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         if: ${{ matrix.compiler_env == 'msvc' }}
 
       - name: Setup MinGW
         if: ${{ matrix.compiler_env == 'mingw' }}
-        uses: msys2/setup-msys2@v2.32.0
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           update: true
           install: mingw-w64-x86_64-gcc
@@ -51,13 +56,13 @@ jobs:
         shell: pwsh
         run: Add-Content -Path $env:GITHUB_PATH -Value "C:\msys64\mingw64\bin"
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/third-parties.cmake') }}
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-${{ matrix.compiler_env }}-ccache-${{ github.sha }}
@@ -65,7 +70,7 @@ jobs:
             ${{ github.workflow }}-${{ runner.os }}-${{ matrix.cmake_preset }}-${{ matrix.compiler_env }}-ccache-
 
       - name: Setup required C++ tools
-        uses: aminya/setup-cpp@v1.8.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           cmake: "4.4.0"
           ninja: true

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -25,9 +25,11 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:1.7.12
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # 1.7.12
         with:
           args: -color


### PR DESCRIPTION
## Summary

Harden GitHub Actions against mutable third-party code and over-scoped credentials while preserving ClusterFuzzLite's persistent corpus and coverage data.

## What changed

- Pin external actions, action containers, and ClusterFuzzLite runtime images to immutable digests or commit SHAs; pin ctcache to a reviewed commit.
- Apply explicit least-privilege permissions, disable checkout credential persistence, and replace the write-capable formatter bot with a read-only formatting check.
- Replace the long-lived cross-repository fuzzing PAT with the run-scoped `GITHUB_TOKEN`, vendored ClusterFuzzLite action contracts, and a one-time migration to dedicated corpus and coverage branches.

## Why

Mutable CI dependencies and credentials with repository or storage write access create an avoidable supply-chain path. This change makes executable CI inputs reviewable and immutable, narrows token access, and retains persistent fuzzing state without long-lived credentials.

## Testing

- `bash -n .clusterfuzzlite/migrate-storage.sh`

## Notes

- The first post-merge batch or scheduled fuzzing run migrates `hpp-proto-storage` branches `main` and `gh-pages` to this repository's `cflite-corpus` and `cflite-coverage` branches. Retain the old storage repository until both destination branches and the first subsequent run are confirmed.
