### PR TITLE
Make package manager graphs reproducible

### DIFF
--- a/.github/workflows/conan-windows.yml
+++ b/.github/workflows/conan-windows.yml
@@ -28,17 +28,21 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: conan-protobuf-binary-shared
+            lockfile: conan/locks/windows-protobuf.lock
+            package_list: conan/packages/windows-protobuf.json
             with_protobuf: "True"
             cmake_configure_preset: conan-release
             cmake_build_preset: conan-release
             build_shared_libs: "ON"
           - name: system-protobuf-cpp23-static
+            lockfile: conan/locks/windows-system.lock
+            package_list: conan/packages/windows-system.json
             with_protobuf: "False"
             cmake_configure_preset: conan-release
             cmake_build_preset: conan-release
@@ -80,30 +84,30 @@ jobs:
           Expand-Archive -Path $zip -DestinationPath "$env:TEMP\\protoc"
           Add-Content $env:GITHUB_PATH "$env:TEMP\\protoc\\bin"
 
-      - name: conan profile
-        run: conan profile detect --force
+      - name: download locked dependency binaries
+        run: |
+          conan download `
+            --list="${{ matrix.package_list }}" `
+            --remote=conancenter
 
       - name: create package
         run: |
           conan create . `
-            -c:a tools.cmake.cmaketoolchain:generator=Ninja `
-            -s:h build_type=Release `
-            -s:h compiler.cppstd=23 `
-            -s:b build_type=Release `
-            -s:b compiler.cppstd=17 `
+            -pr:h conan/profiles/windows-host `
+            -pr:b conan/profiles/windows-build `
             -o "&:with_protobuf=${{ matrix.with_protobuf }}" `
-            --build=missing
+            --lockfile="${{ matrix.lockfile }}" `
+            --no-remote
 
       - name: install dependencies
         run: |
           conan install tutorial `
-            -c:a tools.cmake.cmaketoolchain:generator=Ninja `
-            -s:h build_type=Release `
-            -s:b build_type=Release `
-            -s:h compiler.cppstd=23 `
-            -s:b compiler.cppstd=17 `
+            -pr:h conan/profiles/windows-host `
+            -pr:b conan/profiles/windows-build `
             -o "hpp_proto/*:with_protobuf=${{ matrix.with_protobuf }}" `
-            --build=missing `
+            --lockfile="${{ matrix.lockfile }}" `
+            --lockfile-partial `
+            --no-remote `
             -of tutorial-build
 
       - name: configure

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -35,12 +35,16 @@ jobs:
       matrix:
         include:
           - name: conan-protobuf-binary-shared
-            build_cppstd: gnu17
+            build_profile: conan/profiles/linux-build-gnu17
+            lockfile: conan/locks/linux-protobuf.lock
+            package_list: conan/packages/linux-protobuf.json
             use_system_protobuf: false
             with_protobuf: "True"
             build_shared_libs: "ON"
           - name: system-protobuf-cpp23-static
-            build_cppstd: 23
+            build_profile: conan/profiles/linux-build-cpp23
+            lockfile: conan/locks/linux-system.lock
+            package_list: conan/packages/linux-system.json
             use_system_protobuf: true
             with_protobuf: "False"
             build_shared_libs: "OFF"
@@ -77,29 +81,30 @@ jobs:
           sudo apt-get install -y protobuf-compiler libprotobuf-dev
           echo "PROTOC_BIN=/usr/bin" >> "$GITHUB_ENV"
 
-      - name: conan profile
-        run: conan profile detect --force
+      - name: download locked dependency binaries
+        run: |
+          conan download \
+            --list="${{ matrix.package_list }}" \
+            --remote=conancenter
 
       - name: create package
         run: |
           conan create . \
-            -s:h compiler.cppstd=23 \
-            -s:b arch=x86_64 -s:b compiler=gcc -s:b compiler.version=13 -s:b compiler.libcxx=libstdc++11 \
-            -s:b compiler.cppstd=${{ matrix.build_cppstd }} \
+            -pr:h conan/profiles/linux-host \
+            -pr:b "${{ matrix.build_profile }}" \
             -o '&:with_protobuf=${{ matrix.with_protobuf }}' \
-            --build=missing
+            --lockfile="${{ matrix.lockfile }}" \
+            --no-remote
 
       - name: install dependencies
         run: |
           conan install tutorial \
-            -s:h build_type=Release \
-            -s:b build_type=Release \
-            -s:h compiler.cppstd=23 \
-            -s:h protobuf/*:compiler.cppstd=gnu17 \
-            -s:b arch=x86_64 -s:b compiler=gcc -s:b compiler.version=13 -s:b compiler.libcxx=libstdc++11 \
-            -s:b compiler.cppstd=${{ matrix.build_cppstd }} \
+            -pr:h conan/profiles/linux-host \
+            -pr:b "${{ matrix.build_profile }}" \
             -o 'hpp_proto/*:with_protobuf=${{ matrix.with_protobuf }}' \
-            --build=missing \
+            --lockfile="${{ matrix.lockfile }}" \
+            --lockfile-partial \
+            --no-remote \
             -of tutorial-build
 
       - name: configure

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -61,12 +61,11 @@ jobs:
         with:
           cmake: "4.4.0"
           ninja: true
-          vcpkg: true
+          vcpkg: "0878b5224d4a4968940ee296a2e7fae2d3b62983"
 
       - name: install hpp-proto via local overlay port
         run: |
           vcpkg install \
-            "hpp-proto" \
             --triplet="$VCPKG_DEFAULT_TRIPLET" \
             --overlay-ports="$GITHUB_WORKSPACE/ports"
 
@@ -77,6 +76,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PROGRAM_PATH="$PROTOC_BIN" \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_INSTALLED_DIR="$GITHUB_WORKSPACE/vcpkg_installed" \
             -DVCPKG_TARGET_TRIPLET="$VCPKG_DEFAULT_TRIPLET" \
             -DVCPKG_OVERLAY_PORTS="$GITHUB_WORKSPACE/ports"
 

--- a/conan/README.md
+++ b/conan/README.md
@@ -1,0 +1,24 @@
+# Reproducible Conan graphs
+
+The CI profiles in `profiles/` define every host and build setting used by the
+Linux and Windows workflows. Each job selects a committed lockfile and matching
+package list from `locks/` and `packages/`.
+
+Conan 2 lockfiles pin package versions and recipe revisions (RREVs), but do not
+record binary package revisions (PREVs). The package lists complement the
+lockfiles with exact package IDs and PREVs. CI downloads only that list, then
+runs `conan create` and `conan install` with `--no-remote`; a changed or missing
+binary therefore fails instead of silently changing the dependency graph.
+
+To intentionally update the graph with Conan 2.30.0:
+
+1. Generate each lock with `conan lock create .`, its matching host/build
+   profiles, the corresponding `with_protobuf` option, and `--update`.
+2. Run `conan graph info . --lockfile=<lock> --format=json` with the same
+   profiles and option.
+3. Convert the graph to a package list with
+   `conan list --graph=<graph.json> --graph-binaries=Download --format=json`.
+4. Review the version, RREV, package ID, and PREV changes in both files, then
+   update the corresponding workflow matrix entry if a profile changed.
+
+Do not hand-edit lockfiles or package lists.

--- a/conan/locks/linux-protobuf.lock
+++ b/conan/locks/linux-protobuf.lock
@@ -1,0 +1,14 @@
+{
+    "version": "0.5",
+    "requires": [
+        "glaze/7.8.4#17bfcc0739d8a1618cafd35327b1127e%1783515405.523"
+    ],
+    "build_requires": [
+        "zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb%1777558780.503",
+        "protobuf/7.35.0#59f5248022af755532bfe62482c3de80%1779376426.695",
+        "cmake/4.4.0#a5dd5d73bd9fc56b0fc3163a04573dc8%1784051561.926",
+        "abseil/20260107.1#883e95a7be2b767999f64669ac642e5d%1773137897.755"
+    ],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/conan/locks/linux-system.lock
+++ b/conan/locks/linux-system.lock
@@ -1,0 +1,9 @@
+{
+    "version": "0.5",
+    "requires": [
+        "glaze/7.8.4#17bfcc0739d8a1618cafd35327b1127e%1783515405.523"
+    ],
+    "build_requires": [],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/conan/locks/windows-protobuf.lock
+++ b/conan/locks/windows-protobuf.lock
@@ -1,0 +1,14 @@
+{
+    "version": "0.5",
+    "requires": [
+        "glaze/7.8.4#17bfcc0739d8a1618cafd35327b1127e%1783515405.523"
+    ],
+    "build_requires": [
+        "zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb%1777558780.503",
+        "protobuf/7.35.0#59f5248022af755532bfe62482c3de80%1779376426.695",
+        "cmake/4.4.0#a5dd5d73bd9fc56b0fc3163a04573dc8%1784051561.926",
+        "abseil/20260107.1#883e95a7be2b767999f64669ac642e5d%1773137897.755"
+    ],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/conan/locks/windows-system.lock
+++ b/conan/locks/windows-system.lock
@@ -1,0 +1,9 @@
+{
+    "version": "0.5",
+    "requires": [
+        "glaze/7.8.4#17bfcc0739d8a1618cafd35327b1127e%1783515405.523"
+    ],
+    "build_requires": [],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/conan/packages/linux-protobuf.json
+++ b/conan/packages/linux-protobuf.json
@@ -1,0 +1,142 @@
+{
+    "Local Cache": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            },
+                            "info": {}
+                        }
+                    }
+                }
+            }
+        },
+        "protobuf/7.35.0": {
+            "revisions": {
+                "59f5248022af755532bfe62482c3de80": {
+                    "timestamp": 1779376426.695,
+                    "packages": {
+                        "f5d75c5ca3a4d6147cbb99a5f8f5d03d2a2471a1": {
+                            "revisions": {
+                                "92bf531eb7d9f50d8ecab4496c51acb4": {
+                                    "timestamp": 1779376926.473
+                                }
+                            },
+                            "info": {
+                                "settings": {
+                                    "os": "Linux",
+                                    "arch": "x86_64",
+                                    "compiler": "gcc",
+                                    "compiler.cppstd": "gnu17",
+                                    "compiler.libcxx": "libstdc++11",
+                                    "compiler.version": "13",
+                                    "build_type": "Release"
+                                },
+                                "options": {
+                                    "debug_suffix": "True",
+                                    "fPIC": "True",
+                                    "lite": "False",
+                                    "shared": "False",
+                                    "with_rtti": "True",
+                                    "with_zlib": "True"
+                                },
+                                "requires": [
+                                    "zlib/1.3.Z",
+                                    "abseil/20260107.1.Z"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "conancenter": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "protobuf/7.35.0": {
+            "revisions": {
+                "59f5248022af755532bfe62482c3de80": {
+                    "timestamp": 1779376426.695,
+                    "packages": {
+                        "f5d75c5ca3a4d6147cbb99a5f8f5d03d2a2471a1": {
+                            "revisions": {
+                                "92bf531eb7d9f50d8ecab4496c51acb4": {
+                                    "timestamp": 1779376926.473
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "zlib/1.3.2": {
+            "revisions": {
+                "1cb806da49011867778ffb6ac7190fcb": {
+                    "timestamp": 1777558780.503,
+                    "packages": {
+                        "c81087b06d1a5beef0ad711fc32d45f7a425a8f3": {
+                            "revisions": {
+                                "424b3705b50fb9c7a13cf3d299743946": {
+                                    "timestamp": 1777559540.655
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "abseil/20260107.1": {
+            "revisions": {
+                "883e95a7be2b767999f64669ac642e5d": {
+                    "timestamp": 1773137897.755,
+                    "packages": {
+                        "838c313f1b7acdfd23b222f0156e7c264dcc2515": {
+                            "revisions": {
+                                "530375e51838d5c31c9c1ffce4625cd7": {
+                                    "timestamp": 1773138099.294
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "cmake/4.4.0": {
+            "revisions": {
+                "a5dd5d73bd9fc56b0fc3163a04573dc8": {
+                    "timestamp": 1784051561.926,
+                    "packages": {
+                        "63fead0844576fc02943e16909f08fcdddd6f44b": {
+                            "revisions": {
+                                "8a34df4a66dc462ae25376a2f1224df6": {
+                                    "timestamp": 1784051689.702
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/conan/packages/linux-system.json
+++ b/conan/packages/linux-system.json
@@ -1,0 +1,39 @@
+{
+    "Local Cache": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            },
+                            "info": {}
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "conancenter": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/conan/packages/windows-protobuf.json
+++ b/conan/packages/windows-protobuf.json
@@ -1,0 +1,142 @@
+{
+    "Local Cache": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            },
+                            "info": {}
+                        }
+                    }
+                }
+            }
+        },
+        "protobuf/7.35.0": {
+            "revisions": {
+                "59f5248022af755532bfe62482c3de80": {
+                    "timestamp": 1779376426.695,
+                    "packages": {
+                        "36e137e6aa0eb2d748d75b3100f68c2139b5f19e": {
+                            "revisions": {
+                                "5c4f8d5a48eeb9d6a105ba25dd53d017": {
+                                    "timestamp": 1779377150.001
+                                }
+                            },
+                            "info": {
+                                "settings": {
+                                    "os": "Windows",
+                                    "arch": "x86_64",
+                                    "compiler": "msvc",
+                                    "compiler.cppstd": "17",
+                                    "compiler.runtime": "dynamic",
+                                    "compiler.runtime_type": "Release",
+                                    "compiler.version": "194",
+                                    "build_type": "Release"
+                                },
+                                "options": {
+                                    "debug_suffix": "True",
+                                    "lite": "False",
+                                    "shared": "False",
+                                    "with_rtti": "True",
+                                    "with_zlib": "True"
+                                },
+                                "requires": [
+                                    "zlib/1.3.Z",
+                                    "abseil/20260107.1.Z"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "conancenter": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "protobuf/7.35.0": {
+            "revisions": {
+                "59f5248022af755532bfe62482c3de80": {
+                    "timestamp": 1779376426.695,
+                    "packages": {
+                        "36e137e6aa0eb2d748d75b3100f68c2139b5f19e": {
+                            "revisions": {
+                                "5c4f8d5a48eeb9d6a105ba25dd53d017": {
+                                    "timestamp": 1779377150.001
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "zlib/1.3.2": {
+            "revisions": {
+                "1cb806da49011867778ffb6ac7190fcb": {
+                    "timestamp": 1777558780.503,
+                    "packages": {
+                        "0d6dd492a7d31822b2f2686ec67bbaef586416a3": {
+                            "revisions": {
+                                "5ca7be7b16c68f62ebc4981fd5d11af2": {
+                                    "timestamp": 1777558922.729
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "abseil/20260107.1": {
+            "revisions": {
+                "883e95a7be2b767999f64669ac642e5d": {
+                    "timestamp": 1773137897.755,
+                    "packages": {
+                        "2e51ec0fde483876cccf2be6dea756a2dd099bd4": {
+                            "revisions": {
+                                "90665049c995093df110cb07ec9d83d2": {
+                                    "timestamp": 1773138154.735
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "cmake/4.4.0": {
+            "revisions": {
+                "a5dd5d73bd9fc56b0fc3163a04573dc8": {
+                    "timestamp": 1784051561.926,
+                    "packages": {
+                        "522dcea5982a3f8a5b624c16477e47195da2f84f": {
+                            "revisions": {
+                                "7bce65533d0587701a6cdad1e4eb0872": {
+                                    "timestamp": 1784051852.369
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/conan/packages/windows-system.json
+++ b/conan/packages/windows-system.json
@@ -1,0 +1,39 @@
+{
+    "Local Cache": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            },
+                            "info": {}
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "conancenter": {
+        "glaze/7.8.4": {
+            "revisions": {
+                "17bfcc0739d8a1618cafd35327b1127e": {
+                    "timestamp": 1783515405.523,
+                    "packages": {
+                        "da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+                            "revisions": {
+                                "932b70d70c4d21bb16f60fa91cc3b653": {
+                                    "timestamp": 1783515504.367
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/conan/profiles/linux-build-cpp23
+++ b/conan/profiles/linux-build-cpp23
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=23
+build_type=Release

--- a/conan/profiles/linux-build-gnu17
+++ b/conan/profiles/linux-build-gnu17
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=gnu17
+build_type=Release

--- a/conan/profiles/linux-host
+++ b/conan/profiles/linux-host
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=23
+build_type=Release

--- a/conan/profiles/windows-build
+++ b/conan/profiles/windows-build
@@ -1,0 +1,12 @@
+[settings]
+os=Windows
+arch=x86_64
+compiler=msvc
+compiler.version=194
+compiler.runtime=dynamic
+compiler.runtime_type=Release
+compiler.cppstd=17
+build_type=Release
+
+[conf]
+tools.cmake.cmaketoolchain:generator=Ninja

--- a/conan/profiles/windows-host
+++ b/conan/profiles/windows-host
@@ -1,0 +1,12 @@
+[settings]
+os=Windows
+arch=x86_64
+compiler=msvc
+compiler.version=194
+compiler.runtime=dynamic
+compiler.runtime_type=Release
+compiler.cppstd=23
+build_type=Release
+
+[conf]
+tools.cmake.cmaketoolchain:generator=Ninja

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class HppProtoConan(ConanFile):
     def build_requirements(self):
         self.protoc_mode = self.conf.get("user.hpp_proto:protoc", default="find")
         if self.options.with_protobuf:
-            self.tool_requires("protobuf/[>=3.21.12]")
+            self.tool_requires("protobuf/7.35.0")
 
     def layout(self):
         cmake_layout(self)

--- a/ports/README.md
+++ b/ports/README.md
@@ -15,6 +15,8 @@ This directory contains local vcpkg overlay ports used by this repository.
   - Feature `vcpkg-protobuf` uses `protobuf`/`protoc` from vcpkg host tools.
 - `ports/glaze`: pinned overlay port for `glaze` `7.8.4`.
   - This overrides the registry `glaze` port when `--overlay-ports` points to this directory.
+- `ports/is-utf8`: pinned overlay port for `is-utf8` `1.4.1`.
+  - Its patch disables upstream benchmark downloads and installs the missing CMake target export.
 
 ## How Overlay Resolution Works
 
@@ -28,11 +30,10 @@ vcpkg prefers matching ports from this directory before registry ports.
 
 ### Install `hpp-proto` from this repository overlay
 
-Precondition: default mode, `protoc` must be installed and discoverable via `$PATH`.
+From the repository root, with `protoc` installed and discoverable via `$PATH`:
 
 ```bash
 "$VCPKG_ROOT/vcpkg" install \
