### PR TITLE
Fix allocator-propagating pointer swaps

### DIFF
--- a/include/hpp_proto/indirect.hpp
+++ b/include/hpp_proto/indirect.hpp
@@ -109,35 +109,54 @@ public:
     return *this;
   }
 
-  constexpr indirect & // NOLINTNEXTLINE(bugprone-exception-escape)
-  operator=(indirect &&other) noexcept((allocator_traits::propagate_on_container_move_assignment::value &&
-                                        std::is_nothrow_move_assignable_v<allocator_type>) ||
-                                       allocator_traits::is_always_equal::value) {
+  constexpr indirect &operator=(indirect &&other) noexcept(std::is_nothrow_move_assignable_v<allocator_type>)
+    requires(allocator_traits::propagate_on_container_move_assignment::value)
+  {
     if (this == &other) {
       return *this;
     }
-    if constexpr (allocator_traits::propagate_on_container_move_assignment::value) {
+    destroy();
+    alloc_ = std::move(other.alloc_);
+    obj_ = std::exchange(other.obj_, nullptr);
+    return *this;
+  }
+
+  constexpr indirect &operator=(indirect &&other) noexcept
+    requires(!allocator_traits::propagate_on_container_move_assignment::value &&
+             allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
+      return *this;
+    }
+    destroy();
+    obj_ = std::exchange(other.obj_, nullptr);
+    return *this;
+  }
+
+  // Unequal non-propagating allocators require value move/allocate fallback, so this overload cannot be noexcept.
+  // NOLINTNEXTLINE(bugprone-exception-escape,cppcoreguidelines-noexcept-move-operations,hicpp-noexcept-move,performance-noexcept-move-constructor)
+  constexpr indirect &operator=(indirect &&other)
+    requires(!allocator_traits::propagate_on_container_move_assignment::value &&
+             !allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
+      return *this;
+    }
+    if (alloc_ == other.alloc_) {
       destroy();
-      alloc_ = std::move(other.alloc_);
       obj_ = std::exchange(other.obj_, nullptr);
       return *this;
-    } else if constexpr (allocator_traits::is_always_equal::value) {
-      destroy();
-      obj_ = std::exchange(other.obj_, nullptr);
-      return *this;
-    } else {
-      if (alloc_ == other.alloc_) {
-        destroy();
-        obj_ = std::exchange(other.obj_, nullptr);
-        return *this;
-      }
+    }
+    if (other.obj_) {
       if (obj_) {
         *raw_ptr() = std::move(*other.raw_ptr());
       } else {
         obj_ = allocate_construct(std::move(*other.raw_ptr()));
       }
-      return *this;
+    } else {
+      destroy();
     }
+    return *this;
   }
 
   [[nodiscard]] constexpr T &value() & noexcept { return *raw_ptr(); }
@@ -179,21 +198,46 @@ public:
     return *raw_ptr() <=> *rhs.raw_ptr();
   }
 
-  constexpr void swap(indirect &other) noexcept(allocator_traits::is_always_equal::value ||
-                                                (allocator_traits::propagate_on_container_swap::value &&
-                                                 std::is_nothrow_swappable_v<allocator_type>)) {
-    using std::swap;
-    if constexpr (allocator_traits::propagate_on_container_swap::value) {
-      swap(alloc_, other.alloc_);
+  constexpr void swap(indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>)
+    requires(allocator_traits::propagate_on_container_swap::value)
+  {
+    if (this == &other) {
+      return;
     }
-    if constexpr (allocator_traits::is_always_equal::value) {
+    using std::swap;
+    swap(alloc_, other.alloc_);
+    swap(obj_, other.obj_);
+  }
+
+  constexpr void swap(indirect &other) noexcept
+    requires(!allocator_traits::propagate_on_container_swap::value && allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
+      return;
+    }
+    using std::swap;
+    swap(obj_, other.obj_);
+  }
+
+  // Unequal non-propagating allocators require value move/allocate fallback, so this overload cannot be noexcept.
+  // NOLINTNEXTLINE(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+  constexpr void swap(indirect &other)
+    requires(!allocator_traits::propagate_on_container_swap::value && !allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
+      return;
+    }
+    using std::swap;
+    if (alloc_ == other.alloc_) {
       swap(obj_, other.obj_);
-    } else {
-      if (alloc_ == other.alloc_) {
-        swap(obj_, other.obj_);
-      } else {
-        swap(*raw_ptr(), *other.raw_ptr());
-      }
+    } else if (obj_ && other.obj_) {
+      swap(*raw_ptr(), *other.raw_ptr());
+    } else if (obj_) {
+      other.obj_ = other.allocate_construct(std::move(*raw_ptr()));
+      destroy();
+    } else if (other.obj_) {
+      obj_ = allocate_construct(std::move(*other.raw_ptr()));
+      other.destroy();
     }
   }
 

--- a/include/hpp_proto/indirect.hpp
+++ b/include/hpp_proto/indirect.hpp
@@ -112,12 +112,7 @@ public:
   constexpr indirect &operator=(indirect &&other) noexcept(std::is_nothrow_move_assignable_v<allocator_type>)
     requires(allocator_traits::propagate_on_container_move_assignment::value)
   {
-    if (this == &other) {
-      return *this;
-    }
-    destroy();
-    alloc_ = std::move(other.alloc_);
-    obj_ = std::exchange(other.obj_, nullptr);
+    move_assign_with_allocator_propagation(other);
     return *this;
   }
 
@@ -125,11 +120,7 @@ public:
     requires(!allocator_traits::propagate_on_container_move_assignment::value &&
              allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return *this;
-    }
-    destroy();
-    obj_ = std::exchange(other.obj_, nullptr);
+    move_assign_with_equal_allocator(other);
     return *this;
   }
 
@@ -139,23 +130,7 @@ public:
     requires(!allocator_traits::propagate_on_container_move_assignment::value &&
              !allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return *this;
-    }
-    if (alloc_ == other.alloc_) {
-      destroy();
-      obj_ = std::exchange(other.obj_, nullptr);
-      return *this;
-    }
-    if (other.obj_) {
-      if (obj_) {
-        *raw_ptr() = std::move(*other.raw_ptr());
-      } else {
-        obj_ = allocate_construct(std::move(*other.raw_ptr()));
-      }
-    } else {
-      destroy();
-    }
+    move_assign_with_runtime_allocator_check(other);
     return *this;
   }
 
@@ -201,22 +176,13 @@ public:
   constexpr void swap(indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>)
     requires(allocator_traits::propagate_on_container_swap::value)
   {
-    if (this == &other) {
-      return;
-    }
-    using std::swap;
-    swap(alloc_, other.alloc_);
-    swap(obj_, other.obj_);
+    swap_with_allocator_propagation(other);
   }
 
   constexpr void swap(indirect &other) noexcept
     requires(!allocator_traits::propagate_on_container_swap::value && allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return;
-    }
-    using std::swap;
-    swap(obj_, other.obj_);
+    swap_with_equal_allocator(other);
   }
 
   // Unequal non-propagating allocators require value move/allocate fallback, so this overload cannot be noexcept.
@@ -224,21 +190,7 @@ public:
   constexpr void swap(indirect &other)
     requires(!allocator_traits::propagate_on_container_swap::value && !allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return;
-    }
-    using std::swap;
-    if (alloc_ == other.alloc_) {
-      swap(obj_, other.obj_);
-    } else if (obj_ && other.obj_) {
-      swap(*raw_ptr(), *other.raw_ptr());
-    } else if (obj_) {
-      other.obj_ = other.allocate_construct(std::move(*raw_ptr()));
-      destroy();
-    } else if (other.obj_) {
-      obj_ = allocate_construct(std::move(*other.raw_ptr()));
-      other.destroy();
-    }
+    swap_with_runtime_allocator_check(other);
   }
 
   [[nodiscard]] constexpr allocator_type get_allocator() const noexcept { return alloc_; }
@@ -246,6 +198,123 @@ public:
 private:
   [[nodiscard]] constexpr T *raw_ptr() noexcept { return std::to_address(obj_); }
   [[nodiscard]] constexpr const T *raw_ptr() const noexcept { return std::to_address(obj_); }
