### PR TITLE
Fix non-owning unknown field materialization

### DIFF
--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -636,8 +636,8 @@ constexpr status deserialize_unknown_fields(concepts::uint32_pair_contiguous_ran
                             [field_num](const auto &e) { return e.first == field_num; });
     if (itr != unknown_fields.end()) {
       // the extension with the same field number exists, append the content to the previously parsed.
-      return archive.deserialize_packed(
-          field_len, detail::as_modifiable(archive.context, const_cast<bytes_type &>(itr->second)));
+      return archive.deserialize_packed(field_len,
+                                        detail::as_modifiable(archive.context, const_cast<bytes_type &>(itr->second)));
     }
   }
 

--- a/include/hpp_proto/binpb/deserialize.hpp
+++ b/include/hpp_proto/binpb/deserialize.hpp
@@ -46,6 +46,12 @@ inline constexpr std::size_t unknown_enum_buffer_size = max_varint_bytes + max_v
 inline constexpr std::size_t fixed_64_size = sizeof(std::uint64_t);
 inline constexpr std::size_t fixed_32_size = sizeof(std::uint32_t);
 
+constexpr void materialize_for_search(auto &range) {
+  if constexpr (requires { range.reserve(range.size()); }) {
+    range.reserve(range.size());
+  }
+}
+
 template <typename T>
 struct input_span {
   using value_type = T;
@@ -621,24 +627,27 @@ constexpr status deserialize_unknown_fields(concepts::associative_container auto
 constexpr status deserialize_unknown_fields(concepts::uint32_pair_contiguous_range auto &unknown_fields,
                                             uint32_t field_num, std::size_t field_len,
                                             concepts::is_basic_in auto &archive) {
-  auto itr = std::find_if(unknown_fields.begin(), unknown_fields.end(),
-                          [field_num](const auto &e) { return e.first == field_num; });
-
   using fields_type = std::remove_cvref_t<decltype(unknown_fields)>;
   using bytes_type = fields_type::value_type::second_type;
 
-  if (itr == unknown_fields.end()) [[likely]] {
-    bytes_type field_span;
-    if (auto result = archive.deserialize_packed(field_len, detail::as_modifiable(archive.context, field_span));
-        !result.ok()) {
-      return result;
+  if (!unknown_fields.empty()) {
+    materialize_for_search(unknown_fields);
+    auto itr = std::find_if(unknown_fields.begin(), unknown_fields.end(),
+                            [field_num](const auto &e) { return e.first == field_num; });
+    if (itr != unknown_fields.end()) {
+      // the extension with the same field number exists, append the content to the previously parsed.
+      return archive.deserialize_packed(
+          field_len, detail::as_modifiable(archive.context, const_cast<bytes_type &>(itr->second)));
     }
-    unknown_fields.push_back({field_num, field_span});
-    return {};
   }
-  // the extension with the same field number exists, append the content to the previously parsed.
-  return archive.deserialize_packed(field_len,
-                                    detail::as_modifiable(archive.context, const_cast<bytes_type &>(itr->second)));
+
+  bytes_type field_span;
+  if (auto result = archive.deserialize_packed(field_len, detail::as_modifiable(archive.context, field_span));
+      !result.ok()) {
+    return result;
+  }
+  unknown_fields.push_back({field_num, field_span});
+  return {};
 }
 
 constexpr status deserialize_unknown_fields(concepts::contiguous_byte_range auto &unknown_fields, uint32_t /*unused*/,
@@ -659,15 +668,22 @@ constexpr void deserialize_unknown_enum(auto &unknown_fields, uint32_t field_num
   } else if constexpr (concepts::associative_container<unknown_fields_t>) {
     util::append_range(unknown_fields[field_num], field_span);
   } else if constexpr (concepts::uint32_pair_contiguous_range<unknown_fields_t>) {
-    auto itr = std::find_if(unknown_fields.begin(), unknown_fields.end(),
-                            [field_num](const auto &e) { return e.first == field_num; });
-    if (itr == unknown_fields.end()) {
-      unknown_fields.push_back({field_num, field_span});
-    } else {
-      using bytes_type = unknown_fields_t::value_type::second_type;
-      decltype(auto) v = detail::as_modifiable(archive.context, const_cast<bytes_type &>(itr->second));
-      util::append_range(v, field_span);
+    if (!unknown_fields.empty()) {
+      materialize_for_search(unknown_fields);
+      auto itr = std::find_if(unknown_fields.begin(), unknown_fields.end(),
+                              [field_num](const auto &e) { return e.first == field_num; });
+      if (itr != unknown_fields.end()) {
+        using bytes_type = unknown_fields_t::value_type::second_type;
+        decltype(auto) v = detail::as_modifiable(archive.context, const_cast<bytes_type &>(itr->second));
+        util::append_range(v, field_span);
+        return;
+      }
     }
+    using bytes_type = unknown_fields_t::value_type::second_type;
+    bytes_type persisted_field;
+    decltype(auto) v = detail::as_modifiable(archive.context, persisted_field);
+    util::append_range(v, field_span);
+    unknown_fields.push_back({field_num, persisted_field});
   }
 }
 

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1377,6 +1377,29 @@ auto pb_meta(const extension_example<Traits> &) -> std::tuple<
     hpp_proto::field_meta<1, &extension_example<Traits>::int_value, field_option::none, hpp_proto::vint64_t>,
     hpp_proto::field_meta<UINT32_MAX, &extension_example<Traits>::unknown_fields_>>;
 
+template <typename Traits = hpp_proto::default_traits>
+struct closed_enum_extension_child {
+  std::optional<ForeignEnum> foreign_enum_field;
+  hpp_proto::pb_extensions<Traits> unknown_fields_;
+  bool operator==(const closed_enum_extension_child &) const = default;
+};
+
+template <typename Traits>
+auto pb_meta(const closed_enum_extension_child<Traits> &) -> std::tuple<
+    hpp_proto::field_meta<1, &closed_enum_extension_child<Traits>::foreign_enum_field,
+                          field_option::explicit_presence | field_option::closed_enum>,
+    hpp_proto::field_meta<UINT32_MAX, &closed_enum_extension_child<Traits>::unknown_fields_>>;
+
+template <typename Child>
+struct optional_extension_child {
+  std::optional<Child> child;
+  bool operator==(const optional_extension_child &) const = default;
+};
+
+template <typename Child>
+auto pb_meta(const optional_extension_child<Child> &)
+    -> std::tuple<hpp_proto::field_meta<1, &optional_extension_child<Child>::child, field_option::explicit_presence>>;
+
 template <typename Traits = ::hpp_proto::default_traits>
 struct i32_ext : hpp_proto::extension_base<i32_ext<Traits>, extension_example> {
   using value_type = std::int32_t;
@@ -1545,6 +1568,31 @@ const ut::suite test_extensions = [] {
 
 const ut::suite test_non_owning_extensions = [] {
   using non_owning_extension_example = extension_example<hpp_proto::non_owning_traits>;
+  "repeated_singular_message_materializes_non_owning_extensions_before_search"_test = [] {
+    optional_extension_child<non_owning_extension_example> value;
+    std::pmr::monotonic_buffer_resource mr;
+
+    ut::expect(hpp_proto::read_binpb(value, "\x0a\x02\x50\x01\x0a\x02\x50\x02"sv, hpp_proto::alloc_from{mr}).ok());
+    ut::expect(value.child.has_value());
+    const auto &fields = value.child->unknown_fields_.fields;
+    ut::expect(fields.size() == 1U);
+    ut::expect(fields.front().first == 10U);
+    ut::expect(std::ranges::equal(fields.front().second, "\x50\x01\x50\x02"_bytes));
+  };
+
+  "repeated_singular_message_materializes_closed_enum_extensions_before_search"_test = [] {
+    optional_extension_child<closed_enum_extension_child<hpp_proto::non_owning_traits>> value;
+    std::pmr::monotonic_buffer_resource mr;
+
+    ut::expect(hpp_proto::read_binpb(value, "\x0a\x02\x08\x04\x0a\x02\x08\x05"sv, hpp_proto::alloc_from{mr}).ok());
+    ut::expect(value.child.has_value());
+    ut::expect(!value.child->foreign_enum_field.has_value());
+    const auto &fields = value.child->unknown_fields_.fields;
+    ut::expect(fields.size() == 1U);
+    ut::expect(fields.front().first == 1U);
+    ut::expect(std::ranges::equal(fields.front().second, "\x08\x04\x08\x05"_bytes));
+  };
+
   "get_chunked_non_owning_extension"_test = [] {
     using namespace std::literals;
     const auto encoded_data = "\x5a\x14"

--- a/unittests/pb_serializer_tests.cpp
+++ b/unittests/pb_serializer_tests.cpp
@@ -1385,10 +1385,10 @@ struct closed_enum_extension_child {
 };
 
 template <typename Traits>
-auto pb_meta(const closed_enum_extension_child<Traits> &) -> std::tuple<
-    hpp_proto::field_meta<1, &closed_enum_extension_child<Traits>::foreign_enum_field,
-                          field_option::explicit_presence | field_option::closed_enum>,
-    hpp_proto::field_meta<UINT32_MAX, &closed_enum_extension_child<Traits>::unknown_fields_>>;
+auto pb_meta(const closed_enum_extension_child<Traits> &)
+    -> std::tuple<hpp_proto::field_meta<1, &closed_enum_extension_child<Traits>::foreign_enum_field,
+                                        field_option::explicit_presence | field_option::closed_enum>,
+                  hpp_proto::field_meta<UINT32_MAX, &closed_enum_extension_child<Traits>::unknown_fields_>>;
 
 template <typename Child>
 struct optional_extension_child {


### PR DESCRIPTION
## Summary

Fix a non-owning unknown-field deserialization crash when repeated singular messages merge into extension storage that is backed by a lazily materialized arena vector.

## What changed

- Materialize pair-contiguous unknown-field storage before searching existing field entries.
- Copy synthesized closed-enum unknown-field bytes into arena-backed storage before inserting a new extension entry.
- Add regressions for repeated singular submessage merges with non-owning extension storage, including invalid closed-enum preservation.

## Why

ClusterFuzzLite found that `fuzz_descriptor` could trip `arena_vector::data()` while parsing descriptor options. The parser wrapped a non-empty non-owning extension span, then searched it before the lazy arena vector had materialized storage. This keeps the lazy behavior intact while materializing only at the search sites that require mutable iteration.

## Testing

- Replayed the original UBSan and companion ASan ClusterFuzzLite reproducer inputs against the rebuilt `fuzz_descriptor` with `-runs=1`; both exited cleanly.