-  hpp-proto \
   --triplet=x64-linux \
   --overlay-ports="$PWD/ports"
 ```
@@ -42,6 +43,7 @@ Precondition: default mode, `protoc` must be installed and discoverable via `$PA
 ```bash
 "$VCPKG_ROOT/vcpkg" install \
   "hpp-proto[vcpkg-protobuf]" \
+  --classic \
   --triplet=x64-linux \
   --overlay-ports="$PWD/ports"
 ```
@@ -60,4 +62,5 @@ cmake -S tutorial -B tutorial-build -G Ninja \
 ## Notes
 
 - If triplet/arch differs (for example in ARM containers), use the matching triplet (for example `arm64-linux`).
-- Keep `ports/glaze` aligned with the version expected by `hpp-proto`.
+- Keep the `glaze` and `is-utf8` overlay ports aligned with the versions expected by `hpp-proto`.
+- The repository-root manifest pins the vcpkg registry baseline used by CI. Update the baseline and the pinned `vcpkg` input in `.github/workflows/vcpkg.yml` together.

--- a/ports/hpp-proto/portfile.cmake
+++ b/ports/hpp-proto/portfile.cmake
@@ -24,7 +24,7 @@ vcpkg_cmake_configure(
         -DHPP_PROTO_BENCHMARKS=OFF
         -DHPP_PROTO_FUZZER_ONLY=OFF
         -DHPP_PROTO_PROTOC=${hpp_proto_protoc_mode}
-        -DCPM_USE_LOCAL_PACKAGES=ON
+        -DCPM_LOCAL_PACKAGES_ONLY=ON
         ${hpp_proto_extra_options}
 )
 