+
+  constexpr void
+  move_assign_with_allocator_propagation(indirect &other) noexcept(std::is_nothrow_move_assignable_v<allocator_type>) {
+    if (this != &other) {
+      release_object();
+      alloc_ = std::move(other.alloc_);
+      take_object_from(other);
+    }
+  }
+
+  constexpr void move_assign_with_equal_allocator(indirect &other) noexcept {
+    if (this != &other) {
+      release_object();
+      take_object_from(other);
+    }
+  }
+
+  constexpr void move_assign_with_runtime_allocator_check(indirect &other) {
+    if (this != &other && !try_take_object_with_equal_allocator(other)) {
+      move_value_or_release(other);
+    }
+  }
+
+  constexpr bool try_take_object_with_equal_allocator(indirect &other) {
+    if (!(alloc_ == other.alloc_)) {
+      return false;
+    }
+    release_object();
+    take_object_from(other);
+    return true;
+  }
+
+  constexpr void move_value_or_release(indirect &other) {
+    if (other.obj_) {
+      move_value_from(other);
+    } else {
+      release_object();
+    }
+  }
+
+  constexpr void move_value_from(indirect &other) {
+    if (obj_) {
+      *raw_ptr() = std::move(*other.raw_ptr());
+    } else {
+      obj_ = allocate_construct(std::move(*other.raw_ptr()));
+    }
+  }
+
+  constexpr void
+  swap_with_allocator_propagation(indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>) {
+    if (this != &other) {
+      swap_allocators(other);
+      swap_object_pointers(other);
+    }
+  }
+
+  constexpr void swap_with_equal_allocator(indirect &other) noexcept {
+    if (this != &other) {
+      swap_object_pointers(other);
+    }
+  }
+
+  constexpr void swap_with_runtime_allocator_check(indirect &other) {
+    if (this != &other && !try_swap_object_with_equal_allocator(other)) {
+      swap_values_or_rehome(other);
+    }
+  }
+
+  constexpr bool try_swap_object_with_equal_allocator(indirect &other) {
+    if (!(alloc_ == other.alloc_)) {
+      return false;
+    }
+    swap_object_pointers(other);
+    return true;
+  }
+
+  constexpr void swap_values_or_rehome(indirect &other) {
+    if (both_have_objects(other)) {
+      swap_object_values(other);
+    } else {
+      rehome_present_value(other);
+    }
+  }
+
+  constexpr void rehome_present_value(indirect &other) {
+    if (obj_) {
+      move_value_to_empty(other);
+    } else if (other.obj_) {
+      other.move_value_to_empty(*this);
+    }
+  }
+
+  [[nodiscard]] constexpr bool both_have_objects(const indirect &other) const noexcept { return obj_ && other.obj_; }
+
+  constexpr void swap_allocators(indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>) {
+    using std::swap;
+    swap(alloc_, other.alloc_);
+  }
+
+  constexpr void swap_object_pointers(indirect &other) noexcept {
+    using std::swap;
+    swap(obj_, other.obj_);
+  }
+
+  constexpr void swap_object_values(indirect &other) {
+    using std::swap;
+    swap(*raw_ptr(), *other.raw_ptr());
+  }
+
+  constexpr void move_value_to_empty(indirect &empty) {
+    empty.obj_ = empty.allocate_construct(std::move(*raw_ptr()));
+    release_object();
+  }
+
+  constexpr void take_object_from(indirect &other) noexcept { obj_ = std::exchange(other.obj_, nullptr); }
+
+  constexpr void release_object() noexcept { destroy(); }
 
   constexpr pointer allocate_default() {
     pointer p = allocator_traits::allocate(alloc_, 1);

--- a/include/hpp_proto/optional_indirect.hpp
+++ b/include/hpp_proto/optional_indirect.hpp
@@ -94,39 +94,55 @@ public:
     emplace(std::forward<Args>(args)...);
   }
 
-  constexpr optional_indirect & // NOLINTNEXTLINE(bugprone-exception-escape,misc-no-recursion)
-  operator=(optional_indirect &&other) noexcept((allocator_traits::propagate_on_container_move_assignment::value &&
-                                                 std::is_nothrow_move_assignable_v<allocator_type>) ||
-                                                allocator_traits::is_always_equal::value) {
+  constexpr optional_indirect &
+  operator=(optional_indirect &&other) noexcept(std::is_nothrow_move_assignable_v<allocator_type>)
+    requires(allocator_traits::propagate_on_container_move_assignment::value)
+  {
     if (this == &other) {
       return *this;
     }
-    if constexpr (allocator_traits::propagate_on_container_move_assignment::value) {
-      reset();
-      alloc_ = std::move(other.alloc_);
-      obj_ = std::exchange(other.obj_, nullptr);
-      return *this;
-    } else if constexpr (allocator_traits::is_always_equal::value) {
-      reset();
-      obj_ = std::exchange(other.obj_, nullptr);
-      return *this;
-    } else {
-      if (alloc_ == other.alloc_) {
-        reset();
-        obj_ = std::exchange(other.obj_, nullptr);
-        return *this;
-      }
-      if (other.obj_) {
-        if (obj_) {
-          *raw_ptr() = std::move(*other.raw_ptr());
-        } else {
-          emplace(std::move(*other.raw_ptr()));
-        }
-      } else {
-        reset();
-      }
+    reset();
+    alloc_ = std::move(other.alloc_);
+    obj_ = std::exchange(other.obj_, nullptr);
+    return *this;
+  }
+
+  constexpr optional_indirect &operator=(optional_indirect &&other) noexcept
+    requires(!allocator_traits::propagate_on_container_move_assignment::value &&
+             allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
       return *this;
     }
+    reset();
+    obj_ = std::exchange(other.obj_, nullptr);
+    return *this;
+  }
+
+  // Unequal non-propagating allocators require value move/allocate fallback, so this overload cannot be noexcept.
+  // NOLINTNEXTLINE(bugprone-exception-escape,cppcoreguidelines-noexcept-move-operations,hicpp-noexcept-move,misc-no-recursion,performance-noexcept-move-constructor)
+  constexpr optional_indirect &operator=(optional_indirect &&other)
+    requires(!allocator_traits::propagate_on_container_move_assignment::value &&
+             !allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
+      return *this;
+    }
+    if (alloc_ == other.alloc_) {
+      reset();
+      obj_ = std::exchange(other.obj_, nullptr);
+      return *this;
+    }
+    if (other.obj_) {
+      if (obj_) {
+        *raw_ptr() = std::move(*other.raw_ptr());
+      } else {
+        emplace(std::move(*other.raw_ptr()));
+      }
+    } else {
+      reset();
+    }
+    return *this;
   }
 
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
@@ -199,21 +215,36 @@ public:
     return emplace_impl(std::forward<Args>(args)...);
   }
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  constexpr void swap(optional_indirect &other) noexcept(
-      (allocator_traits::propagate_on_container_swap::value && std::is_nothrow_swappable_v<allocator_type>) ||
-      (!allocator_traits::propagate_on_container_swap::value && allocator_traits::is_always_equal::value)) {
+  constexpr void swap(optional_indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>)
+    requires(allocator_traits::propagate_on_container_swap::value)
+  {
     if (this == &other) {
       return;
     }
     using std::swap;
-    if constexpr (allocator_traits::propagate_on_container_swap::value) {
-      swap(alloc_, other.alloc_);
-    }
-    if constexpr (allocator_traits::is_always_equal::value) {
-      swap(obj_, other.obj_);
+    swap(alloc_, other.alloc_);
+    swap(obj_, other.obj_);
+  }
+
+  constexpr void swap(optional_indirect &other) noexcept
+    requires(!allocator_traits::propagate_on_container_swap::value && allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
       return;
     }
+    using std::swap;
+    swap(obj_, other.obj_);
+  }
+
+  // Unequal non-propagating allocators require value move/allocate fallback, so this overload cannot be noexcept.
+  // NOLINTNEXTLINE(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+  constexpr void swap(optional_indirect &other)
+    requires(!allocator_traits::propagate_on_container_swap::value && !allocator_traits::is_always_equal::value)
+  {
+    if (this == &other) {
+      return;
+    }
+    using std::swap;
     if (alloc_ == other.alloc_) {
       swap(obj_, other.obj_);
     } else if (obj_ && other.obj_) {

--- a/include/hpp_proto/optional_indirect.hpp
+++ b/include/hpp_proto/optional_indirect.hpp
@@ -98,12 +98,7 @@ public:
   operator=(optional_indirect &&other) noexcept(std::is_nothrow_move_assignable_v<allocator_type>)
     requires(allocator_traits::propagate_on_container_move_assignment::value)
   {
-    if (this == &other) {
-      return *this;
-    }
-    reset();
-    alloc_ = std::move(other.alloc_);
-    obj_ = std::exchange(other.obj_, nullptr);
+    move_assign_with_allocator_propagation(other);
     return *this;
   }
 
@@ -111,11 +106,7 @@ public:
     requires(!allocator_traits::propagate_on_container_move_assignment::value &&
              allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return *this;
-    }
-    reset();
-    obj_ = std::exchange(other.obj_, nullptr);
+    move_assign_with_equal_allocator(other);
     return *this;
   }
 
@@ -125,23 +116,7 @@ public:
     requires(!allocator_traits::propagate_on_container_move_assignment::value &&
              !allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return *this;
-    }
-    if (alloc_ == other.alloc_) {
-      reset();
-      obj_ = std::exchange(other.obj_, nullptr);
-      return *this;
-    }
-    if (other.obj_) {
-      if (obj_) {
-        *raw_ptr() = std::move(*other.raw_ptr());
-      } else {
-        emplace(std::move(*other.raw_ptr()));
-      }
-    } else {
-      reset();
-    }
+    move_assign_with_runtime_allocator_check(other);
     return *this;
   }
 
@@ -218,22 +193,13 @@ public:
   constexpr void swap(optional_indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>)
     requires(allocator_traits::propagate_on_container_swap::value)
   {
-    if (this == &other) {
-      return;
-    }
-    using std::swap;
-    swap(alloc_, other.alloc_);
-    swap(obj_, other.obj_);
+    swap_with_allocator_propagation(other);
   }
 
   constexpr void swap(optional_indirect &other) noexcept
     requires(!allocator_traits::propagate_on_container_swap::value && allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return;
-    }
-    using std::swap;
-    swap(obj_, other.obj_);
+    swap_with_equal_allocator(other);
   }
 
   // Unequal non-propagating allocators require value move/allocate fallback, so this overload cannot be noexcept.
