### PR TITLE
Fix ClusterFuzzLite storage migration

### DIFF
--- a/.clusterfuzzlite/migrate-storage.sh
+++ b/.clusterfuzzlite/migrate-storage.sh
@@ -2,27 +2,44 @@
 
 set -euo pipefail
 
-readonly source_repository="${CFL_STORAGE_SOURCE_REPOSITORY:-huangminghuang/hpp-proto-storage}"
-readonly destination_repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
-readonly github_token="${GITHUB_TOKEN:?GITHUB_TOKEN must be set}"
-readonly destination_url="https://x-access-token:${github_token}@github.com/${destination_repository}.git"
+readonly source_url="${CFL_STORAGE_SOURCE_URL:-https://github.com/huangminghuang/hpp-proto-storage.git}"
+if [[ -n "${CFL_STORAGE_DESTINATION_URL:-}" ]]; then
+    readonly destination_url="${CFL_STORAGE_DESTINATION_URL}"
+else
+    readonly destination_repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+    readonly github_token="${GITHUB_TOKEN:?GITHUB_TOKEN must be set}"
+    readonly destination_url="https://x-access-token:${github_token}@github.com/${destination_repository}.git"
+fi
 
-migrate_branch() {
-    local source_branch="$1"
-    local destination_branch="$2"
+migrate_branch() (
+    readonly source_branch="$1"
+    readonly destination_branch="$2"
 
     if git ls-remote --exit-code --heads "${destination_url}" "refs/heads/${destination_branch}" >/dev/null; then
         return
     fi
 
-    local migration_directory
+    local migration_directory source_tree snapshot_commit snapshot_date
     migration_directory="$(mktemp -d)"
-    git clone --quiet --single-branch --branch "${source_branch}" \
-        "https://github.com/${source_repository}.git" "${migration_directory}"
+    trap 'rm -rf -- "${migration_directory}"' EXIT
+
+    git clone --quiet --depth 1 --no-tags --single-branch --branch "${source_branch}" \
+        "${source_url}" "${migration_directory}"
+    source_tree="$(git -C "${migration_directory}" rev-parse 'HEAD^{tree}')"
+    snapshot_date="$(git -C "${migration_directory}" show -s --format=%aI HEAD)"
+    snapshot_commit="$(
+        printf 'Snapshot migrated ClusterFuzzLite %s\n' "${source_branch}" |
+            GIT_AUTHOR_NAME=CIFuzz \
+                GIT_AUTHOR_EMAIL=cifuzz@clusterfuzz.com \
+                GIT_AUTHOR_DATE="${snapshot_date}" \
+                GIT_COMMITTER_NAME=CIFuzz \
+                GIT_COMMITTER_EMAIL=cifuzz@clusterfuzz.com \
+                GIT_COMMITTER_DATE="${snapshot_date}" \
+                git -C "${migration_directory}" commit-tree "${source_tree}"
+    )"
     git -C "${migration_directory}" remote set-url origin "${destination_url}"
-    git -C "${migration_directory}" push origin "HEAD:refs/heads/${destination_branch}"
-    rm -rf "${migration_directory}"
-}
+    git -C "${migration_directory}" push origin "${snapshot_commit}:refs/heads/${destination_branch}"
+)
 
 migrate_branch main cflite-corpus
 migrate_branch gh-pages cflite-coverage

--- a/.clusterfuzzlite/migrate-storage.sh
+++ b/.clusterfuzzlite/migrate-storage.sh
@@ -19,7 +19,7 @@ migrate_branch() (
         return
     fi
 
-    local migration_directory source_tree snapshot_commit snapshot_date
+    local migration_directory remote_commit source_tree snapshot_commit snapshot_date
     migration_directory="$(mktemp -d)"
     trap 'rm -rf -- "${migration_directory}"' EXIT
 
@@ -38,7 +38,13 @@ migrate_branch() (
                 git -C "${migration_directory}" commit-tree "${source_tree}"
     )"
     git -C "${migration_directory}" remote set-url origin "${destination_url}"
-    git -C "${migration_directory}" push origin "${snapshot_commit}:refs/heads/${destination_branch}"
+    if ! git -C "${migration_directory}" push origin "${snapshot_commit}:refs/heads/${destination_branch}"; then
+        remote_commit="$(
+            git ls-remote --heads "${destination_url}" "refs/heads/${destination_branch}" |
+                awk 'NR == 1 { print $1 }'
+        )"
+        [[ "${remote_commit}" == "${snapshot_commit}" ]]
+    fi
 )
 
 migrate_branch main cflite-corpus


### PR DESCRIPTION
## Summary

Fix the one-time ClusterFuzzLite storage migration so it copies only current branch snapshots instead of importing the storage repository's full history.

## What changed

- Shallow-clone each storage source branch and create a parentless snapshot commit with the identical tree.
- Make snapshot commits deterministic so concurrent sanitizer jobs converge on the same SHA.
- Treat a concurrent create-ref rejection as success only when the remote branch exactly matches the expected snapshot; conflicting results remain failures.
- Allow local source and destination URL overrides for isolated migration testing.

## Why

The first post-merge rollout of #194 revealed that the original migration cloned roughly 1 GB of storage history. The run was cancelled, but `cflite-corpus` had already been created at the history-bearing source commit. That branch was replaced with a parentless commit preserving the same corpus tree. This follow-up prevents the remaining coverage migration and future fresh migrations from importing source history.

## Testing

- `bash -n .clusterfuzzlite/migrate-storage.sh`
- Two simultaneous end-to-end migrations against local bare repositories; both processes succeeded through create-ref races, produced parentless corpus and coverage branches, and remained idempotent.

## Notes

- The original `hpp-proto-storage` repository remains intact as the recovery source.
- The cancelled rollout created no `cflite-coverage` branch; the post-merge batch rerun will create it with the corrected snapshot migration.