--- a/ports/hpp-proto/vcpkg.json
+++ b/ports/hpp-proto/vcpkg.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": [
     "glaze",
+    "is-utf8",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/is-utf8/fix-install-and-benchmarks.patch
+++ b/ports/is-utf8/fix-install-and-benchmarks.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2c98033..bc00403 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,6 +10,7 @@ include(GNUInstallDirs)
+ include(CTest)
+ 
+ option(IS_UTF8_SANITIZE "Sanitize addresses" OFF)
++option(IS_UTF8_BUILD_BENCHMARKS "Build benchmarks" OFF)
+ 
+ if (NOT CMAKE_BUILD_TYPE)
+   message(STATUS "No build type selected, default to Release")
+@@ -43,7 +44,9 @@ else()
+ endif(BUILD_TESTING)
+ 
+ 
+-add_subdirectory(benchmarks)
++if(IS_UTF8_BUILD_BENCHMARKS)
++  add_subdirectory(benchmarks)
++endif()
+ 
+ message(STATUS "Compiling using the C++ standard:" ${CMAKE_CXX_STANDARD})
+ # ---- Install rules ----
+@@ -75,6 +78,13 @@ install(
+     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+ )
+ 
++install(
++    EXPORT is_utf8Targets
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/is_utf8"
++    NAMESPACE is_utf8::
++    COMPONENT is_utf8_Development
++)
++
+ configure_file(cmake/is_utf8-config.cmake.in is_utf8-config.cmake @ONLY)
+ 
+ write_basic_package_version_file(

--- a/ports/is-utf8/portfile.cmake
+++ b/ports/is-utf8/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO simdutf/is_utf8
+    REF 77103c7462b9498f0bbc238260d1f1408a66a461
+    SHA512 9280df82aaf077e661e33352651976b2af7a686ed0ad51c6da959534168b6cb8e5a8f3e22073fe3dda0f4bad5a9990882678615604c2dd794b36692f6fc11f5b
+    PATCHES
+        fix-install-and-benchmarks.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DIS_UTF8_BUILD_BENCHMARKS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME is_utf8
+    CONFIG_PATH lib/cmake/is_utf8
+)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/LICENSE-APACHE"
+    "${SOURCE_PATH}/LICENSE-BOOST"
+    "${SOURCE_PATH}/LICENSE-MIT"
+)