@@ -241,21 +207,7 @@ public:
   constexpr void swap(optional_indirect &other)
     requires(!allocator_traits::propagate_on_container_swap::value && !allocator_traits::is_always_equal::value)
   {
-    if (this == &other) {
-      return;
-    }
-    using std::swap;
-    if (alloc_ == other.alloc_) {
-      swap(obj_, other.obj_);
-    } else if (obj_ && other.obj_) {
-      swap(*raw_ptr(), *other.raw_ptr());
-    } else if (obj_) {
-      other.emplace(std::move(*raw_ptr()));
-      reset();
-    } else if (other.obj_) {
-      emplace(std::move(*other.raw_ptr()));
-      other.reset();
-    }
+    swap_with_runtime_allocator_check(other);
   }
 
   constexpr void reset() noexcept {
@@ -393,6 +345,125 @@ private:
 
   [[nodiscard]] constexpr T *raw_ptr() noexcept { return std::to_address(obj_); }
   [[nodiscard]] constexpr const T *raw_ptr() const noexcept { return std::to_address(obj_); }
+
+  constexpr void move_assign_with_allocator_propagation(optional_indirect &other) noexcept(
+      std::is_nothrow_move_assignable_v<allocator_type>) {
+    if (this != &other) {
+      release_object();
+      alloc_ = std::move(other.alloc_);
+      take_object_from(other);
+    }
+  }
+
+  constexpr void move_assign_with_equal_allocator(optional_indirect &other) noexcept {
+    if (this != &other) {
+      release_object();
+      take_object_from(other);
+    }
+  }
+
+  constexpr void move_assign_with_runtime_allocator_check(optional_indirect &other) {
+    if (this != &other && !try_take_object_with_equal_allocator(other)) {
+      move_value_or_release(other);
+    }
+  }
+
+  constexpr bool try_take_object_with_equal_allocator(optional_indirect &other) {
+    if (!(alloc_ == other.alloc_)) {
+      return false;
+    }
+    release_object();
+    take_object_from(other);
+    return true;
+  }
+
+  constexpr void move_value_or_release(optional_indirect &other) {
+    if (other.obj_) {
+      move_value_from(other);
+    } else {
+      release_object();
+    }
+  }
+
+  constexpr void move_value_from(optional_indirect &other) {
+    if (obj_) {
+      *raw_ptr() = std::move(*other.raw_ptr());
+    } else {
+      emplace(std::move(*other.raw_ptr()));
+    }
+  }
+
+  constexpr void
+  swap_with_allocator_propagation(optional_indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>) {
+    if (this != &other) {
+      swap_allocators(other);
+      swap_object_pointers(other);
+    }
+  }
+
+  constexpr void swap_with_equal_allocator(optional_indirect &other) noexcept {
+    if (this != &other) {
+      swap_object_pointers(other);
+    }
+  }
+
+  constexpr void swap_with_runtime_allocator_check(optional_indirect &other) {
+    if (this != &other && !try_swap_object_with_equal_allocator(other)) {
+      swap_values_or_rehome(other);
+    }
+  }
+
+  constexpr bool try_swap_object_with_equal_allocator(optional_indirect &other) {
+    if (!(alloc_ == other.alloc_)) {
+      return false;
+    }
+    swap_object_pointers(other);
+    return true;
+  }
+
+  constexpr void swap_values_or_rehome(optional_indirect &other) {
+    if (both_have_objects(other)) {
+      swap_object_values(other);
+    } else {
+      rehome_present_value(other);
+    }
+  }
+
+  constexpr void rehome_present_value(optional_indirect &other) {
+    if (obj_) {
+      move_value_to_empty(other);
+    } else if (other.obj_) {
+      other.move_value_to_empty(*this);
+    }
+  }
+
+  [[nodiscard]] constexpr bool both_have_objects(const optional_indirect &other) const noexcept {
+    return obj_ && other.obj_;
+  }
+
+  constexpr void swap_allocators(optional_indirect &other) noexcept(std::is_nothrow_swappable_v<allocator_type>) {
+    using std::swap;
+    swap(alloc_, other.alloc_);
+  }
+
+  constexpr void swap_object_pointers(optional_indirect &other) noexcept {
+    using std::swap;
+    swap(obj_, other.obj_);
+  }
+
+  constexpr void swap_object_values(optional_indirect &other) {
+    using std::swap;
+    swap(*raw_ptr(), *other.raw_ptr());
+  }
+
+  constexpr void move_value_to_empty(optional_indirect &empty) {
+    empty.emplace(std::move(*raw_ptr()));
+    release_object();
+  }
+
+  constexpr void take_object_from(optional_indirect &other) noexcept { obj_ = std::exchange(other.obj_, nullptr); }
+
+  constexpr void release_object() noexcept { reset(); }
 };
 
 /// Used for recursive non-owning message types

--- a/include/hpp_proto/optional_indirect.hpp
+++ b/include/hpp_proto/optional_indirect.hpp
@@ -98,7 +98,7 @@ public:
   operator=(optional_indirect &&other) noexcept(std::is_nothrow_move_assignable_v<allocator_type>)
     requires(allocator_traits::propagate_on_container_move_assignment::value)
   {
-    move_assign_with_allocator_propagation(other);
+    move_assign_after_allocator_propagation(other);
     return *this;
   }
 
@@ -346,13 +346,14 @@ private:
   [[nodiscard]] constexpr T *raw_ptr() noexcept { return std::to_address(obj_); }
   [[nodiscard]] constexpr const T *raw_ptr() const noexcept { return std::to_address(obj_); }
 
