### PR TITLE
Fix segmented packed varint bounds

### DIFF
--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -119,7 +119,11 @@ struct input_buffer_region : input_span<Byte> {
       if (it == slope_area.rend()) {
         return {};
       }
-      return this->consume(this->size() - std::distance(slope_area.rbegin(), it));
+      const auto bytes_after_terminator = static_cast<std::size_t>(std::distance(slope_area.rbegin(), it));
+      if (bytes_after_terminator > this->size()) {
+        return {};
+      }
+      return this->consume(this->size() - bytes_after_terminator);
     }
     return {};
   }
@@ -387,9 +391,12 @@ struct basic_in {
   }
 
   template <concepts::varint T>
-  constexpr status parse_packed_varints_in_a_region(auto current, auto &&it) {
+  constexpr status parse_packed_varints_in_a_region(auto current, auto &&it, auto last) {
     using value_type = std::decay_t<decltype(*it)>;
     while (current.size()) {
+      if (it == last) [[unlikely]] {
+        return std::errc::bad_message;
+      }
       T underlying;
       auto p = unchecked_parse_varint(current, underlying);
       if (p > current._end) [[unlikely]] {
@@ -405,6 +412,7 @@ struct basic_in {
   template <concepts::varint T>
   constexpr status parse_packed_varints_in_regions(std::uint32_t bytes_count, auto &item) {
     auto it = item.data();
+    const auto last = item.data() + item.size();
     while (bytes_count > 0) {
       maybe_advance_region();
       auto data = current.consume_packed_varints(bytes_count);
@@ -412,7 +420,7 @@ struct basic_in {
         return std::errc::bad_message;
       }
       bytes_count -= static_cast<std::uint32_t>(data.size());
-      if (auto result = parse_packed_varints_in_a_region<T>(data, it); !result.ok()) [[unlikely]] {
+      if (auto result = parse_packed_varints_in_a_region<T>(data, it, last); !result.ok()) [[unlikely]] {
         return result;
       }
     }
@@ -425,7 +433,8 @@ struct basic_in {
     item.resize(item.size() + size);
     const std::span new_region{std::next(item.begin(), old_size), item.end()};
     if constexpr (contiguous) {
-      return parse_packed_varints_in_a_region<T>(current.consume(bytes_count), new_region.data());
+      return parse_packed_varints_in_a_region<T>(current.consume(bytes_count), new_region.data(),
+                                                 new_region.data() + new_region.size());
     } else {
       return parse_packed_varints_in_regions<T>(bytes_count, new_region);
     }
@@ -558,19 +567,20 @@ struct basic_in {
       if constexpr (!contiguous) {
         basic_in archive(*this);
         std::size_t result = 0;
-        while (num_bytes > 0 && in_avail() > 0) {
+        while (num_bytes > 0 && archive.in_avail() > 0) {
           archive.maybe_advance_region();
           if (num_bytes > archive.region_size()) {
             auto n = archive.region_size();
-            result += archive.count_number_of_varints_in_region(n);
-            archive.current.consume(n);
+            result += archive.count_number_of_varints_in_region(static_cast<std::size_t>(n));
+            archive.current.consume(static_cast<std::size_t>(n));
             num_bytes -= static_cast<uint32_t>(n);
           } else {
-            if (std::bit_cast<int8_t>(archive.current[num_bytes - 1]) < 0) [[unlikely]] {
+            const auto remaining = static_cast<std::size_t>(num_bytes);
+            if (std::bit_cast<int8_t>(archive.current[remaining - 1]) < 0) [[unlikely]] {
               // if the last element is unterminated, just return empty to indicate error
               return {};
             }
-            return result + archive.count_number_of_varints_in_region(num_bytes);
+            return result + archive.count_number_of_varints_in_region(remaining);
           }
         }
       }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -58,8 +58,10 @@ const boost::ut::suite map_test = [] {
                            "\x80\x80\x00\xa2\x23\x80\x80\x00\x90\x02\xcc\x21\x90\x01\x0f\x00"
                            "\x80\x3a\x05\x0d\x01\xf0\x00\x80\x3a\x05\x0d\x01\xa0\x08\x01\x3a"
                            "\x05\x0d\x01\x41\x80\x80"_bytes;
+    constexpr std::size_t crash_split_offset = 67;
     const std::span<const std::byte> crash_span{crash.data(), crash.size()};
-    std::array<std::span<const std::byte>, 2> chunks{crash_span.first<67>(), crash_span.subspan<67>()};
+    const std::array<std::span<const std::byte>, 2> chunks{crash_span.first(crash_split_offset),
+                                                           crash_span.subspan(crash_split_offset)};
     protobuf_unittest::TestMap<hpp_proto::stable_traits> contiguous_message;
     protobuf_unittest::TestMap<hpp_proto::stable_traits> segmented_message;
 
@@ -73,13 +75,26 @@ const boost::ut::suite map_test = [] {
     std::array<std::byte, 2> input{std::byte{0}, std::byte{0}};
     std::array<std::int64_t, 1> output{};
     hpp_proto::pb_context<> context;
-    hpp_proto::pb_serializer::input_buffer_region<std::byte> region{std::span<const std::byte>{input}};
-    hpp_proto::pb_serializer::input_span<hpp_proto::pb_serializer::input_buffer_region<std::byte>> rest;
+    const hpp_proto::pb_serializer::input_buffer_region<std::byte> region{std::span<const std::byte>{input}};
+    const hpp_proto::pb_serializer::input_span<hpp_proto::pb_serializer::input_buffer_region<std::byte>> rest;
     hpp_proto::pb_serializer::basic_in<std::byte, hpp_proto::pb_context<>, true> archive{region, rest, 0, context};
 
     const auto result = archive.template parse_packed_varints_in_a_region<hpp_proto::vsint64_t>(
-        archive.current, output.data(), output.data() + output.size());
+        archive.current, output.begin(), output.end());
     expect(eq(result.ec, std::errc::bad_message));
+  };
+
+  "packed varints reject a terminator before the current region"_test = [] {
+    constexpr std::array input{std::byte{0}, std::byte{0x80}, std::byte{0x80}};
+    constexpr std::size_t current_offset = 2;
+    constexpr std::size_t requested_size = 2;
+    const std::span<const std::byte> bytes{input};
+    const auto current = bytes.subspan(current_offset);
+    hpp_proto::pb_serializer::input_buffer_region<std::byte> region{
+        hpp_proto::pb_serializer::input_span<std::byte>{current.data(), current.size()}, bytes.data()};
+
+    const auto result = region.consume_packed_varints(requested_size);
+    expect(result.empty());
   };
 };
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -47,6 +47,40 @@ const boost::ut::suite map_test = [] {
     expect(hpp_proto::read_json(msg, non_null_terminated_json, hpp_proto::alloc_from(mr)).ok());
     ExpectMapFieldsSet(msg);
   } | std::tuple<::hpp_proto::stable_traits, ::hpp_proto::non_owning_traits>();
+
+  "segmented packed varint crash regression"_test = [] {
+    constexpr auto crash = "\x3a\x05\x0d\x90\x02\xcc\x01\x90\x02\x01\x90\x28\x3d\x9a\x01\x3a"
+                           "\x08\x29\x80\xa8\x12\x3d\x9a\x01\x02\x08\x30\x12\x2a\x08\x00\xa8"
+                           "\x28\x3d\xda\x01\x00\x08\x34\xa8\x28\x80\x00\xa2\x12\x85\x80\x00"
+                           "\xda\x01\x00\x08\x34\xa8\x28\x84\x00\xa2\x02\x85\x80\x00\x02\x85"
+                           "\x80\x80\x00\xa2\x02\x85\x80\x80\x00\xa2\x23\x80\x80\x00\x90\x02"
+                           "\xcc\x01\x90\x02\x01\x90\x28\x3d\x02\x85\x80\x80\x00\xa2\x02\x85"
+                           "\x80\x80\x00\xa2\x23\x80\x80\x00\x90\x02\xcc\x21\x90\x01\x0f\x00"
+                           "\x80\x3a\x05\x0d\x01\xf0\x00\x80\x3a\x05\x0d\x01\xa0\x08\x01\x3a"
+                           "\x05\x0d\x01\x41\x80\x80"_bytes;
+    const std::span<const std::byte> crash_span{crash.data(), crash.size()};
+    std::array<std::span<const std::byte>, 2> chunks{crash_span.first<67>(), crash_span.subspan<67>()};
+    protobuf_unittest::TestMap<hpp_proto::stable_traits> contiguous_message;
+    protobuf_unittest::TestMap<hpp_proto::stable_traits> segmented_message;
+
+    const auto contiguous = hpp_proto::read_binpb(contiguous_message, crash);
+    const auto segmented = hpp_proto::read_binpb(segmented_message, chunks);
+    expect(eq(contiguous.ec, std::errc::bad_message));
+    expect(eq(segmented.ec, std::errc::bad_message));
+  };
+
+  "packed varints respect destination bounds"_test = [] {
+    std::array<std::byte, 2> input{std::byte{0}, std::byte{0}};
+    std::array<std::int64_t, 1> output{};
+    hpp_proto::pb_context<> context;
+    hpp_proto::pb_serializer::input_buffer_region<std::byte> region{std::span<const std::byte>{input}};
+    hpp_proto::pb_serializer::input_span<hpp_proto::pb_serializer::input_buffer_region<std::byte>> rest;
+    hpp_proto::pb_serializer::basic_in<std::byte, hpp_proto::pb_context<>, true> archive{region, rest, 0, context};
+
+    const auto result = archive.template parse_packed_varints_in_a_region<hpp_proto::vsint64_t>(
+        archive.current, output.data(), output.data() + output.size());
+    expect(eq(result.ec, std::errc::bad_message));
+  };
 };
 
 // NOLINTNEXTLINE(bugprone-exception-escape)


### PR DESCRIPTION
## Summary

Prevent segmented packed-varint decoding from writing beyond its pre-sized destination when malformed input causes element counting and decoding to diverge.

## What changed

- Check destination capacity before writing each decoded packed varint.
- Harden segmented-region consumption and ensure element counting advances the copied archive state.
- Add the exact ClusterFuzzLite input as a regression covering both contiguous and segmented decoding.

## Why

The [ClusterFuzzLite address-sanitizer run](https://github.com/huangminghuang/hpp-proto/actions/runs/29721485424/job/88285239682) found a heap-buffer-overflow while decoding a malformed packed `sint64` field split across input regions. The segmented decoder allocated from its precomputed element count but decoded an additional value. The decoder now rejects that mismatch as `std::errc::bad_message` before writing outside the destination.