--- a/ports/is-utf8/vcpkg.json
+++ b/ports/is-utf8/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "is-utf8",
+  "version": "1.4.1",
+  "description": "Fast UTF-8 validation",
+  "homepage": "https://github.com/simdutf/is_utf8",
+  "license": "Apache-2.0 OR BSL-1.0 OR MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "hpp-proto-ci",
+  "version-string": "1",
+  "builtin-baseline": "0878b5224d4a4968940ee296a2e7fae2d3b62983",
+  "dependencies": [
+    "hpp-proto"
+  ]
+}


### PR DESCRIPTION
## Summary

Make the vcpkg and Conan CI dependency graphs reproducible and fail closed when a pinned source or binary revision is unavailable.

## What changed

- Pin the vcpkg checkout and root registry baseline, add a checksum-verified `is-utf8` overlay port, and require all port dependencies to resolve locally.
- Pin Conan's Protobuf requirement and commit explicit Linux/Windows host and build profiles.
- Commit per-profile Conan lockfiles for versions/RREVs and package lists for package IDs/PREVs, then prefetch exactly those artifacts before running create/install with remotes disabled.
- Document the intentional package-manager lock update process.

## Why

The vcpkg port previously allowed CPM to fetch an undeclared dependency, while vcpkg and Conan CI could silently resolve different registries, recipes, or binaries over time. These controls put every dependency in the package-manager graph and make unexpected graph drift a build failure.

## Notes

The Windows Conan job is pinned to `windows-2022`/MSVC 194 because its committed package list targets the reviewed ConanCenter Protobuf binary for that compiler ABI.