-  constexpr void move_assign_with_allocator_propagation(optional_indirect &other) noexcept(
+  constexpr void move_assign_after_allocator_propagation(optional_indirect &other) noexcept(
       std::is_nothrow_move_assignable_v<allocator_type>) {
-    if (this != &other) {
-      release_object();
-      alloc_ = std::move(other.alloc_);
-      take_object_from(other);
+    if (this == &other) {
+      return;
     }
+    release_object();
+    alloc_ = std::move(other.alloc_);
+    take_object_from(other);
   }
 
   constexpr void move_assign_with_equal_allocator(optional_indirect &other) noexcept {

--- a/unittests/indirect_tests.cpp
+++ b/unittests/indirect_tests.cpp
@@ -24,11 +24,14 @@ struct ThrowingDefaultMessage {
 using indirect_with_throwing_move_ctor_alloc = hpp_proto::indirect<int, throwing_move_ctor_allocator<int>>;
 using indirect_with_throwing_move_assign_alloc = hpp_proto::indirect<int, throwing_move_assign_allocator<int>>;
 using indirect_with_throwing_swap_alloc = hpp_proto::indirect<int, throwing_swap_allocator<int>>;
+using indirect_with_tracking_move_assign_alloc = hpp_proto::indirect<int, propagating_move_tracking_allocator<int>>;
 using indirect_with_tracking_swap_alloc = hpp_proto::indirect<int, propagating_swap_tracking_allocator<int>>;
 
 static_assert(!std::is_nothrow_move_constructible_v<indirect_with_throwing_move_ctor_alloc>);
 static_assert(!std::is_nothrow_move_assignable_v<indirect_with_throwing_move_assign_alloc>);
 static_assert(!std::is_nothrow_swappable_v<indirect_with_throwing_swap_alloc>);
+static_assert(noexcept(std::declval<indirect_with_tracking_move_assign_alloc &>() =
+                           std::declval<indirect_with_tracking_move_assign_alloc &&>()));
 static_assert(!noexcept(
     std::declval<indirect_with_throwing_swap_alloc &>().swap(std::declval<indirect_with_throwing_swap_alloc &>())));
 static_assert(noexcept(
@@ -284,32 +287,55 @@ const boost::ut::suite indirect_exception_safety_tests = [] {
     expect(lhs.get_allocator() == rhs.get_allocator());
   };
 
+  "move_assignment_with_propagating_allocator_transfers_allocation_owner"_test = [] {
+    expect(propagating_move_assignment_transfers_allocator_and_storage<hpp_proto::indirect>());
+  };
+
+  "move_assignment_with_unequal_allocators_moves_values_without_stealing_storage"_test = [] {
+    expect(unequal_allocator_move_assignment_moves_value_without_stealing_storage<hpp_proto::indirect>());
+  };
+
+  "move_assignment_with_unequal_allocators_ignores_self_move"_test = [] {
+    using Alloc = non_propagating_tracking_allocator<int>;
+    hpp_proto::indirect<int, Alloc> value(std::allocator_arg, Alloc{}, 21);
+
+    value = std::move(value);
+
+    expect(eq(*value, 21));
+  };
+
+  "move_assignment_with_unequal_allocators_handles_moved_from_storage"_test = [] {
+    expect(unequal_allocator_indirect_move_assignment_handles_empty_states<hpp_proto::indirect>());
+  };
+
   "swap_with_propagating_allocator_keeps_allocations_with_owners"_test = [] {
-    auto left_state = std::make_shared<tracking_alloc_state>();
-    auto right_state = std::make_shared<tracking_alloc_state>();
+    expect(propagating_swap_between_engaged_objects_transfers_allocators<hpp_proto::indirect>());
+  };
+
+  "swap_with_propagating_allocator_ignores_self_swap"_test = [] {
     using Alloc = propagating_swap_tracking_allocator<int>;
-    using Indirect = hpp_proto::indirect<int, Alloc>;
+    hpp_proto::indirect<int, Alloc> value(std::allocator_arg, Alloc{}, 22);
 
-    {
-      Indirect left(std::allocator_arg, Alloc{left_state}, 1);
-      Indirect right(std::allocator_arg, Alloc{right_state}, 2);
+    value.swap(value);
 
-      left.swap(right);
+    expect(eq(*value, 22));
+  };
 
-      expect(eq(*left, 2));
-      expect(eq(*right, 1));
-      expect(left.get_allocator() == Alloc{right_state});
-      expect(right.get_allocator() == Alloc{left_state});
-    }
+  "swap_with_unequal_allocators_moves_values_without_stealing_storage"_test = [] {
+    expect(unequal_allocator_swap_between_engaged_objects_moves_values<hpp_proto::indirect>());
+  };
 
-    expect(eq(left_state->alloc_count, std::size_t{1}));
-    expect(eq(left_state->dealloc_count, std::size_t{1}));
-    expect(eq(left_state->mismatched_dealloc_count, std::size_t{0}));
-    expect(left_state->live_allocations.empty());
-    expect(eq(right_state->alloc_count, std::size_t{1}));
-    expect(eq(right_state->dealloc_count, std::size_t{1}));
-    expect(eq(right_state->mismatched_dealloc_count, std::size_t{0}));
-    expect(right_state->live_allocations.empty());
+  "swap_with_unequal_allocators_ignores_self_swap"_test = [] {
+    using Alloc = non_propagating_tracking_allocator<int>;
+    hpp_proto::indirect<int, Alloc> value(std::allocator_arg, Alloc{}, 23);
+
+    value.swap(value);
+
+    expect(eq(*value, 23));
+  };
+
+  "swap_with_unequal_allocators_handles_moved_from_storage"_test = [] {
+    expect(unequal_allocator_indirect_swap_handles_empty_states<hpp_proto::indirect>());
   };
 };
 

--- a/unittests/indirect_tests.cpp
+++ b/unittests/indirect_tests.cpp
@@ -24,10 +24,15 @@ struct ThrowingDefaultMessage {
 using indirect_with_throwing_move_ctor_alloc = hpp_proto::indirect<int, throwing_move_ctor_allocator<int>>;
 using indirect_with_throwing_move_assign_alloc = hpp_proto::indirect<int, throwing_move_assign_allocator<int>>;
 using indirect_with_throwing_swap_alloc = hpp_proto::indirect<int, throwing_swap_allocator<int>>;
+using indirect_with_tracking_swap_alloc = hpp_proto::indirect<int, propagating_swap_tracking_allocator<int>>;
 
 static_assert(!std::is_nothrow_move_constructible_v<indirect_with_throwing_move_ctor_alloc>);
 static_assert(!std::is_nothrow_move_assignable_v<indirect_with_throwing_move_assign_alloc>);
 static_assert(!std::is_nothrow_swappable_v<indirect_with_throwing_swap_alloc>);
+static_assert(!noexcept(
+    std::declval<indirect_with_throwing_swap_alloc &>().swap(std::declval<indirect_with_throwing_swap_alloc &>())));
+static_assert(noexcept(
+    std::declval<indirect_with_tracking_swap_alloc &>().swap(std::declval<indirect_with_tracking_swap_alloc &>())));
 
 const boost::ut::suite indirect_tests = [] {
   using namespace boost::ut;
@@ -277,6 +282,34 @@ const boost::ut::suite indirect_exception_safety_tests = [] {
 
     expect(eq(*lhs, 7));
     expect(lhs.get_allocator() == rhs.get_allocator());
+  };
+
+  "swap_with_propagating_allocator_keeps_allocations_with_owners"_test = [] {
+    auto left_state = std::make_shared<tracking_alloc_state>();
+    auto right_state = std::make_shared<tracking_alloc_state>();
+    using Alloc = propagating_swap_tracking_allocator<int>;
+    using Indirect = hpp_proto::indirect<int, Alloc>;
+
+    {
+      Indirect left(std::allocator_arg, Alloc{left_state}, 1);
+      Indirect right(std::allocator_arg, Alloc{right_state}, 2);
+
+      left.swap(right);
+
+      expect(eq(*left, 2));
+      expect(eq(*right, 1));
+      expect(left.get_allocator() == Alloc{right_state});
+      expect(right.get_allocator() == Alloc{left_state});
+    }
+
+    expect(eq(left_state->alloc_count, std::size_t{1}));
+    expect(eq(left_state->dealloc_count, std::size_t{1}));
+    expect(eq(left_state->mismatched_dealloc_count, std::size_t{0}));
+    expect(left_state->live_allocations.empty());
+    expect(eq(right_state->alloc_count, std::size_t{1}));
+    expect(eq(right_state->dealloc_count, std::size_t{1}));
+    expect(eq(right_state->mismatched_dealloc_count, std::size_t{0}));
+    expect(right_state->live_allocations.empty());
   };
 };
 

--- a/unittests/optional_indirect_tests.cpp
+++ b/unittests/optional_indirect_tests.cpp
@@ -30,10 +30,15 @@ struct glz::meta<TestRecursiveMessage<Traits>> {
 using optional_with_throwing_move_ctor_alloc = hpp_proto::optional_indirect<int, throwing_move_ctor_allocator<int>>;
 using optional_with_throwing_move_assign_alloc = hpp_proto::optional_indirect<int, throwing_move_assign_allocator<int>>;
 using optional_with_throwing_swap_alloc = hpp_proto::optional_indirect<int, throwing_swap_allocator<int>>;
+using optional_with_tracking_swap_alloc = hpp_proto::optional_indirect<int, propagating_swap_tracking_allocator<int>>;
 
 static_assert(!std::is_nothrow_move_constructible_v<optional_with_throwing_move_ctor_alloc>);
 static_assert(!std::is_nothrow_move_assignable_v<optional_with_throwing_move_assign_alloc>);
 static_assert(!std::is_nothrow_swappable_v<optional_with_throwing_swap_alloc>);
+static_assert(!noexcept(
+    std::declval<optional_with_throwing_swap_alloc &>().swap(std::declval<optional_with_throwing_swap_alloc &>())));
+static_assert(noexcept(
+    std::declval<optional_with_tracking_swap_alloc &>().swap(std::declval<optional_with_tracking_swap_alloc &>())));
 
 const boost::ut::suite optional_indirect_tests = [] {
   using namespace boost::ut;
@@ -375,6 +380,65 @@ const boost::ut::suite optional_indirect_exception_safety_tests = [] {
     expect(eq(opt->value, 42));
     expect(eq(state->alloc_count, std::size_t{2}));
     expect(eq(state->dealloc_count, std::size_t{1}));
+  };
+
+  "swap_with_propagating_allocator_keeps_allocations_with_owners"_test = [] {
+    auto left_state = std::make_shared<tracking_alloc_state>();
+    auto right_state = std::make_shared<tracking_alloc_state>();
+    using Alloc = propagating_swap_tracking_allocator<int>;
+    using Optional = hpp_proto::optional_indirect<int, Alloc>;
+
+    {
+      Optional left(std::allocator_arg, Alloc{left_state}, 1);
+      Optional right(std::allocator_arg, Alloc{right_state}, 2);
+
+      left.swap(right);
+
+      expect(left.has_value());
+      expect(right.has_value());
+      expect(eq(*left, 2));
+      expect(eq(*right, 1));
+      expect(left.get_allocator() == Alloc{right_state});
+      expect(right.get_allocator() == Alloc{left_state});
+    }
+
+    expect(eq(left_state->alloc_count, std::size_t{1}));
+    expect(eq(left_state->dealloc_count, std::size_t{1}));
+    expect(eq(left_state->mismatched_dealloc_count, std::size_t{0}));
+    expect(left_state->live_allocations.empty());
+    expect(eq(right_state->alloc_count, std::size_t{1}));
+    expect(eq(right_state->dealloc_count, std::size_t{1}));
+    expect(eq(right_state->mismatched_dealloc_count, std::size_t{0}));
+    expect(right_state->live_allocations.empty());
+  };
+
+  "swap_engaged_with_empty_propagating_allocator_keeps_allocation_owner"_test = [] {
+    auto left_state = std::make_shared<tracking_alloc_state>();
+    auto right_state = std::make_shared<tracking_alloc_state>();
+    using Alloc = propagating_swap_tracking_allocator<int>;
+    using Optional = hpp_proto::optional_indirect<int, Alloc>;
+
+    {
+      Optional left(std::allocator_arg, Alloc{left_state}, 1);
+      Optional right(std::allocator_arg, Alloc{right_state});
+
+      left.swap(right);
+
+      expect(!left.has_value());
+      expect(right.has_value());
+      expect(eq(*right, 1));
+      expect(left.get_allocator() == Alloc{right_state});
+      expect(right.get_allocator() == Alloc{left_state});
+    }
+
+    expect(eq(left_state->alloc_count, std::size_t{1}));
+    expect(eq(left_state->dealloc_count, std::size_t{1}));
+    expect(eq(left_state->mismatched_dealloc_count, std::size_t{0}));
+    expect(left_state->live_allocations.empty());
+    expect(eq(right_state->alloc_count, std::size_t{0}));
+    expect(eq(right_state->dealloc_count, std::size_t{0}));
+    expect(eq(right_state->mismatched_dealloc_count, std::size_t{0}));
+    expect(right_state->live_allocations.empty());
   };
 };
 

--- a/unittests/optional_indirect_tests.cpp
+++ b/unittests/optional_indirect_tests.cpp
@@ -390,6 +390,16 @@ const boost::ut::suite optional_indirect_exception_safety_tests = [] {
     expect(propagating_move_assignment_transfers_allocator_and_storage<hpp_proto::optional_indirect>());
   };
 
+  "move_assignment_with_propagating_allocator_ignores_self_move"_test = [] {
+    using Alloc = propagating_move_tracking_allocator<int>;
+    hpp_proto::optional_indirect<int, Alloc> value(std::allocator_arg, Alloc{}, 25);
+
+    value = std::move(value);
+
+    expect(value.has_value());
+    expect(eq(*value, 25));
+  };
+
   "move_assignment_with_unequal_allocators_moves_values_without_stealing_storage"_test = [] {
     expect(unequal_allocator_move_assignment_moves_value_without_stealing_storage<hpp_proto::optional_indirect>());
   };

--- a/unittests/optional_indirect_tests.cpp
+++ b/unittests/optional_indirect_tests.cpp
@@ -30,11 +30,15 @@ struct glz::meta<TestRecursiveMessage<Traits>> {
 using optional_with_throwing_move_ctor_alloc = hpp_proto::optional_indirect<int, throwing_move_ctor_allocator<int>>;
 using optional_with_throwing_move_assign_alloc = hpp_proto::optional_indirect<int, throwing_move_assign_allocator<int>>;
 using optional_with_throwing_swap_alloc = hpp_proto::optional_indirect<int, throwing_swap_allocator<int>>;
+using optional_with_tracking_move_assign_alloc =
+    hpp_proto::optional_indirect<int, propagating_move_tracking_allocator<int>>;
 using optional_with_tracking_swap_alloc = hpp_proto::optional_indirect<int, propagating_swap_tracking_allocator<int>>;
 
 static_assert(!std::is_nothrow_move_constructible_v<optional_with_throwing_move_ctor_alloc>);
 static_assert(!std::is_nothrow_move_assignable_v<optional_with_throwing_move_assign_alloc>);
 static_assert(!std::is_nothrow_swappable_v<optional_with_throwing_swap_alloc>);
+static_assert(noexcept(std::declval<optional_with_tracking_move_assign_alloc &>() =
+                           std::declval<optional_with_tracking_move_assign_alloc &&>()));
 static_assert(!noexcept(
     std::declval<optional_with_throwing_swap_alloc &>().swap(std::declval<optional_with_throwing_swap_alloc &>())));
 static_assert(noexcept(
@@ -382,63 +386,41 @@ const boost::ut::suite optional_indirect_exception_safety_tests = [] {
     expect(eq(state->dealloc_count, std::size_t{1}));
   };
 
+  "move_assignment_with_propagating_allocator_transfers_allocation_owner"_test = [] {
+    expect(propagating_move_assignment_transfers_allocator_and_storage<hpp_proto::optional_indirect>());
+  };
+
+  "move_assignment_with_unequal_allocators_moves_values_without_stealing_storage"_test = [] {
+    expect(unequal_allocator_move_assignment_moves_value_without_stealing_storage<hpp_proto::optional_indirect>());
+  };
+
+  "move_assignment_with_unequal_allocators_handles_empty_states"_test = [] {
+    expect(unequal_allocator_optional_move_assignment_handles_empty_states<hpp_proto::optional_indirect>());
+  };
+
   "swap_with_propagating_allocator_keeps_allocations_with_owners"_test = [] {
-    auto left_state = std::make_shared<tracking_alloc_state>();
-    auto right_state = std::make_shared<tracking_alloc_state>();
-    using Alloc = propagating_swap_tracking_allocator<int>;
-    using Optional = hpp_proto::optional_indirect<int, Alloc>;
-
-    {
-      Optional left(std::allocator_arg, Alloc{left_state}, 1);
-      Optional right(std::allocator_arg, Alloc{right_state}, 2);
-
-      left.swap(right);
-
-      expect(left.has_value());
-      expect(right.has_value());
-      expect(eq(*left, 2));
-      expect(eq(*right, 1));
-      expect(left.get_allocator() == Alloc{right_state});
-      expect(right.get_allocator() == Alloc{left_state});
-    }
-
-    expect(eq(left_state->alloc_count, std::size_t{1}));
-    expect(eq(left_state->dealloc_count, std::size_t{1}));
-    expect(eq(left_state->mismatched_dealloc_count, std::size_t{0}));
-    expect(left_state->live_allocations.empty());
-    expect(eq(right_state->alloc_count, std::size_t{1}));
-    expect(eq(right_state->dealloc_count, std::size_t{1}));
-    expect(eq(right_state->mismatched_dealloc_count, std::size_t{0}));
-    expect(right_state->live_allocations.empty());
+    expect(propagating_swap_between_engaged_objects_transfers_allocators<hpp_proto::optional_indirect>());
   };
 
   "swap_engaged_with_empty_propagating_allocator_keeps_allocation_owner"_test = [] {
-    auto left_state = std::make_shared<tracking_alloc_state>();
-    auto right_state = std::make_shared<tracking_alloc_state>();
-    using Alloc = propagating_swap_tracking_allocator<int>;
-    using Optional = hpp_proto::optional_indirect<int, Alloc>;
+    expect(propagating_optional_swap_engaged_with_empty_transfers_allocators<hpp_proto::optional_indirect>());
+  };
 
-    {
-      Optional left(std::allocator_arg, Alloc{left_state}, 1);
-      Optional right(std::allocator_arg, Alloc{right_state});
+  "swap_with_always_equal_allocator_ignores_self_swap"_test = [] {
+    hpp_proto::optional_indirect<int> value(24);
 
-      left.swap(right);
+    value.swap(value);
 
-      expect(!left.has_value());
-      expect(right.has_value());
-      expect(eq(*right, 1));
-      expect(left.get_allocator() == Alloc{right_state});
-      expect(right.get_allocator() == Alloc{left_state});
-    }
+    expect(value.has_value());
+    expect(eq(*value, 24));
+  };
 
-    expect(eq(left_state->alloc_count, std::size_t{1}));
-    expect(eq(left_state->dealloc_count, std::size_t{1}));
-    expect(eq(left_state->mismatched_dealloc_count, std::size_t{0}));
-    expect(left_state->live_allocations.empty());
-    expect(eq(right_state->alloc_count, std::size_t{0}));
-    expect(eq(right_state->dealloc_count, std::size_t{0}));
-    expect(eq(right_state->mismatched_dealloc_count, std::size_t{0}));
-    expect(right_state->live_allocations.empty());
+  "swap_with_unequal_allocators_moves_values_without_stealing_storage"_test = [] {
+    expect(unequal_allocator_swap_between_engaged_objects_moves_values<hpp_proto::optional_indirect>());
+  };
+
+  "swap_with_unequal_allocators_handles_empty_states"_test = [] {
+    expect(unequal_allocator_optional_swap_handles_empty_states<hpp_proto::optional_indirect>());
   };
 };
 

--- a/unittests/test_allocators.hpp
+++ b/unittests/test_allocators.hpp
@@ -179,25 +179,32 @@ template <template <class, class> class Wrapper>
       });
 }
 
+template <template <class, class> class Wrapper, template <class> class AllocTemplate, bool PropagatesAllocators>
+[[nodiscard]] bool tracked_swap_between_engaged_objects();
+
 template <template <class, class> class Wrapper>
 [[nodiscard]] bool unequal_allocator_swap_between_engaged_objects_moves_values() {
-  return with_two_engaged_tracked_wrappers<Wrapper, non_propagating_tracking_allocator>(
-      [](auto &left, auto &right, const auto &left_state, const auto &right_state) {
-        using Alloc = std::remove_cvref_t<decltype(left.get_allocator())>;
-        left.swap(right);
-        return *left == 2 && *right == 1 && left.get_allocator() == Alloc{left_state} &&
-               right.get_allocator() == Alloc{right_state};
-      });
+  return tracked_swap_between_engaged_objects<Wrapper, non_propagating_tracking_allocator, false>();
 }
 
 template <template <class, class> class Wrapper>
 [[nodiscard]] bool propagating_swap_between_engaged_objects_transfers_allocators() {
-  return with_two_engaged_tracked_wrappers<Wrapper, propagating_swap_tracking_allocator>(
+  return tracked_swap_between_engaged_objects<Wrapper, propagating_swap_tracking_allocator, true>();
+}
+
+template <template <class, class> class Wrapper, template <class> class AllocTemplate, bool PropagatesAllocators>
+[[nodiscard]] bool tracked_swap_between_engaged_objects() {
+  return with_two_engaged_tracked_wrappers<Wrapper, AllocTemplate>(
       [](auto &left, auto &right, const auto &left_state, const auto &right_state) {
         using Alloc = std::remove_cvref_t<decltype(left.get_allocator())>;
         left.swap(right);
-        return *left == 2 && *right == 1 && left.get_allocator() == Alloc{right_state} &&
-               right.get_allocator() == Alloc{left_state};
+        if constexpr (PropagatesAllocators) {
+          return *left == 2 && *right == 1 && left.get_allocator() == Alloc{right_state} &&
+                 right.get_allocator() == Alloc{left_state};
+        } else {
+          return *left == 2 && *right == 1 && left.get_allocator() == Alloc{left_state} &&
+                 right.get_allocator() == Alloc{right_state};
+        }
       });
 }
 

--- a/unittests/test_allocators.hpp
+++ b/unittests/test_allocators.hpp
@@ -8,6 +8,9 @@
 #include <utility>
 #include <vector>
 
+// Test literals and intentionally mutable setup values keep allocator scenarios readable.
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
 struct throwing_constructible {
   int value{};
   explicit throwing_constructible(int v) {
@@ -59,19 +62,25 @@ struct tracking_alloc_state {
   std::vector<void *> live_allocations;
 };
 
-template <class T>
-struct propagating_swap_tracking_allocator {
+template <class T, bool PropagateOnSwap, bool PropagateOnMoveAssignment>
+struct tracking_allocator {
   using value_type = T;
   using is_always_equal = std::false_type;
-  using propagate_on_container_swap = std::true_type;
+  using propagate_on_container_swap = std::bool_constant<PropagateOnSwap>;
+  using propagate_on_container_move_assignment = std::bool_constant<PropagateOnMoveAssignment>;
+
+  template <class U>
+  struct rebind {
+    using other = tracking_allocator<U, PropagateOnSwap, PropagateOnMoveAssignment>;
+  };
 
   std::shared_ptr<tracking_alloc_state> state = std::make_shared<tracking_alloc_state>();
 
-  propagating_swap_tracking_allocator() = default;
-  explicit propagating_swap_tracking_allocator(std::shared_ptr<tracking_alloc_state> s) : state(std::move(s)) {}
+  tracking_allocator() = default;
+  explicit tracking_allocator(std::shared_ptr<tracking_alloc_state> s) : state(std::move(s)) {}
 
   template <class U>
-  explicit propagating_swap_tracking_allocator(const propagating_swap_tracking_allocator<U> &other) noexcept
+  explicit tracking_allocator(const tracking_allocator<U, PropagateOnSwap, PropagateOnMoveAssignment> &other) noexcept
       : state(other.state) {}
 
   [[nodiscard]] T *allocate(std::size_t n) {
@@ -79,34 +88,286 @@ struct propagating_swap_tracking_allocator {
     try {
       state->live_allocations.push_back(ptr);
       state->alloc_count += n;
+      // LCOV_EXCL_START
     } catch (...) {
       std::allocator<T>{}.deallocate(ptr, n);
       throw;
     }
+    // LCOV_EXCL_STOP
     return ptr;
   }
 
   void deallocate(T *ptr, std::size_t n) noexcept {
     auto it = std::find(state->live_allocations.begin(), state->live_allocations.end(), ptr);
-    if (it == state->live_allocations.end()) {
-      state->mismatched_dealloc_count += n;
-    } else {
+    if (it != state->live_allocations.end()) {
       state->live_allocations.erase(it);
+    } else {                                // LCOV_EXCL_LINE
+      state->mismatched_dealloc_count += n; // LCOV_EXCL_LINE
     }
     state->dealloc_count += n;
     std::allocator<T>{}.deallocate(ptr, n);
   }
 
-  friend void swap(propagating_swap_tracking_allocator &lhs, propagating_swap_tracking_allocator &rhs) noexcept {
+  friend void swap(tracking_allocator &lhs, tracking_allocator &rhs) noexcept {
     using std::swap;
     swap(lhs.state, rhs.state);
   }
 
   template <class U>
-  constexpr bool operator==(const propagating_swap_tracking_allocator<U> &rhs) const noexcept {
+  constexpr bool
+  operator==(const tracking_allocator<U, PropagateOnSwap, PropagateOnMoveAssignment> &rhs) const noexcept {
     return state == rhs.state;
   }
 };
+
+template <class T>
+using non_propagating_tracking_allocator = tracking_allocator<T, false, false>;
+
+template <class T>
+using propagating_move_tracking_allocator = tracking_allocator<T, false, true>;
+
+template <class T>
+using propagating_swap_tracking_allocator = tracking_allocator<T, true, false>;
+
+[[nodiscard]] inline bool tracking_alloc_state_is_clear(const tracking_alloc_state &state, std::size_t alloc_count,
+                                                        std::size_t dealloc_count) noexcept {
+  return state.alloc_count == alloc_count && state.dealloc_count == dealloc_count &&
+         state.mismatched_dealloc_count == 0 && state.live_allocations.empty();
+}
+
+template <class Wrapped>
+void steal_storage_from_second(Wrapped &storage_owner, Wrapped &emptied) {
+  storage_owner = std::move(emptied);
+}
+
+template <template <class, class> class Wrapper, template <class> class AllocTemplate, class Exercise>
+[[nodiscard]] bool with_two_engaged_tracked_wrappers(Exercise exercise) {
+  auto left_state = std::make_shared<tracking_alloc_state>();
+  auto right_state = std::make_shared<tracking_alloc_state>();
+  using Alloc = AllocTemplate<int>;
+  using Wrapped = Wrapper<int, Alloc>;
+
+  bool exercise_ok = false;
+  {
+    Wrapped left(std::allocator_arg, Alloc{left_state}, 1);
+    Wrapped right(std::allocator_arg, Alloc{right_state}, 2);
+
+    exercise_ok = exercise(left, right, left_state, right_state);
+  }
+
+  return exercise_ok && tracking_alloc_state_is_clear(*left_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*right_state, 1, 1);
+}
+
+template <template <class, class> class Wrapper>
+[[nodiscard]] bool propagating_move_assignment_transfers_allocator_and_storage() {
+  return with_two_engaged_tracked_wrappers<Wrapper, propagating_move_tracking_allocator>(
+      [](auto &left, auto &right, const auto & /*left_state*/, const auto &right_state) {
+        using Alloc = std::remove_cvref_t<decltype(left.get_allocator())>;
+        left = std::move(right);
+        return *left == 2 && left.get_allocator() == Alloc{right_state};
+      });
+}
+
+template <template <class, class> class Wrapper>
+[[nodiscard]] bool unequal_allocator_move_assignment_moves_value_without_stealing_storage() {
+  return with_two_engaged_tracked_wrappers<Wrapper, non_propagating_tracking_allocator>(
+      [](auto &left, auto &right, const auto &left_state, const auto & /*right_state*/) {
+        using Alloc = std::remove_cvref_t<decltype(left.get_allocator())>;
+        left = std::move(right);
+        return *left == 2 && left.get_allocator() == Alloc{left_state};
+      });
+}
+
+template <template <class, class> class Wrapper>
+[[nodiscard]] bool unequal_allocator_swap_between_engaged_objects_moves_values() {
+  return with_two_engaged_tracked_wrappers<Wrapper, non_propagating_tracking_allocator>(
+      [](auto &left, auto &right, const auto &left_state, const auto &right_state) {
+        using Alloc = std::remove_cvref_t<decltype(left.get_allocator())>;
+        left.swap(right);
+        return *left == 2 && *right == 1 && left.get_allocator() == Alloc{left_state} &&
+               right.get_allocator() == Alloc{right_state};
+      });
+}
+
+template <template <class, class> class Wrapper>
+[[nodiscard]] bool propagating_swap_between_engaged_objects_transfers_allocators() {
+  return with_two_engaged_tracked_wrappers<Wrapper, propagating_swap_tracking_allocator>(
+      [](auto &left, auto &right, const auto &left_state, const auto &right_state) {
+        using Alloc = std::remove_cvref_t<decltype(left.get_allocator())>;
+        left.swap(right);
+        return *left == 2 && *right == 1 && left.get_allocator() == Alloc{right_state} &&
+               right.get_allocator() == Alloc{left_state};
+      });
+}
+
+template <template <class, class> class Optional>
+[[nodiscard]] bool propagating_optional_swap_engaged_with_empty_transfers_allocators() {
+  auto left_state = std::make_shared<tracking_alloc_state>();
+  auto right_state = std::make_shared<tracking_alloc_state>();
+  using Alloc = propagating_swap_tracking_allocator<int>;
+  using Wrapped = Optional<int, Alloc>;
+
+  bool swap_ok = false;
+  {
+    Wrapped left(std::allocator_arg, Alloc{left_state}, 3);
+    Wrapped right(std::allocator_arg, Alloc{right_state});
+
+    left.swap(right);
+
+    swap_ok = !left.has_value() && right.has_value() && *right == 3 && left.get_allocator() == Alloc{right_state} &&
+              right.get_allocator() == Alloc{left_state};
+  }
+
+  return swap_ok && tracking_alloc_state_is_clear(*left_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*right_state, 0, 0);
+}
+
+template <template <class, class> class Optional>
+[[nodiscard]] bool unequal_allocator_optional_move_assignment_handles_empty_states() {
+  using Alloc = non_propagating_tracking_allocator<int>;
+  using Wrapped = Optional<int, Alloc>;
+
+  auto empty_target_state = std::make_shared<tracking_alloc_state>();
+  auto source_state = std::make_shared<tracking_alloc_state>();
+  bool empty_target_ok = false;
+  {
+    Wrapped target(std::allocator_arg, Alloc{empty_target_state});
+    Wrapped source(std::allocator_arg, Alloc{source_state}, 3);
+
+    target = std::move(source);
+
+    empty_target_ok = target.has_value() && *target == 3;
+  }
+
+  auto target_state = std::make_shared<tracking_alloc_state>();
+  auto empty_source_state = std::make_shared<tracking_alloc_state>();
+  bool empty_source_ok = false;
+  {
+    Wrapped target(std::allocator_arg, Alloc{target_state}, 4);
+    Wrapped source(std::allocator_arg, Alloc{empty_source_state});
+
+    target = std::move(source);
+
+    empty_source_ok = !target.has_value();
+  }
+
+  return empty_target_ok && empty_source_ok && tracking_alloc_state_is_clear(*empty_target_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*source_state, 1, 1) && tracking_alloc_state_is_clear(*target_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*empty_source_state, 0, 0);
+}
+
+template <template <class, class> class Optional>
+[[nodiscard]] bool unequal_allocator_optional_swap_handles_empty_states() {
+  using Alloc = non_propagating_tracking_allocator<int>;
+  using Wrapped = Optional<int, Alloc>;
+
+  auto left_engaged_state = std::make_shared<tracking_alloc_state>();
+  auto right_empty_state = std::make_shared<tracking_alloc_state>();
+  bool engaged_left_ok = false;
+  {
+    Wrapped left(std::allocator_arg, Alloc{left_engaged_state}, 5);
+    Wrapped right(std::allocator_arg, Alloc{right_empty_state});
+
+    left.swap(right);
+
+    engaged_left_ok = !left.has_value() && right.has_value() && *right == 5;
+  }
+
+  auto left_empty_state = std::make_shared<tracking_alloc_state>();
+  auto right_engaged_state = std::make_shared<tracking_alloc_state>();
+  bool engaged_right_ok = false;
+  {
+    Wrapped left(std::allocator_arg, Alloc{left_empty_state});
+    Wrapped right(std::allocator_arg, Alloc{right_engaged_state}, 6);
+
+    left.swap(right);
+
+    engaged_right_ok = left.has_value() && *left == 6 && !right.has_value();
+  }
+
+  return engaged_left_ok && engaged_right_ok && tracking_alloc_state_is_clear(*left_engaged_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*right_empty_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*left_empty_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*right_engaged_state, 1, 1);
+}
+
+template <template <class, class> class Wrapper>
+[[nodiscard]] bool unequal_allocator_indirect_move_assignment_handles_empty_states() {
+  using Alloc = non_propagating_tracking_allocator<int>;
+  using Wrapped = Wrapper<int, Alloc>;
+
+  auto empty_target_state = std::make_shared<tracking_alloc_state>();
+  auto source_state = std::make_shared<tracking_alloc_state>();
+  bool empty_target_ok = false;
+  {
+    Wrapped keeper(std::allocator_arg, Alloc{empty_target_state}, 7);
+    Wrapped target(std::allocator_arg, Alloc{empty_target_state}, 8);
+    steal_storage_from_second(keeper, target);
+    Wrapped source(std::allocator_arg, Alloc{source_state}, 9);
+
+    target = std::move(source);
+
+    empty_target_ok = *target == 9 && target.get_allocator() == Alloc{empty_target_state};
+  }
+
+  auto target_state = std::make_shared<tracking_alloc_state>();
+  auto empty_source_state = std::make_shared<tracking_alloc_state>();
+  bool empty_source_ok = false;
+  {
+    Wrapped target(std::allocator_arg, Alloc{target_state}, 10);
+    Wrapped keeper(std::allocator_arg, Alloc{empty_source_state}, 11);
+    Wrapped source(std::allocator_arg, Alloc{empty_source_state}, 12);
+    steal_storage_from_second(keeper, source);
+
+    target = std::move(source);
+
+    empty_source_ok = target.get_allocator() == Alloc{target_state};
+  }
+
+  return empty_target_ok && empty_source_ok && tracking_alloc_state_is_clear(*empty_target_state, 3, 3) &&
+         tracking_alloc_state_is_clear(*source_state, 1, 1) && tracking_alloc_state_is_clear(*target_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*empty_source_state, 2, 2);
+}
+
+template <template <class, class> class Wrapper>
+[[nodiscard]] bool unequal_allocator_indirect_swap_handles_empty_states() {
+  using Alloc = non_propagating_tracking_allocator<int>;
+  using Wrapped = Wrapper<int, Alloc>;
+
+  auto left_empty_state = std::make_shared<tracking_alloc_state>();
+  auto right_engaged_state = std::make_shared<tracking_alloc_state>();
+  bool engaged_right_ok = false;
+  {
+    Wrapped keeper(std::allocator_arg, Alloc{left_empty_state}, 13);
+    Wrapped left(std::allocator_arg, Alloc{left_empty_state}, 14);
+    steal_storage_from_second(keeper, left);
+    Wrapped right(std::allocator_arg, Alloc{right_engaged_state}, 15);
+
+    left.swap(right);
+
+    engaged_right_ok = *left == 15;
+  }
+
+  auto left_engaged_state = std::make_shared<tracking_alloc_state>();
+  auto right_empty_state = std::make_shared<tracking_alloc_state>();
+  bool engaged_left_ok = false;
+  {
+    Wrapped left(std::allocator_arg, Alloc{left_engaged_state}, 16);
+    Wrapped keeper(std::allocator_arg, Alloc{right_empty_state}, 17);
+    Wrapped right(std::allocator_arg, Alloc{right_empty_state}, 18);
+    steal_storage_from_second(keeper, right);
+
+    left.swap(right);
+
+    engaged_left_ok = *right == 16;
+  }
+
+  return engaged_right_ok && engaged_left_ok && tracking_alloc_state_is_clear(*left_empty_state, 3, 3) &&
+         tracking_alloc_state_is_clear(*right_engaged_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*left_engaged_state, 1, 1) &&
+         tracking_alloc_state_is_clear(*right_empty_state, 3, 3);
+}
 
 template <class T>
 struct throwing_move_ctor_allocator {
@@ -208,3 +469,5 @@ struct propagating_copy_allocator {
     return id == rhs.id;
   }
 };
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)

--- a/unittests/test_allocators.hpp
+++ b/unittests/test_allocators.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 struct throwing_constructible {
   int value{};
@@ -46,6 +48,62 @@ struct counting_allocator {
 
   template <class U>
   constexpr bool operator==(const counting_allocator<U> &rhs) const noexcept {
+    return state == rhs.state;
+  }
+};
+
+struct tracking_alloc_state {
+  std::size_t alloc_count{};
+  std::size_t dealloc_count{};
+  std::size_t mismatched_dealloc_count{};
+  std::vector<void *> live_allocations;
+};
+
+template <class T>
+struct propagating_swap_tracking_allocator {
+  using value_type = T;
+  using is_always_equal = std::false_type;
+  using propagate_on_container_swap = std::true_type;
+
+  std::shared_ptr<tracking_alloc_state> state = std::make_shared<tracking_alloc_state>();
+
+  propagating_swap_tracking_allocator() = default;
+  explicit propagating_swap_tracking_allocator(std::shared_ptr<tracking_alloc_state> s) : state(std::move(s)) {}
+
+  template <class U>
+  explicit propagating_swap_tracking_allocator(const propagating_swap_tracking_allocator<U> &other) noexcept
+      : state(other.state) {}
+
+  [[nodiscard]] T *allocate(std::size_t n) {
+    auto *ptr = std::allocator<T>{}.allocate(n);
+    try {
+      state->live_allocations.push_back(ptr);
+      state->alloc_count += n;
+    } catch (...) {
+      std::allocator<T>{}.deallocate(ptr, n);
+      throw;
+    }
+    return ptr;
+  }
+
+  void deallocate(T *ptr, std::size_t n) noexcept {
+    auto it = std::find(state->live_allocations.begin(), state->live_allocations.end(), ptr);
+    if (it == state->live_allocations.end()) {
+      state->mismatched_dealloc_count += n;
+    } else {
+      state->live_allocations.erase(it);
+    }
+    state->dealloc_count += n;
+    std::allocator<T>{}.deallocate(ptr, n);
+  }
+
+  friend void swap(propagating_swap_tracking_allocator &lhs, propagating_swap_tracking_allocator &rhs) noexcept {
+    using std::swap;
+    swap(lhs.state, rhs.state);
+  }
+
+  template <class U>
+  constexpr bool operator==(const propagating_swap_tracking_allocator<U> &rhs) const noexcept {
     return state == rhs.state;
   }
 };


### PR DESCRIPTION
## Summary

Fix allocator-aware move assignment and swap behavior for `optional_indirect` and `indirect` so propagating allocator paths keep stored pointers paired with the allocator state that owns them.

## What changed

- Split move assignment and member `swap` into allocator-trait-specific overloads for propagating, always-equal, and unequal non-propagating allocator cases.
- Swap allocator and stored pointer together for `propagate_on_container_swap` instead of swapping allocators first and then deciding how to move storage.
- Added a tracking allocator test helper plus allocator-propagation tests for `optional_indirect` and `indirect`.

## Why

The previous implementation could separate allocated storage from the allocator state that owned it during propagating swaps, especially for `optional_indirect` engaged/empty swaps. Codacy/Cppcheck also reported potentially throwing move/allocate fallbacks inside conditionally `noexcept` operations. The new overload split keeps no-throw paths free of allocating fallbacks and leaves the unequal non-propagating fallback explicitly potentially throwing.

## Testing

- `cppcheck --std=c++23 --enable=warning,performance,portability --inline-suppr --error-exitcode=2 -I include include/hpp_proto/optional_indirect.hpp include/hpp_proto/indirect.hpp`
- `clang-tidy -p build/debug unittests/optional_indirect_tests.cpp unittests/indirect_tests.cpp --header-filter='.*/(include/hpp_proto/(optional_indirect|indirect)\.hpp|unittests/(optional_indirect_tests|indirect_tests|test_allocators)\.(cpp|hpp))' --warnings-as-errors='*'`
- `cmake --build build/debug --target optional_indirect_tests indirect_tests -j`
- `ctest --test-dir build/debug -R 'optional_indirect_tests|indirect_tests' --output-on-failure`
- `cmake --build build/debug -j`
- `ctest --test-dir build/debug --output-on-failure`

## Notes

The unequal non-propagating allocator fallback remains potentially throwing by design; the code now documents that behavior with targeted analyzer suppressions.
